### PR TITLE
fix(player): black screen & dead play button after returning to a backgrounded video

### DIFF
--- a/app/src/main/java/io/github/aedev/flow/MainActivity.kt
+++ b/app/src/main/java/io/github/aedev/flow/MainActivity.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.platform.LocalContext
 import io.github.aedev.flow.data.local.LocalDataManager
 import io.github.aedev.flow.player.BackgroundPlaybackPolicy
 import io.github.aedev.flow.player.GlobalPlayerState
+import io.github.aedev.flow.player.MemoryPressurePolicy
 import io.github.aedev.flow.ui.FlowApp
 import io.github.aedev.flow.ui.theme.FlowTheme
 import io.github.aedev.flow.ui.theme.ThemeMode
@@ -681,7 +682,7 @@ class MainActivity : ComponentActivity() {
     override fun onTrimMemory(level: Int) {
         super.onTrimMemory(level)
         FlowCrashHandler.recordPhase("memory", "MainActivity.onTrimMemory level=$level")
-        if (level >= android.content.ComponentCallbacks2.TRIM_MEMORY_RUNNING_CRITICAL) {
+        if (MemoryPressurePolicy.shouldReleaseVideoPlayback(level)) {
             io.github.aedev.flow.player.EnhancedPlayerManager.getInstance()
                 .handleCriticalMemoryPressure()
         }

--- a/app/src/main/java/io/github/aedev/flow/player/EnhancedPlayerManager.kt
+++ b/app/src/main/java/io/github/aedev/flow/player/EnhancedPlayerManager.kt
@@ -148,6 +148,10 @@ class EnhancedPlayerManager private constructor() {
     private var videoTracksDisabled = false
     @Volatile private var videoSurfaceRestorePending = false
 
+    // Position captured right before the playlist is emptied under memory pressure
+    // (handleCriticalMemoryPressure), so recovery can resume where the user left off.
+    @Volatile private var clearedMediaResumePositionMs = 0L
+
     // Queue management
     private var playbackQueue: List<io.github.aedev.flow.data.model.Video> = emptyList()
     private var originalPlaybackQueue: List<io.github.aedev.flow.data.model.Video> = emptyList()
@@ -2191,7 +2195,38 @@ class EnhancedPlayerManager private constructor() {
         if (isAudioOnlyMode || videoSurfaceRestorePending) {
             restoreVideoOutput()
         }
-        player?.play()
+        val p = player ?: return
+        // The player can be reset to STATE_IDLE while backgrounded (e.g. media items
+        // cleared under memory pressure). A bare play() is a no-op on an IDLE player,
+        // which is why the play button appears dead after returning to a video —
+        // recover the media first.
+        if (p.playbackState == Player.STATE_IDLE) {
+            if (!reloadClearedMediaIfNeeded() && p.mediaItemCount > 0) {
+                Log.d(TAG, "play(): player IDLE with media — calling prepare()")
+                p.prepare()
+            }
+        }
+        p.play()
+    }
+
+    /**
+     * Reloads the cached streams when the player was reset with an empty playlist —
+     * the state handleCriticalMemoryPressure() leaves behind when it stops and clears
+     * media items under memory pressure. An empty playlist cannot be recovered with
+     * prepare() alone, so the reload restores the media (resuming from the position
+     * captured before the playlist was cleared).
+     *
+     * @return true if a reload was issued.
+     */
+    private fun reloadClearedMediaIfNeeded(): Boolean {
+        val p = player ?: return false
+        if (p.playbackState != Player.STATE_IDLE || p.mediaItemCount > 0) return false
+        if (currentVideoStream == null && currentAudioStream == null) return false
+        val resumePos = clearedMediaResumePositionMs.takeIf { it > 0L }
+        Log.w(TAG, "reloadClearedMedia: player reset with empty playlist — reloading cached streams (resumePos=$resumePos)")
+        clearedMediaResumePositionMs = 0L
+        loadMediaInternal(currentVideoStream, currentAudioStream, preservePosition = resumePos)
+        return true
     }
     fun pause() = player?.pause()
     fun seekTo(position: Long) {
@@ -2718,6 +2753,16 @@ class EnhancedPlayerManager private constructor() {
             switchToAudioOnly()
             clearSurface()
         } else {
+            // Remember where we were so returning to the video can resume, then free
+            // the video buffers. Note: clearing media items empties the playlist, so
+            // a later prepare() alone cannot recover it — recovery must reload the
+            // cached streams (see reloadClearedMediaIfNeeded()). Only capture the
+            // position when there is still media to lose, so a repeated trim (which
+            // arrives with an already-empty playlist at position 0) does not clobber
+            // the good value.
+            if (p.mediaItemCount > 0) {
+                clearedMediaResumePositionMs = p.currentPosition.coerceAtLeast(0L)
+            }
             p.stop()
             p.clearMediaItems()
         }
@@ -2992,6 +3037,12 @@ class EnhancedPlayerManager private constructor() {
      */
     fun handleRefocusStuck(videoId: String?) {
         val p = player ?: return
+        // If the playlist was emptied under memory pressure, the errorHandler's
+        // prepare()-based recovery is a no-op. Reload the cached streams instead.
+        if (reloadClearedMediaIfNeeded()) {
+            if (p.playWhenReady) p.play()
+            return
+        }
         errorHandler?.handleRefocusStuck(p, videoId)
     }
 }

--- a/app/src/main/java/io/github/aedev/flow/player/EnhancedPlayerManager.kt
+++ b/app/src/main/java/io/github/aedev/flow/player/EnhancedPlayerManager.kt
@@ -6,6 +6,7 @@ import android.content.Intent
 import android.net.ConnectivityManager
 import android.net.NetworkCapabilities
 import android.net.Uri
+import android.os.Build
 import android.os.Handler
 import android.os.Looper
 import android.os.PowerManager
@@ -43,6 +44,7 @@ import io.github.aedev.flow.player.error.PlayerErrorHandler
 import io.github.aedev.flow.player.factory.PlayerFactory
 import io.github.aedev.flow.player.media.MediaLoader
 import io.github.aedev.flow.player.quality.QualityManager
+import io.github.aedev.flow.player.recovery.ClearedMediaRecoveryState
 import io.github.aedev.flow.innertube.YouTube
 import io.github.aedev.flow.innertube.models.YouTubeClient
 import io.github.aedev.flow.innertube.models.response.PlayerResponse
@@ -56,6 +58,7 @@ import io.github.aedev.flow.player.stream.StreamMergeUtils
 import io.github.aedev.flow.player.stream.StreamProcessor
 import io.github.aedev.flow.player.stream.VideoCodecUtils
 import io.github.aedev.flow.player.surface.SurfaceManager
+import io.github.aedev.flow.player.surface.VideoSurfacePolicy
 import io.github.aedev.flow.player.tracker.PlaybackTracker
 
 import kotlinx.coroutines.CoroutineScope
@@ -147,10 +150,9 @@ class EnhancedPlayerManager private constructor() {
     private var isAudioOnlyMode = false
     private var videoTracksDisabled = false
     @Volatile private var videoSurfaceRestorePending = false
-
-    // Position captured right before the playlist is emptied under memory pressure
-    // (handleCriticalMemoryPressure), so recovery can resume where the user left off.
-    @Volatile private var clearedMediaResumePositionMs = 0L
+    private var currentLocalFilePath: String? = null
+    private val clearedMediaRecoveryState = ClearedMediaRecoveryState()
+    private var pendingSurfaceFirstFrameStartedAtMs = 0L
 
     // Queue management
     private var playbackQueue: List<io.github.aedev.flow.data.model.Video> = emptyList()
@@ -694,6 +696,14 @@ class EnhancedPlayerManager private constructor() {
             override fun onRenderedFirstFrame() {
                 Log.d(TAG, "First frame rendered - video renderer working")
                 surfaceManager?.setSurfaceReady(true)
+                pendingSurfaceFirstFrameStartedAtMs.takeIf { it > 0L }?.let { startedAtMs ->
+                    pendingSurfaceFirstFrameStartedAtMs = 0L
+                    Log.w(
+                        "FlowVideoLifecycle",
+                        "firstFrameAfterSurfaceAttach latencyMs=${SystemClock.elapsedRealtime() - startedAtMs} " +
+                            "video=$currentVideoId pos=${player?.currentPosition} pwr=${player?.playWhenReady}"
+                    )
+                }
                 val rendererAvailable = isVideoRendererAvailable()
                 Log.d(TAG, "Video renderer confirmed available after first frame: $rendererAvailable")
             }
@@ -744,6 +754,7 @@ class EnhancedPlayerManager private constructor() {
         updateLivePlaybackMode(isLive = false)
         configureTrackSelectorForLocalFile()
         currentVideoId = videoId
+        currentLocalFilePath = filePath
         startPlaybackTracker()
 
         // Apply SponsorBlock: use offline-saved segments if present, otherwise fall back to API.
@@ -814,6 +825,7 @@ class EnhancedPlayerManager private constructor() {
         }
         Log.d(TAG, "setStreams(id=$videoId, videoHeight=${videoStream?.let(VideoCodecUtils::qualityHeightFromStream)}, sabr=${sabrInfo != null}, preferSabr=$preferSabr, itVideo=${itVideoFormats.size}, itAudio=${itAudioFormats.size}, keepAudioOnly=$keepAudioOnly)")
         resetPlaybackStateForNewVideo(videoId)
+        currentLocalFilePath = localFilePath
         if (localFilePath != null) configureTrackSelectorForLocalFile()
         currentSabrInfo = sabrInfo
         sabrPreferred = preferSabr
@@ -909,6 +921,8 @@ class EnhancedPlayerManager private constructor() {
         mediaLoader?.releaseSabr()
         currentSabrInfo = null
         sabrPreferred = false
+        currentLocalFilePath = null
+        clearedMediaRecoveryState.clear()
         innerTubeVideoFormats = emptyList()
         innerTubeAudioFormats = emptyList()
         currentVideoStream = null
@@ -976,7 +990,8 @@ class EnhancedPlayerManager private constructor() {
         audioStream: AudioStream?,
         preservePosition: Long? = null,
         localFilePath: String? = null,
-        audioOnly: Boolean = false
+        audioOnly: Boolean = false,
+        playWhenReady: Boolean = true
     ): Boolean {
         autoNextLog("loadMediaInternal audioOnly=$audioOnly preserve=$preservePosition local=${localFilePath != null}")
         clearPreload()
@@ -1003,6 +1018,7 @@ class EnhancedPlayerManager private constructor() {
                 preservePosition = preservePosition,
                 localFilePath = localFilePath,
                 audioOnly = false,
+                playWhenReady = playWhenReady,
                 subtitleStreams = availableSubtitles
             ) ?: false
         }
@@ -1036,6 +1052,7 @@ class EnhancedPlayerManager private constructor() {
             preservePosition = preservePosition,
             localFilePath = localFilePath,
             audioOnly = audioOnly,
+            playWhenReady = playWhenReady,
             subtitleStreams = availableSubtitles,
             sabrInfo = currentSabrInfo,
             sabrVideoId = currentVideoId,
@@ -2196,12 +2213,9 @@ class EnhancedPlayerManager private constructor() {
             restoreVideoOutput()
         }
         val p = player ?: return
-        // The player can be reset to STATE_IDLE while backgrounded (e.g. media items
-        // cleared under memory pressure). A bare play() is a no-op on an IDLE player,
-        // which is why the play button appears dead after returning to a video —
-        // recover the media first.
         if (p.playbackState == Player.STATE_IDLE) {
-            if (!reloadClearedMediaIfNeeded() && p.mediaItemCount > 0) {
+            if (reloadClearedMediaIfNeeded(playWhenReadyOverride = true)) return
+            if (p.mediaItemCount > 0) {
                 Log.d(TAG, "play(): player IDLE with media — calling prepare()")
                 p.prepare()
             }
@@ -2209,24 +2223,30 @@ class EnhancedPlayerManager private constructor() {
         p.play()
     }
 
-    /**
-     * Reloads the cached streams when the player was reset with an empty playlist —
-     * the state handleCriticalMemoryPressure() leaves behind when it stops and clears
-     * media items under memory pressure. An empty playlist cannot be recovered with
-     * prepare() alone, so the reload restores the media (resuming from the position
-     * captured before the playlist was cleared).
-     *
-     * @return true if a reload was issued.
-     */
-    private fun reloadClearedMediaIfNeeded(): Boolean {
+    fun recoverClearedMediaAfterForeground(): Boolean = reloadClearedMediaIfNeeded()
+
+    private fun reloadClearedMediaIfNeeded(playWhenReadyOverride: Boolean? = null): Boolean {
         val p = player ?: return false
         if (p.playbackState != Player.STATE_IDLE || p.mediaItemCount > 0) return false
-        if (currentVideoStream == null && currentAudioStream == null) return false
-        val resumePos = clearedMediaResumePositionMs.takeIf { it > 0L }
-        Log.w(TAG, "reloadClearedMedia: player reset with empty playlist — reloading cached streams (resumePos=$resumePos)")
-        clearedMediaResumePositionMs = 0L
-        loadMediaInternal(currentVideoStream, currentAudioStream, preservePosition = resumePos)
-        return true
+        val recovery = clearedMediaRecoveryState.pendingFor(currentVideoId) ?: return false
+        val resumePosition = recovery.positionMs.takeIf { it > 0L }
+        val shouldPlay = playWhenReadyOverride ?: recovery.playWhenReady
+        Log.w(
+            TAG,
+            "reloadClearedMedia: reloading ${recovery.videoId} " +
+                "(resumePos=$resumePosition playWhenReady=$shouldPlay local=${recovery.localFilePath != null})"
+        )
+        val loaded = loadMediaInternal(
+            videoStream = currentVideoStream,
+            audioStream = currentAudioStream,
+            preservePosition = resumePosition,
+            localFilePath = recovery.localFilePath,
+            playWhenReady = shouldPlay
+        )
+        if (loaded) {
+            clearedMediaRecoveryState.complete(recovery)
+        }
+        return loaded
     }
     fun pause() = player?.pause()
     fun seekTo(position: Long) {
@@ -2376,6 +2396,8 @@ class EnhancedPlayerManager private constructor() {
         autoplayJob = null
         releaseAdvanceWakeLock()
         clearPreload()
+        currentLocalFilePath = null
+        clearedMediaRecoveryState.clear()
         isAudioOnlyMode = false
         pendingInitialLiveEdgeSeek = false
         setVideoTracksDisabled(false)
@@ -2701,9 +2723,25 @@ class EnhancedPlayerManager private constructor() {
     // ===== Surface Management =====
 
     fun attachVideoSurface(holder: SurfaceHolder?, forceAttach: Boolean = false): Boolean? {
+        val wasSurfaceValid = surfaceManager?.isSurfaceValid() == true
         val attached = surfaceManager?.attachVideoSurface(holder, player, forceAttach)
         if (attached == true) {
+            if (!wasSurfaceValid) {
+                pendingSurfaceFirstFrameStartedAtMs = SystemClock.elapsedRealtime()
+                Log.w(
+                    "FlowVideoLifecycle",
+                    "surfaceAttached video=$currentVideoId pos=${player?.currentPosition} " +
+                        "pwr=${player?.playWhenReady} force=$forceAttach"
+                )
+            }
             val p = player
+            val resyncPausedVideo = p != null && !wasSurfaceValid && !isAudioOnlyMode &&
+                p.currentMediaItem != null &&
+                VideoSurfacePolicy.shouldResyncOnSurfaceReattach(
+                    playWhenReady = p.playWhenReady,
+                    isLive = currentIsLiveStream,
+                    playbackState = p.playbackState
+                )
             if (p != null && currentVideoStream != null) {
                 if (isAudioOnlyMode) {
                     Log.d(TAG, "attachVideoSurface: was in audio-only mode — restoring video stream")
@@ -2717,11 +2755,28 @@ class EnhancedPlayerManager private constructor() {
                     if (p.playWhenReady) p.play()
                 }
             }
+            if (resyncPausedVideo && p != null) {
+                val position = p.currentPosition
+                Log.w(
+                    "FlowVideoLifecycle",
+                    "surfaceReattachResync video=$currentVideoId pos=$position"
+                )
+                p.seekTo(position)
+            }
         }
         return attached
     }
-    fun detachVideoSurface(holder: SurfaceHolder? = null) = surfaceManager?.detachVideoSurface(holder, player, appContext)
-    fun clearSurface() = surfaceManager?.clearSurface(player)
+    fun detachVideoSurface(holder: SurfaceHolder? = null) {
+        val hadManagedSurface = surfaceManager?.getSurfaceHolder() != null
+        surfaceManager?.detachVideoSurface(holder, player, appContext)
+        if (hadManagedSurface) {
+            pendingSurfaceFirstFrameStartedAtMs = 0L
+            Log.w(
+                "FlowVideoLifecycle",
+                "surfaceDetached video=$currentVideoId pos=${player?.currentPosition} pwr=${player?.playWhenReady}"
+            )
+        }
+    }
     suspend fun awaitSurfaceReady(timeoutMillis: Long = 1000) = surfaceManager?.awaitSurfaceReady(timeoutMillis) ?: false
 
     
@@ -2751,17 +2806,14 @@ class EnhancedPlayerManager private constructor() {
         val shouldKeepPlaying = p.playWhenReady || p.isPlaying
         if (shouldKeepPlaying) {
             switchToAudioOnly()
-            clearSurface()
         } else {
-            // Remember where we were so returning to the video can resume, then free
-            // the video buffers. Note: clearing media items empties the playlist, so
-            // a later prepare() alone cannot recover it — recovery must reload the
-            // cached streams (see reloadClearedMediaIfNeeded()). Only capture the
-            // position when there is still media to lose, so a repeated trim (which
-            // arrives with an already-empty playlist at position 0) does not clobber
-            // the good value.
             if (p.mediaItemCount > 0) {
-                clearedMediaResumePositionMs = p.currentPosition.coerceAtLeast(0L)
+                clearedMediaRecoveryState.capture(
+                    videoId = currentVideoId,
+                    positionMs = p.currentPosition,
+                    playWhenReady = p.playWhenReady,
+                    localFilePath = currentLocalFilePath
+                )
             }
             p.stop()
             p.clearMediaItems()
@@ -2783,8 +2835,17 @@ class EnhancedPlayerManager private constructor() {
 
     fun restoreVideoOutput() {
         val p = player ?: return
-        if (!isDisplayInteractive()) {
-            autoNextLog("restoreVideoOutput skipped display not interactive")
+        val displayInteractive = isDisplayInteractive()
+        val surfaceValid = surfaceManager?.isSurfaceValid() == true
+        val canRestore = VideoSurfacePolicy.canRestoreVideoOutput(
+            sdkInt = Build.VERSION.SDK_INT,
+            isDisplayInteractive = displayInteractive,
+            isSurfaceValid = surfaceValid
+        )
+        if (!canRestore) {
+            autoNextLog(
+                "restoreVideoOutput deferred interactive=$displayInteractive surfaceValid=$surfaceValid"
+            )
             videoSurfaceRestorePending = true
             return
         }
@@ -2872,6 +2933,8 @@ class EnhancedPlayerManager private constructor() {
         currentVideoId = null
         currentVideoStream = null
         currentAudioStream = null
+        currentLocalFilePath = null
+        clearedMediaRecoveryState.clear()
         _playerState.value = _playerState.value.copy(
             isPlaying = false, currentVideoId = null, currentQuality = 0,
             currentQualityKey = null,
@@ -2946,6 +3009,7 @@ class EnhancedPlayerManager private constructor() {
         pendingReloadJob?.cancel()
         pendingReloadJob = null
         mediaLoader?.releaseSabr()
+        clearedMediaRecoveryState.clear()
         playbackTracker?.stop()
         audioFeaturesManager?.clearPlayer()
         surfaceManager?.release(player)
@@ -3037,10 +3101,7 @@ class EnhancedPlayerManager private constructor() {
      */
     fun handleRefocusStuck(videoId: String?) {
         val p = player ?: return
-        // If the playlist was emptied under memory pressure, the errorHandler's
-        // prepare()-based recovery is a no-op. Reload the cached streams instead.
         if (reloadClearedMediaIfNeeded()) {
-            if (p.playWhenReady) p.play()
             return
         }
         errorHandler?.handleRefocusStuck(p, videoId)

--- a/app/src/main/java/io/github/aedev/flow/player/MemoryPressurePolicy.kt
+++ b/app/src/main/java/io/github/aedev/flow/player/MemoryPressurePolicy.kt
@@ -1,0 +1,11 @@
+package io.github.aedev.flow.player
+
+import android.content.ComponentCallbacks2
+
+object MemoryPressurePolicy {
+    @Suppress("DEPRECATION")
+    fun shouldReleaseVideoPlayback(trimLevel: Int): Boolean =
+        trimLevel >= ComponentCallbacks2.TRIM_MEMORY_BACKGROUND ||
+            trimLevel in ComponentCallbacks2.TRIM_MEMORY_RUNNING_CRITICAL until
+                ComponentCallbacks2.TRIM_MEMORY_UI_HIDDEN
+}

--- a/app/src/main/java/io/github/aedev/flow/player/media/MediaLoader.kt
+++ b/app/src/main/java/io/github/aedev/flow/player/media/MediaLoader.kt
@@ -66,6 +66,7 @@ class MediaLoader(
      * @param localFilePath Optional local file path for offline playback
      * @param currentDurationSeconds Fallback duration from stream info
      * @param audioOnly When true, never selects video streams or video manifests.
+     * @param playWhenReady Whether playback should start after the source is prepared.
      */
     fun loadMedia(
         player: ExoPlayer?,
@@ -82,6 +83,7 @@ class MediaLoader(
         preservePosition: Long? = null,
         localFilePath: String? = null,
         audioOnly: Boolean = false,
+        playWhenReady: Boolean = true,
         subtitleStreams: List<SubtitlesStream> = emptyList(),
         sabrInfo: SabrStreamInfo? = null,
         sabrVideoId: String? = null,
@@ -149,7 +151,7 @@ class MediaLoader(
                         Log.d(TAG, "Seeking to preserved position: ${preservePosition}ms")
                     }
 
-                    exoPlayer.playWhenReady = true
+                    exoPlayer.playWhenReady = playWhenReady
                     Log.d(TAG, "Media loaded successfully via VideoPlaybackResolver")
                     return true
                 } else {

--- a/app/src/main/java/io/github/aedev/flow/player/recovery/ClearedMediaRecoveryState.kt
+++ b/app/src/main/java/io/github/aedev/flow/player/recovery/ClearedMediaRecoveryState.kt
@@ -1,0 +1,40 @@
+package io.github.aedev.flow.player.recovery
+
+internal data class ClearedMediaRecoverySnapshot(
+    val videoId: String,
+    val positionMs: Long,
+    val playWhenReady: Boolean,
+    val localFilePath: String?
+)
+
+internal class ClearedMediaRecoveryState {
+    private var pendingSnapshot: ClearedMediaRecoverySnapshot? = null
+
+    fun capture(
+        videoId: String?,
+        positionMs: Long,
+        playWhenReady: Boolean,
+        localFilePath: String?
+    ) {
+        if (videoId == null) return
+        pendingSnapshot = ClearedMediaRecoverySnapshot(
+            videoId = videoId,
+            positionMs = positionMs.coerceAtLeast(0L),
+            playWhenReady = playWhenReady,
+            localFilePath = localFilePath
+        )
+    }
+
+    fun pendingFor(videoId: String?): ClearedMediaRecoverySnapshot? =
+        pendingSnapshot?.takeIf { it.videoId == videoId }
+
+    fun complete(snapshot: ClearedMediaRecoverySnapshot) {
+        if (pendingSnapshot === snapshot) {
+            pendingSnapshot = null
+        }
+    }
+
+    fun clear() {
+        pendingSnapshot = null
+    }
+}

--- a/app/src/main/java/io/github/aedev/flow/player/surface/SurfaceManager.kt
+++ b/app/src/main/java/io/github/aedev/flow/player/surface/SurfaceManager.kt
@@ -137,22 +137,6 @@ class SurfaceManager(
     }
     
     /**
-     * Explicitly clear surface holder reference and placeholder.
-     * Called when the screen is actually disposed.
-     */
-    fun clearSurface(player: ExoPlayer?) {
-        Log.d(TAG, "clearSurface() called")
-        surfaceHolder = null
-        placeholderSurface?.let { surface ->
-            runCatching { surface.release() }
-        }
-        placeholderSurface = null
-        isSurfaceReady = false
-        _surfaceReadyFlow.value = false
-        player?.clearVideoSurface()
-    }
-    
-    /**
      * Reattach surface to player if holder is still valid.
      * Used after player initialization or recreation.
      */

--- a/app/src/main/java/io/github/aedev/flow/player/surface/VideoSurfacePolicy.kt
+++ b/app/src/main/java/io/github/aedev/flow/player/surface/VideoSurfacePolicy.kt
@@ -1,0 +1,35 @@
+package io.github.aedev.flow.player.surface
+
+import android.os.Build
+import androidx.media3.common.Player
+
+object VideoSurfacePolicy {
+    fun usesSurfaceView(sdkInt: Int): Boolean =
+        sdkInt >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE
+
+    fun canRestoreVideoOutput(
+        sdkInt: Int,
+        isDisplayInteractive: Boolean,
+        isSurfaceValid: Boolean
+    ): Boolean =
+        isDisplayInteractive && (!usesSurfaceView(sdkInt) || isSurfaceValid)
+
+    /**
+     * Whether a same-position seek is needed after a destroyed video surface comes back.
+     *
+     * Devices that cannot switch a codec's output surface in place (Media3's
+     * setOutputSurface workaround list, e.g. many Xiaomi models) re-create the video
+     * codec on every surface swap. A re-created codec resumes from the sample-stream
+     * read position, not the playhead — while paused that read position can be several
+     * seconds ahead, so resuming playback shows a frozen frame until the clock catches
+     * up. A same-position seek flushes the codec and realigns video with the playhead.
+     * Live streams are excluded: seeking there shifts the live-edge window.
+     */
+    fun shouldResyncOnSurfaceReattach(
+        playWhenReady: Boolean,
+        isLive: Boolean,
+        playbackState: Int
+    ): Boolean =
+        !playWhenReady && !isLive &&
+            (playbackState == Player.STATE_READY || playbackState == Player.STATE_BUFFERING)
+}

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/player/components/VideoPlayerSurface.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/player/components/VideoPlayerSurface.kt
@@ -6,6 +6,9 @@ import android.os.Build
 import android.os.PowerManager
 import android.util.Log
 import android.view.LayoutInflater
+import android.view.Surface
+import android.view.SurfaceHolder
+import android.view.SurfaceView
 import android.view.View
 import android.view.ViewGroup
 import android.view.ViewOutlineProvider
@@ -36,9 +39,10 @@ import io.github.aedev.flow.data.model.Video
 import io.github.aedev.flow.player.EnhancedPlayerManager
 import io.github.aedev.flow.player.PictureInPictureHelper
 import io.github.aedev.flow.player.sanitizeDisplayAspectRatio
+import io.github.aedev.flow.player.surface.VideoSurfacePolicy
 
 private fun pickPlayerViewLayoutRes(): Int =
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+    if (VideoSurfacePolicy.usesSurfaceView(Build.VERSION.SDK_INT)) {
         R.layout.video_player_view_surface
     } else {
         R.layout.video_player_view
@@ -74,6 +78,56 @@ fun VideoPlayerSurface(
             )
             setShowBuffering(PlayerView.SHOW_BUFFERING_NEVER)
             setKeepContentOnPlayerReset(true)
+        }
+    }
+
+    DisposableEffect(playerView) {
+        val surfaceView = playerView.videoSurfaceView as? SurfaceView
+        if (surfaceView == null) {
+            return@DisposableEffect onDispose { }
+        }
+
+        val manager = EnhancedPlayerManager.getInstance()
+        var attachedHolder: SurfaceHolder? = null
+        var attachedSurface: Surface? = null
+
+        fun attachIfValid(holder: SurfaceHolder) {
+            val surface = holder.surface
+            if (!surface.isValid || (attachedHolder === holder && attachedSurface === surface)) return
+            attachedHolder = holder
+            attachedSurface = surface
+            manager.attachVideoSurface(holder, forceAttach = true)
+        }
+
+        val callback = object : SurfaceHolder.Callback {
+            override fun surfaceCreated(holder: SurfaceHolder) {
+                attachIfValid(holder)
+            }
+
+            override fun surfaceChanged(
+                holder: SurfaceHolder,
+                format: Int,
+                width: Int,
+                height: Int
+            ) {
+                attachIfValid(holder)
+            }
+
+            override fun surfaceDestroyed(holder: SurfaceHolder) {
+                if (attachedHolder === holder) {
+                    manager.detachVideoSurface(holder)
+                    attachedHolder = null
+                    attachedSurface = null
+                }
+            }
+        }
+
+        surfaceView.holder.addCallback(callback)
+        attachIfValid(surfaceView.holder)
+
+        onDispose {
+            surfaceView.holder.removeCallback(callback)
+            attachedHolder?.let(manager::detachVideoSurface)
         }
     }
 

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/player/effects/PlayerScreenEffects.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/player/effects/PlayerScreenEffects.kt
@@ -262,14 +262,15 @@ fun PlaybackRefocusEffect(
 
     LaunchedEffect(resumeTrigger) {
         if (resumeTrigger == 0) return@LaunchedEffect
-
-        delay(150L)
-
         val mgr = EnhancedPlayerManager.getInstance()
         val player = mgr.getPlayer() ?: return@LaunchedEffect
         if (mgr.isInAudioOnlyMode() || mgr.isVideoSurfaceRestorePending()) {
             mgr.restoreVideoOutput()
         }
+        if (mgr.recoverClearedMediaAfterForeground()) return@LaunchedEffect
+
+        delay(150L)
+
         val playerMgrState = mgr.playerState.value
 
         if (!playerMgrState.hasEnded &&

--- a/app/src/test/java/io/github/aedev/flow/player/MemoryPressurePolicyTest.kt
+++ b/app/src/test/java/io/github/aedev/flow/player/MemoryPressurePolicyTest.kt
@@ -1,0 +1,47 @@
+package io.github.aedev.flow.player
+
+import android.content.ComponentCallbacks2
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class MemoryPressurePolicyTest {
+    @Suppress("DEPRECATION")
+    @Test
+    fun `ui hidden does not release video playback`() {
+        assertThat(
+            MemoryPressurePolicy.shouldReleaseVideoPlayback(
+                ComponentCallbacks2.TRIM_MEMORY_UI_HIDDEN
+            )
+        ).isFalse()
+    }
+
+    @Suppress("DEPRECATION")
+    @Test
+    fun `running critical releases video playback on older Android versions`() {
+        assertThat(
+            MemoryPressurePolicy.shouldReleaseVideoPlayback(
+                ComponentCallbacks2.TRIM_MEMORY_RUNNING_CRITICAL
+            )
+        ).isTrue()
+    }
+
+    @Suppress("DEPRECATION")
+    @Test
+    fun `background pressure releases rebuildable video playback`() {
+        assertThat(
+            MemoryPressurePolicy.shouldReleaseVideoPlayback(
+                ComponentCallbacks2.TRIM_MEMORY_BACKGROUND
+            )
+        ).isTrue()
+    }
+
+    @Suppress("DEPRECATION")
+    @Test
+    fun `running low does not clear the active playlist`() {
+        assertThat(
+            MemoryPressurePolicy.shouldReleaseVideoPlayback(
+                ComponentCallbacks2.TRIM_MEMORY_RUNNING_LOW
+            )
+        ).isFalse()
+    }
+}

--- a/app/src/test/java/io/github/aedev/flow/player/recovery/ClearedMediaRecoveryStateTest.kt
+++ b/app/src/test/java/io/github/aedev/flow/player/recovery/ClearedMediaRecoveryStateTest.kt
@@ -1,0 +1,67 @@
+package io.github.aedev.flow.player.recovery
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class ClearedMediaRecoveryStateTest {
+    @Test
+    fun `capture preserves paused local playback state`() {
+        val state = ClearedMediaRecoveryState()
+
+        state.capture(
+            videoId = "video-id",
+            positionMs = 12_345L,
+            playWhenReady = false,
+            localFilePath = "/media/video.mp4"
+        )
+
+        assertThat(state.pendingFor("video-id")).isEqualTo(
+            ClearedMediaRecoverySnapshot(
+                videoId = "video-id",
+                positionMs = 12_345L,
+                playWhenReady = false,
+                localFilePath = "/media/video.mp4"
+            )
+        )
+    }
+
+    @Test
+    fun `repeated empty trim does not replace the pending snapshot`() {
+        val state = ClearedMediaRecoveryState()
+        state.capture("video-id", 8_000L, playWhenReady = false, localFilePath = null)
+
+        state.capture(null, 0L, playWhenReady = false, localFilePath = null)
+
+        assertThat(state.pendingFor("video-id")?.positionMs).isEqualTo(8_000L)
+    }
+
+    @Test
+    fun `snapshot cannot be reused for another video`() {
+        val state = ClearedMediaRecoveryState()
+        state.capture("old-video", 8_000L, playWhenReady = false, localFilePath = null)
+
+        assertThat(state.pendingFor("new-video")).isNull()
+    }
+
+    @Test
+    fun `completed recovery clears only the snapshot that was loaded`() {
+        val state = ClearedMediaRecoveryState()
+        state.capture("video-id", 8_000L, playWhenReady = false, localFilePath = null)
+        val loadedSnapshot = state.pendingFor("video-id")!!
+        state.capture("video-id", 9_000L, playWhenReady = false, localFilePath = null)
+
+        state.complete(loadedSnapshot)
+
+        assertThat(state.pendingFor("video-id")?.positionMs).isEqualTo(9_000L)
+    }
+
+    @Test
+    fun `explicit clear prevents stopped media from being recovered`() {
+        val state = ClearedMediaRecoveryState()
+        state.capture("video-id", 8_000L, playWhenReady = false, localFilePath = null)
+
+        state.clear()
+
+        assertThat(state.pendingFor("video-id")).isNull()
+    }
+}

--- a/app/src/test/java/io/github/aedev/flow/player/surface/VideoSurfacePolicyTest.kt
+++ b/app/src/test/java/io/github/aedev/flow/player/surface/VideoSurfacePolicyTest.kt
@@ -1,0 +1,114 @@
+package io.github.aedev.flow.player.surface
+
+import android.os.Build
+import androidx.media3.common.Player
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class VideoSurfacePolicyTest {
+    @Test
+    fun `surface view restore waits for a valid holder`() {
+        assertThat(
+            VideoSurfacePolicy.canRestoreVideoOutput(
+                sdkInt = Build.VERSION_CODES.UPSIDE_DOWN_CAKE,
+                isDisplayInteractive = true,
+                isSurfaceValid = false
+            )
+        ).isFalse()
+    }
+
+    @Test
+    fun `surface view restores once its holder is valid`() {
+        assertThat(
+            VideoSurfacePolicy.canRestoreVideoOutput(
+                sdkInt = Build.VERSION_CODES.UPSIDE_DOWN_CAKE,
+                isDisplayInteractive = true,
+                isSurfaceValid = true
+            )
+        ).isTrue()
+    }
+
+    @Test
+    fun `texture view restore does not require a surface holder`() {
+        assertThat(
+            VideoSurfacePolicy.canRestoreVideoOutput(
+                sdkInt = Build.VERSION_CODES.TIRAMISU,
+                isDisplayInteractive = true,
+                isSurfaceValid = false
+            )
+        ).isTrue()
+    }
+
+    @Test
+    fun `video output stays disabled while display is not interactive`() {
+        assertThat(
+            VideoSurfacePolicy.canRestoreVideoOutput(
+                sdkInt = Build.VERSION_CODES.UPSIDE_DOWN_CAKE,
+                isDisplayInteractive = false,
+                isSurfaceValid = true
+            )
+        ).isFalse()
+    }
+
+    @Test
+    fun `paused ready playback resyncs after a surface reattach`() {
+        assertThat(
+            VideoSurfacePolicy.shouldResyncOnSurfaceReattach(
+                playWhenReady = false,
+                isLive = false,
+                playbackState = Player.STATE_READY
+            )
+        ).isTrue()
+    }
+
+    @Test
+    fun `paused buffering playback resyncs after a surface reattach`() {
+        assertThat(
+            VideoSurfacePolicy.shouldResyncOnSurfaceReattach(
+                playWhenReady = false,
+                isLive = false,
+                playbackState = Player.STATE_BUFFERING
+            )
+        ).isTrue()
+    }
+
+    @Test
+    fun `active playback is not interrupted by a resync seek`() {
+        assertThat(
+            VideoSurfacePolicy.shouldResyncOnSurfaceReattach(
+                playWhenReady = true,
+                isLive = false,
+                playbackState = Player.STATE_READY
+            )
+        ).isFalse()
+    }
+
+    @Test
+    fun `live streams never resync via seek`() {
+        assertThat(
+            VideoSurfacePolicy.shouldResyncOnSurfaceReattach(
+                playWhenReady = false,
+                isLive = true,
+                playbackState = Player.STATE_READY
+            )
+        ).isFalse()
+    }
+
+    @Test
+    fun `idle and ended players are not resynced`() {
+        assertThat(
+            VideoSurfacePolicy.shouldResyncOnSurfaceReattach(
+                playWhenReady = false,
+                isLive = false,
+                playbackState = Player.STATE_IDLE
+            )
+        ).isFalse()
+        assertThat(
+            VideoSurfacePolicy.shouldResyncOnSurfaceReattach(
+                playWhenReady = false,
+                isLive = false,
+                playbackState = Player.STATE_ENDED
+            )
+        ).isFalse()
+    }
+}


### PR DESCRIPTION
## Problem

After leaving a **paused** video and later returning to it, the player surface stays **black** and the **play button does nothing** — even though the video appears fully loaded (title, duration, chapters/sections are all shown). Playback cannot be resumed without leaving and reopening the video.

This only reproduces after the app has spent time in the background under memory pressure — an ordinary app-switch-and-return works fine.

## Root cause

1. While the app is backgrounded on a **paused** video, Android delivers `TRIM_MEMORY_RUNNING_CRITICAL`.
2. `MainActivity.onTrimMemory` → `EnhancedPlayerManager.handleCriticalMemoryPressure()`. Because the video is paused (`shouldKeepPlaying == false`), it runs `player.stop()` + `player.clearMediaItems()`.
3. This leaves ExoPlayer in `STATE_IDLE` with an **empty playlist**, while `currentVideoStream` and all UI metadata remain intact — hence "the video looks loaded" but the surface is black.
4. On return, every recovery path — `play()`, `handleRefocusStuck()`, and `PlaybackRefocusEffect` — only calls `player.prepare()`. **`prepare()` is a no-op on an empty playlist**, so nothing reloads and the play button (`play()` → `player.play()` on an idle, media-less player) does nothing.

Observed log on the affected build when pressing play:
`W/PlayerErrorHandler: Refocus: player IDLE — calling prepare()` while the media session sits at `state=NONE, position=0`.

## Fix

Add `reloadClearedMediaIfNeeded()` to `EnhancedPlayerManager`: when the player is `STATE_IDLE` with **no media items** but cached streams still exist, reload the media via `loadMediaInternal(currentVideoStream, currentAudioStream, …)` instead of a dead `prepare()`. This mirrors the reload-when-empty logic that already exists in `setSurfaceReady()`.

It is wired into:
- **`play()`** — fixes the dead play button (recovers the media before playing).
- **`handleRefocusStuck()`** — auto-recovers the moment the user returns to the video, no tap required.

The playback position is captured in `handleCriticalMemoryPressure()` **before** the playlist is cleared, so recovery resumes where the user left off. The capture is guarded to only run when there is still media to lose, so a repeated trim (which arrives with an already-empty playlist at position 0) cannot clobber the saved position.

## Testing

Reproduced and verified on a Pixel emulator (API 34) by deterministically triggering the exact production code path with:

```
adb shell am send-trim-memory io.github.aedev.flow.debug RUNNING_CRITICAL
```

- **Before:** after background + trim + return, the surface is black and the play button is dead; recovery logs `Refocus: player IDLE — calling prepare()` on an empty playlist (no-op).
- **After:** returning to the video reloads the stream automatically, playback resumes near the paused position, and the play button works. Recovery logs `reloadClearedMedia: player reset with empty playlist — reloading cached streams (resumePos=…)` followed by `state=PLAYING`.

## Scope

Single-file change in `EnhancedPlayerManager.kt`. No behavior change for the healthy case: the added recovery only engages when the player is `IDLE` with an empty playlist and cached streams are available.