### PR TITLE
close description after clicking timestamp issue solved

### DIFF
--- a/app/src/main/java/io/github/aedev/flow/ui/screens/player/dialogs/PlayerBottomSheetsContainer.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/player/dialogs/PlayerBottomSheetsContainer.kt
@@ -83,9 +83,6 @@ fun PlayerBottomSheetsContainer(
             }
             val ms = seconds * 1000L
             EnhancedPlayerManager.getInstance().seekTo(ms)
-            
-            screenState.showCommentsSheet = false
-            screenState.showDescriptionSheet = false
         }
     }
     

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -5,6 +5,9 @@ pluginManagement {
         gradlePluginPortal()
     }
 }
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.10.0"
+}
 
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)


### PR DESCRIPTION
This PR fixes a bug where clicking a timestamp in the video description or comments bottom sheet would automatically dismiss the sheet. The intended behaviour is to seek the video to the specified timestamp while keeping the bottom sheet open, allowing users to continue reading or navigating through other timestamps without losing their place in the UI.

Fixes #423 

You can see the changes in the video below:

https://github.com/user-attachments/assets/8efe8258-ea0b-4802-9fc9-d23aea88b53c

