### PR TITLE
✨: add sorting by views and rating functionality to search results

### DIFF
--- a/app/src/main/java/io/github/aedev/flow/data/local/SearchHistoryRepository.kt
+++ b/app/src/main/java/io/github/aedev/flow/data/local/SearchHistoryRepository.kt
@@ -36,11 +36,16 @@ enum class SuggestionType {
 data class SearchFilter(
     val contentType: ContentType = ContentType.ALL,
     val duration: Duration = Duration.ANY,
-    val uploadDate: UploadDate = UploadDate.ANY
+    val uploadDate: UploadDate = UploadDate.ANY,
+    val sortType: SortType = SortType.RELEVANCE
 )
 
 enum class ContentType {
     ALL, VIDEOS, CHANNELS, PLAYLISTS, LIVE
+}
+
+enum class SortType {
+   RELEVANCE, RATING, VIEWS
 }
 
 enum class Duration {

--- a/app/src/main/java/io/github/aedev/flow/data/paging/SearchPagingSource.kt
+++ b/app/src/main/java/io/github/aedev/flow/data/paging/SearchPagingSource.kt
@@ -6,6 +6,7 @@ import androidx.paging.PagingState
 import io.github.aedev.flow.data.local.Duration
 import io.github.aedev.flow.data.local.UploadDate
 import io.github.aedev.flow.data.local.SearchFilter
+import io.github.aedev.flow.data.local.SortType
 import io.github.aedev.flow.data.model.Channel
 import io.github.aedev.flow.data.model.Playlist
 import io.github.aedev.flow.data.model.Video
@@ -160,7 +161,7 @@ class SearchPagingSource(
                 Log.d(TAG, "Loaded ${items.size} items | query='$query' | nextPage=${infoPage.nextPage != null}")
 
                 LoadResult.Page(
-                    data = items,
+                    data = sortVideoItems(searchFilter = searchFilter, items),
                     prevKey = null,
                     nextKey = infoPage.nextPage
                 )
@@ -193,4 +194,19 @@ class SearchPagingSource(
     private fun extractPlaylistId(url: String): String =
         url.substringAfter("list=").substringBefore("&")
             .ifEmpty { url.substringAfterLast("/").substringBefore("?") }
+
+    private fun sortVideoItems(searchFilter: SearchFilter?, items: List<SearchResultItem>): List<SearchResultItem> =
+        when (searchFilter?.sortType) {
+            SortType.RELEVANCE -> items
+            SortType.RATING -> items.sortedByDescending { item ->
+                if (item is SearchResultItem.VideoResult) item.video.likeCount else 0L
+            }
+
+            SortType.VIEWS -> items.sortedByDescending { item ->
+                if (item is SearchResultItem.VideoResult) item.video.viewCount else 0L
+            }
+
+            else -> items
+        }
+
 }

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/search/SearchScreen.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/search/SearchScreen.kt
@@ -219,6 +219,9 @@ fun SearchScreen(
         ContentType.ALL, ContentType.VIDEOS, ContentType.CHANNELS,
         ContentType.PLAYLISTS, ContentType.LIVE
     )
+    val sortByTypes = listOf(
+        SortType.RELEVANCE, SortType.RATING, SortType.VIEWS
+    )
     LaunchedEffect(selectedTabIndex) {
         if (uiState.query.isNotBlank()) {
             val base = uiState.filters ?: SearchFilter()
@@ -356,7 +359,12 @@ fun SearchScreen(
                     viewModel.updateFilters(base.copy(uploadDate = date))
                 },
                 isGridMode = isGridMode,
-                onToggleGridMode = { scope.launch { preferences.setSearchIsGridMode(!isGridMode) } }
+                onToggleGridMode = { scope.launch { preferences.setSearchIsGridMode(!isGridMode) } },
+                selectedSortType = uiState.filters?.sortType ?: SortType.RELEVANCE,
+                onSelectedSortType = {
+                    val base = uiState.filters ?: SearchFilter()
+                    viewModel.updateFilters(base.copy(sortType = it))
+                }
             )
 
             val isInitialLoading =
@@ -579,8 +587,10 @@ private fun SearchFiltersBar(
     onDurationSelected: (Duration) -> Unit,
     selectedUploadDate: UploadDate,
     onUploadDateSelected: (UploadDate) -> Unit,
+    selectedSortType: SortType,
+    onSelectedSortType: (SortType) -> Unit,
     isGridMode: Boolean,
-    onToggleGridMode: () -> Unit
+    onToggleGridMode: () -> Unit,
 ) {
     val showVideoFilters = selectedContentType in listOf(
         ContentType.ALL, ContentType.VIDEOS, ContentType.LIVE
@@ -604,6 +614,11 @@ private fun SearchFiltersBar(
         UploadDate.THIS_WEEK to "This Week",
         UploadDate.THIS_MONTH to "This Month",
         UploadDate.THIS_YEAR to "This Year"
+    )
+    val sortTypeLabels = listOf(
+        SortType.RELEVANCE to "Relevance",
+        SortType.RATING to "Rating",
+        SortType.VIEWS to "Views"
     )
 
     Row(
@@ -708,6 +723,36 @@ private fun SearchFiltersBar(
                                     onClick = {
                                         onUploadDateSelected(date)
                                         dateExpanded = false
+                                    }
+                                )
+                            }
+                        }
+                    }
+                }
+                item {
+                    var sortExpanded by remember { mutableStateOf(false) }
+                    Box {
+                        FilterChip(
+                            selected = selectedSortType != SortType.RELEVANCE,
+                            onClick = { sortExpanded = true },
+                            label = { Text(sortTypeLabels.first { it.first == selectedSortType }.second) },
+                            trailingIcon = {
+                                Icon(Icons.Default.ArrowDropDown, null, Modifier.size(16.dp))
+                            }
+                        )
+                        DropdownMenu(
+                            expanded = sortExpanded,
+                            onDismissRequest = { sortExpanded = false }
+                        ) {
+                            sortTypeLabels.forEach { (sort, label) ->
+                                DropdownMenuItem(
+                                    text = { Text(label) },
+                                    leadingIcon = if (sort == selectedSortType) {
+                                        { Icon(Icons.Default.Check, null, Modifier.size(16.dp)) }
+                                    } else null,
+                                    onClick = {
+                                        onSelectedSortType(sort)
+                                        sortExpanded = false
                                     }
                                 )
                             }

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/search/SearchViewModel.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/search/SearchViewModel.kt
@@ -85,7 +85,10 @@ class SearchViewModel(
 
     fun hasActiveFilters(filters: SearchFilter?): Boolean {
         if (filters == null) return false
-        return filters.contentType != ContentType.ALL || filters.duration != io.github.aedev.flow.data.local.Duration.ANY || filters.uploadDate != io.github.aedev.flow.data.local.UploadDate.ANY
+        return filters.contentType != ContentType.ALL
+                || filters.duration != io.github.aedev.flow.data.local.Duration.ANY
+                || filters.uploadDate != io.github.aedev.flow.data.local.UploadDate.ANY
+                || filters.sortType != io.github.aedev.flow.data.local.SortType.RELEVANCE
     }
 
     suspend fun getSearchSuggestions(query: String): List<String> {


### PR DESCRIPTION
## Description
Adds sorting functionality to search results, allowing users to sort by **Views** and **Rating** in addition to the existing **Relevance** option. A dropdown menu is now accessible from the search filter bar, with a checkmark indicator showing the currently selected sort option.
<table>
  <tr>
    <td><img width="360" alt="Screenshot_20260507_180432" src="https://github.com/user-attachments/assets/9816a728-fa4b-4919-80fe-9507567ea58e" /></td>
    <td><img width="360" alt="Screenshot_20260507_180456" src="https://github.com/user-attachments/assets/4a0ddfb2-c0c5-401c-86f8-fdbd11dce3b5" /></td>
  </tr>
  <tr>
    <td><img width="360" alt="Screenshot_20260507_180512" src="https://github.com/user-attachments/assets/4e731da0-2ee1-4ad9-8c87-b23759361117" /></td>
    <td><img width="360" alt="Screenshot_20260507_180533" src="https://github.com/user-attachments/assets/48443d60-60ff-49f5-b0c6-31312e4cbf05" /></td>
  </tr>
</table>

Fixes #402
## Type of change
Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Manually tested on Android by searching for "android io" and verifying:

- [x] Test A: Sorting by **Views** correctly reorders results and shows a checkmark next to the selected option
- [x] Test B: Sorting by **Rating** correctly reorders results and shows a checkmark next to the selected option
- [x] Test C: Default **Relevance** sort is selected on initial search load
- [x] Test D: Selected sort option is reflected in the filter bar label

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
