### PR TITLE
feat(player): auto-hide lock-mode unlock button with tap-to-reveal

### DIFF
--- a/app/src/main/java/io/github/aedev/flow/ui/GlobalPlayerOverlay.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/GlobalPlayerOverlay.kt
@@ -74,6 +74,7 @@ import io.github.aedev.flow.ui.screens.player.components.PlayerGestureOverlays
 import io.github.aedev.flow.ui.screens.player.components.SponsorBlockSkipButton
 import io.github.aedev.flow.ui.screens.player.components.SettingsMenuDialog
 import io.github.aedev.flow.ui.screens.player.components.PlayerSettingsPage
+import io.github.aedev.flow.ui.screens.player.components.LockModeTouchShield
 import io.github.aedev.flow.data.local.SponsorBlockAction
 import io.github.aedev.flow.player.PictureInPictureHelper
 import androidx.compose.foundation.gestures.detectHorizontalDragGestures
@@ -983,10 +984,14 @@ fun GlobalPlayerOverlay(
                                 onToggleRemainingTime = { showRemainingTime = !showRemainingTime },
                                 isTouchLocked = screenState.isTouchLocked,
                                 lockModeEnabled = lockModeEnabled,
+                                lockOverlayRevealSignal = screenState.lockOverlayRevealSignal,
                                 onTouchLockToggle = {
                                     if (lockModeEnabled || screenState.isTouchLocked) {
                                         screenState.isTouchLocked = !screenState.isTouchLocked
                                         screenState.showControls = true
+                                        if (screenState.isTouchLocked) {
+                                            screenState.revealLockOverlay()
+                                        }
                                         screenState.onInteraction()
                                     }
                                 }
@@ -995,26 +1000,45 @@ fun GlobalPlayerOverlay(
                     }
                 },
             bodyContent = { alpha, videoHeight ->
-                EnhancedVideoPlayerScreen(
-                    viewModel = playerViewModel,
-                    video = video,
-                    alpha = alpha,
-                    videoPlayerHeight = videoHeight,
-                    screenState = screenState,
-                    onVideoClick = { clickedVideo ->
-                        if (clickedVideo.isShort) {
-                            onClose()
-                            EnhancedPlayerManager.getInstance().stop()
-                            onNavigateToShorts(clickedVideo.id)
-                        } else {
-                            playerViewModel.playVideo(clickedVideo)
-                            GlobalPlayerState.setCurrentVideo(clickedVideo)
+                Box(Modifier.fillMaxSize()) {
+                    EnhancedVideoPlayerScreen(
+                        viewModel = playerViewModel,
+                        video = video,
+                        alpha = alpha,
+                        videoPlayerHeight = videoHeight,
+                        screenState = screenState,
+                        onVideoClick = { clickedVideo ->
+                            if (clickedVideo.isShort) {
+                                onClose()
+                                EnhancedPlayerManager.getInstance().stop()
+                                onNavigateToShorts(clickedVideo.id)
+                            } else {
+                                playerViewModel.playVideo(clickedVideo)
+                                GlobalPlayerState.setCurrentVideo(clickedVideo)
+                            }
+                        },
+                        onChannelClick = { channelId ->
+                            onNavigateToChannel(channelId)
                         }
-                    },
-                    onChannelClick = { channelId ->
-                        onNavigateToChannel(channelId)
+                    )
+
+                    if (screenState.isTouchLocked && !screenState.isFullscreen && !localIsInPipMode && !isLandscape) {
+                        LockModeTouchShield(
+                            onRevealUnlock = {
+                                screenState.revealLockOverlay()
+                                screenState.onInteraction()
+                            },
+                            onUnlock = {
+                                screenState.isTouchLocked = false
+                                screenState.showControls = true
+                                screenState.onInteraction()
+                            },
+                            modifier = Modifier
+                                .matchParentSize()
+                                .zIndex(2f)
+                        )
                     }
-                )
+                }
             },
             miniControls = { _ ->
                 Box(modifier = Modifier.fillMaxSize()) {

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/player/PremiumControlsOverlay.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/player/PremiumControlsOverlay.kt
@@ -55,6 +55,10 @@ import kotlin.math.abs
 private const val LIVE_SCRUB_SEEK_INTERVAL_MS = 80L
 private const val LIVE_SCRUB_IMMEDIATE_DELTA_MS = 750L
 
+// How long the lock-mode unlock affordance stays on screen before it auto-hides
+// for a clean, unobstructed locked view. A single tap re-reveals it (see issue #619).
+private const val LOCKED_OVERLAY_AUTO_HIDE_MS = 3_000L
+
 @Composable
 fun PremiumControlsOverlay(
     isVisible: Boolean,
@@ -123,6 +127,26 @@ fun PremiumControlsOverlay(
     var lastScrubSeekPosition by remember { mutableLongStateOf(Long.MIN_VALUE) }
     var pendingScrubSeekJob by remember { mutableStateOf<Job?>(null) }
     val displayedPosition = scrubPosition ?: currentPosition
+
+    // Lock-mode unlock affordance auto-hide (issue #619). While touch-locked, the
+    // unlock button hides itself after a short delay so the locked view is clean,
+    // then a single tap anywhere re-reveals it and restarts the timer.
+    var isLockOverlayVisible by remember { mutableStateOf(true) }
+
+    // Reset the unlock affordance to visible whenever lock mode is (re-)entered.
+    LaunchedEffect(isTouchLocked) {
+        if (isTouchLocked) {
+            isLockOverlayVisible = true
+        }
+    }
+
+    // Auto-hide the unlock affordance after the delay while it is showing in lock mode.
+    LaunchedEffect(isTouchLocked, isLockOverlayVisible) {
+        if (isTouchLocked && isLockOverlayVisible) {
+            delay(LOCKED_OVERLAY_AUTO_HIDE_MS)
+            isLockOverlayVisible = false
+        }
+    }
 
     DisposableEffect(Unit) {
         onDispose {
@@ -208,33 +232,42 @@ fun PremiumControlsOverlay(
                             awaitPointerEventScope {
                                 while (true) {
                                     val event = awaitPointerEvent()
+                                    // Any tap on the locked surface re-reveals the unlock
+                                    // affordance and restarts its auto-hide timer (#619).
+                                    isLockOverlayVisible = true
                                     event.changes.forEach { it.consume() }
                                 }
                             }
                         }
                 )
 
-                Surface(
-                    color = Color.Black.copy(alpha = 0.42f),
-                    shape = CircleShape,
-                    modifier = Modifier
-                        .align(Alignment.TopEnd)
-                        .padding(horizontal = 16.dp, vertical = 12.dp)
-                        .size(44.dp)
-                        .clip(CircleShape)
-                        .clickable(
-                            interactionSource = remember { MutableInteractionSource() },
-                            indication = ripple(color = Color.White),
-                            onClick = onTouchLockToggle
-                        )
+                AnimatedVisibility(
+                    visible = isLockOverlayVisible,
+                    enter = fadeIn(animationSpec = tween(300)),
+                    exit = fadeOut(animationSpec = tween(300)),
+                    modifier = Modifier.align(Alignment.TopEnd)
                 ) {
-                    Box(contentAlignment = Alignment.Center) {
-                        Icon(
-                            imageVector = Icons.Rounded.LockOpen,
-                            contentDescription = stringResource(R.string.player_unlock_controls),
-                            tint = Color.White,
-                            modifier = Modifier.size(24.dp)
-                        )
+                    Surface(
+                        color = Color.Black.copy(alpha = 0.42f),
+                        shape = CircleShape,
+                        modifier = Modifier
+                            .padding(horizontal = 16.dp, vertical = 12.dp)
+                            .size(44.dp)
+                            .clip(CircleShape)
+                            .clickable(
+                                interactionSource = remember { MutableInteractionSource() },
+                                indication = ripple(color = Color.White),
+                                onClick = onTouchLockToggle
+                            )
+                    ) {
+                        Box(contentAlignment = Alignment.Center) {
+                            Icon(
+                                imageVector = Icons.Rounded.LockOpen,
+                                contentDescription = stringResource(R.string.player_unlock_controls),
+                                tint = Color.White,
+                                modifier = Modifier.size(24.dp)
+                            )
+                        }
                     }
                 }
             } else {

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/player/PremiumControlsOverlay.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/player/PremiumControlsOverlay.kt
@@ -29,6 +29,8 @@ import androidx.compose.ui.graphics.drawscope.rotate
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.semantics.onClick
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -132,16 +134,25 @@ fun PremiumControlsOverlay(
     // unlock button hides itself after a short delay so the locked view is clean,
     // then a single tap anywhere re-reveals it and restarts the timer.
     var isLockOverlayVisible by remember { mutableStateOf(true) }
+    // Bumped on every reveal so that re-revealing while already visible still
+    // restarts the auto-hide timer (a no-op `isLockOverlayVisible = true` would not).
+    var lockOverlayRevealTick by remember { mutableIntStateOf(0) }
+
+    val revealLockOverlay: () -> Unit = {
+        isLockOverlayVisible = true
+        lockOverlayRevealTick++
+    }
 
     // Reset the unlock affordance to visible whenever lock mode is (re-)entered.
     LaunchedEffect(isTouchLocked) {
         if (isTouchLocked) {
-            isLockOverlayVisible = true
+            revealLockOverlay()
         }
     }
 
     // Auto-hide the unlock affordance after the delay while it is showing in lock mode.
-    LaunchedEffect(isTouchLocked, isLockOverlayVisible) {
+    // Keyed on the reveal tick so each tap restarts the full delay window.
+    LaunchedEffect(isTouchLocked, isLockOverlayVisible, lockOverlayRevealTick) {
         if (isTouchLocked && isLockOverlayVisible) {
             delay(LOCKED_OVERLAY_AUTO_HIDE_MS)
             isLockOverlayVisible = false
@@ -225,6 +236,7 @@ fun PremiumControlsOverlay(
                     )
             ) {
             if (isTouchLocked) {
+                val revealUnlockHint = stringResource(R.string.player_unlock_controls)
                 Box(
                     modifier = Modifier
                         .matchParentSize()
@@ -234,9 +246,18 @@ fun PremiumControlsOverlay(
                                     val event = awaitPointerEvent()
                                     // Any tap on the locked surface re-reveals the unlock
                                     // affordance and restarts its auto-hide timer (#619).
-                                    isLockOverlayVisible = true
+                                    revealLockOverlay()
                                     event.changes.forEach { it.consume() }
                                 }
+                            }
+                        }
+                        // Keep an accessible path to the unlock control once it auto-hides:
+                        // the raw pointer handler above exposes no semantics, so give
+                        // assistive tech an explicit action that re-reveals the button.
+                        .semantics {
+                            onClick(label = revealUnlockHint) {
+                                revealLockOverlay()
+                                true
                             }
                         }
                 )

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/player/PremiumControlsOverlay.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/player/PremiumControlsOverlay.kt
@@ -27,14 +27,12 @@ import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.drawscope.rotate
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.semantics.onClick
-import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import io.github.aedev.flow.ui.screens.player.components.LockModeTouchShield
 import io.github.aedev.flow.ui.screens.player.components.SeekbarWithPreview
 import io.github.aedev.flow.ui.screens.player.util.VideoPlayerUtils
 import io.github.aedev.flow.player.EnhancedPlayerManager
@@ -112,6 +110,7 @@ fun PremiumControlsOverlay(
     onToggleRemainingTime: () -> Unit = {},
     isTouchLocked: Boolean = false,
     lockModeEnabled: Boolean = false,
+    lockOverlayRevealSignal: Int = 0,
     onTouchLockToggle: () -> Unit = {},
     modifier: Modifier = Modifier
 ) {
@@ -144,7 +143,7 @@ fun PremiumControlsOverlay(
     }
 
     // Reset the unlock affordance to visible whenever lock mode is (re-)entered.
-    LaunchedEffect(isTouchLocked) {
+    LaunchedEffect(isTouchLocked, lockOverlayRevealSignal) {
         if (isTouchLocked) {
             revealLockOverlay()
         }
@@ -236,30 +235,10 @@ fun PremiumControlsOverlay(
                     )
             ) {
             if (isTouchLocked) {
-                val revealUnlockHint = stringResource(R.string.player_unlock_controls)
-                Box(
-                    modifier = Modifier
-                        .matchParentSize()
-                        .pointerInput(Unit) {
-                            awaitPointerEventScope {
-                                while (true) {
-                                    val event = awaitPointerEvent()
-                                    // Any tap on the locked surface re-reveals the unlock
-                                    // affordance and restarts its auto-hide timer (#619).
-                                    revealLockOverlay()
-                                    event.changes.forEach { it.consume() }
-                                }
-                            }
-                        }
-                        // Keep an accessible path to the unlock control once it auto-hides:
-                        // the raw pointer handler above exposes no semantics, so give
-                        // assistive tech a one-step unlock action that matches its label.
-                        .semantics {
-                            onClick(label = revealUnlockHint) {
-                                onTouchLockToggle()
-                                true
-                            }
-                        }
+                LockModeTouchShield(
+                    onRevealUnlock = revealLockOverlay,
+                    onUnlock = onTouchLockToggle,
+                    modifier = Modifier.matchParentSize()
                 )
 
                 AnimatedVisibility(

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/player/PremiumControlsOverlay.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/player/PremiumControlsOverlay.kt
@@ -253,10 +253,10 @@ fun PremiumControlsOverlay(
                         }
                         // Keep an accessible path to the unlock control once it auto-hides:
                         // the raw pointer handler above exposes no semantics, so give
-                        // assistive tech an explicit action that re-reveals the button.
+                        // assistive tech a one-step unlock action that matches its label.
                         .semantics {
                             onClick(label = revealUnlockHint) {
-                                revealLockOverlay()
+                                onTouchLockToggle()
                                 true
                             }
                         }

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/player/components/LockModeTouchShield.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/player/components/LockModeTouchShield.kt
@@ -1,0 +1,38 @@
+package io.github.aedev.flow.ui.screens.player.components
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.onClick
+import androidx.compose.ui.semantics.semantics
+import io.github.aedev.flow.R
+
+@Composable
+fun LockModeTouchShield(
+    onRevealUnlock: () -> Unit,
+    onUnlock: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val unlockLabel = stringResource(R.string.player_unlock_controls)
+
+    Box(
+        modifier = modifier
+            .pointerInput(Unit) {
+                awaitPointerEventScope {
+                    while (true) {
+                        val event = awaitPointerEvent()
+                        onRevealUnlock()
+                        event.changes.forEach { it.consume() }
+                    }
+                }
+            }
+            .semantics {
+                onClick(label = unlockLabel) {
+                    onUnlock()
+                    true
+                }
+            }
+    )
+}

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/player/state/PlayerScreenState.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/player/state/PlayerScreenState.kt
@@ -10,6 +10,7 @@ class PlayerScreenState {
     // UI Visibility States
     var showControls by mutableStateOf(true)
     var isTouchLocked by mutableStateOf(false)
+    var lockOverlayRevealSignal by mutableIntStateOf(0)
     var isFullscreen by mutableStateOf(false)
     var lastInteractionTimestamp by mutableLongStateOf(System.currentTimeMillis())
     
@@ -82,6 +83,7 @@ class PlayerScreenState {
         lastInteractionTimestamp = System.currentTimeMillis()
         showControls = true
         isTouchLocked = false
+        lockOverlayRevealSignal = 0
         currentPosition = 0L
         duration = 0L
         subtitlesEnabled = false
@@ -153,6 +155,10 @@ class PlayerScreenState {
 
     fun onInteraction() {
         lastInteractionTimestamp = System.currentTimeMillis()
+    }
+
+    fun revealLockOverlay() {
+        lockOverlayRevealSignal++
     }
 }
 


### PR DESCRIPTION
## Description

In touch-lock mode the circular unlock button stayed permanently pinned to the
top-right corner, partially obscuring the video (#619). This makes the unlock
affordance behave like the normal player controls: it auto-hides after a short
delay so the locked view is clean and unobstructed, and a single tap anywhere on
the locked surface re-reveals it and restarts the hide timer.

Why it matters: the point of lock mode is an unobstructed, accidental-touch-proof
view, which a chip that never leaves the corner defeats. Mirroring the standard
controls' show-on-tap / hide-after-delay pattern gives a genuinely clean locked
view while keeping unlock one tap (and one accessibility action) away.

All work is contained in `PremiumControlsOverlay.kt`, inside the existing
`if (isTouchLocked)` branch:

- A local `isLockOverlayVisible` flag wraps the unlock `Surface` in
  `AnimatedVisibility`, so it fades out/in with the existing 300ms tween.
- A `LaunchedEffect` runs the auto-hide delay; a reveal "tick" keys the effect so
  that tapping while the button is still visible restarts the full window (a plain
  re-assignment of an already-true flag would not).
- The full-screen gesture-consuming `Box` re-reveals the button on any tap and
  also exposes a `semantics { onClick(...) }` unlock action so assistive tech
  retains a one-step path after the icon auto-hides.
- Entering lock mode always resets the affordance to visible.

This covers the landscape / general auto-hide of the unlock icon (item 1 in the
issue, which the maintainer indicated he wanted to look at). The separate portrait
lock-mode behavior (item 2), which the maintainer noted is harder because the
player is a standalone component, is intentionally left out of scope. The existing
controls auto-hide path (which deliberately excludes `isTouchLocked`) is untouched.

Refs #619

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Verified the changed Kotlin compiles and the new state/effect wiring is sound by
inspection; a full on-device run was not performed in this environment.
Recommended manual verification:

- Enter lock mode: the unlock button fades out after the delay, leaving the video
  unobstructed.
- While hidden, a single tap anywhere re-shows the button and restarts the timer;
  repeated taps keep it visible.
- Tapping the unlock button itself (while visible) still exits lock mode.
- Leaving and re-entering lock mode resets the overlay to visible.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] No documentation changes are required for this in-player UI-behavior change

No automated tests were added (the change is in the Compose player overlay); the
new logic was verified by inspection and compilation, and the manual scenarios
above are recommended for a device check.
