### PR TITLE
fix: playlist dock overlapping button nav bar

### DIFF
--- a/app/src/main/java/io/github/aedev/flow/ui/components/PlaylistQueueDock.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/components/PlaylistQueueDock.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.layout.safeDrawingPadding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ExpandLess
 import androidx.compose.material.icons.filled.SkipNext
@@ -37,6 +38,7 @@ fun PlaylistQueueDock(
         modifier = modifier
             .fillMaxWidth()
             .padding(horizontal = 12.dp)
+            .safeDrawingPadding()
             .height(64.dp)
             .clickable(onClick = onClick)
     ) {

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/channel/ChannelScreen.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/channel/ChannelScreen.kt
@@ -469,10 +469,10 @@ private fun ChannelContent(
                         onFilterSelected = { 
                             selectedFilter = it
                             if (pagerState.currentPage == 0){
-                              videosListState.scrollToItem(0)
+                              coroutineScope.launch { videosListState.scrollToItem(0) }
                             }
                             else if (pagerState.currentPage == 2){
-                              liveListState.scrollToItem(0)
+                              coroutineScope.launch { liveListState.scrollToItem(0) }
                             }
                             
                         },

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/channel/ChannelScreen.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/channel/ChannelScreen.kt
@@ -469,12 +469,12 @@ private fun ChannelContent(
                         onFilterSelected = { 
                             selectedFilter = it
                             if (pagerState.currentPage == 0){
-                              videosListState.initialFirstVisibleItemIndex = 0
-                              videosListState.initialFirstVisibleItemScrollOffset = 0
+                              videosListState.firstVisibleItemIndex = initialScrollIndex
+                              videosListState.firstVisibleItemScrollOffset = initialScrollOffset
                             }
                             else if (pagerState.currentPage == 2){
-                              liveListState.initialFirstVisibleItemIndex = 0
-                              liveListState.initialFirstVisibleItemScrollOffset = 0
+                              liveListState.firstVisibleItemIndex = initialScrollIndex
+                              liveListState.firstVisibleItemScrollOffset = initialScrollOffset
                             }
                             
                         },

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/channel/ChannelScreen.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/channel/ChannelScreen.kt
@@ -466,7 +466,18 @@ private fun ChannelContent(
                         isGridView = isGridView,
                         searchActive = uiState.searchActive,
                         searchQuery = uiState.searchQuery,
-                        onFilterSelected = { selectedFilter = it },
+                        onFilterSelected = { 
+                            selectedFilter = it
+                            if (pagerState.currentPage == 0){
+                              videosListState.initialFirstVisibleItemIndex = 0
+                              videosListState.initialFirstVisibleItemScrollOffset = 0
+                            }
+                            else if (pagerState.currentPage == 2){
+                              liveListState.initialFirstVisibleItemIndex = 0
+                              liveListState.initialFirstVisibleItemScrollOffset = 0
+                            }
+                            
+                        },
                         onToggleGridView = { coroutineScope.launch { preferences.setChannelIsGridView(!isGridView) } },
                         onSearchToggle = onSearchToggle,
                         onSearchQueryChange = onSearchQueryChange,

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/channel/ChannelScreen.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/channel/ChannelScreen.kt
@@ -469,12 +469,10 @@ private fun ChannelContent(
                         onFilterSelected = { 
                             selectedFilter = it
                             if (pagerState.currentPage == 0){
-                              videosListState.firstVisibleItemIndex = initialScrollIndex
-                              videosListState.firstVisibleItemScrollOffset = initialScrollOffset
+                              videosListState.scrollToItem(0)
                             }
                             else if (pagerState.currentPage == 2){
-                              liveListState.firstVisibleItemIndex = initialScrollIndex
-                              liveListState.firstVisibleItemScrollOffset = initialScrollOffset
+                              liveListState.scrollToItem(0)
                             }
                             
                         },


### PR DESCRIPTION
## Description
Fixed: [BUG] Bottom “Next/Playlist” panel is rendered under navigation bar #371

Added safepadding option for queue dock

Fixes # (issue)

## Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test A
- [x] Test B

## Checklist:
- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
