### PR TITLE
Fix StackOverflowError in ChannelsStep floating window

### DIFF
--- a/app/src/main/java/io/github/aedev/flow/ui/screens/onboarding/ChannelsStep.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/onboarding/ChannelsStep.kt
@@ -79,89 +79,98 @@ internal fun ChannelsStep(
         focusRequester.requestFocus()
     }
 
-    LazyColumn(
-        modifier = Modifier.fillMaxSize(),
-        contentPadding = PaddingValues(horizontal = 24.dp, vertical = 8.dp),
-        verticalArrangement = Arrangement.spacedBy(10.dp)
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(horizontal = 24.dp)
+            .padding(top = 8.dp)
     ) {
-        item {
-            StepHeader(
-                title = stringResource(R.string.onboarding_channels_title),
-                subtitle = stringResource(R.string.onboarding_channels_subtitle)
-            )
-        }
+        StepHeader(
+            title = stringResource(R.string.onboarding_channels_title),
+            subtitle = stringResource(R.string.onboarding_channels_subtitle)
+        )
 
-        item {
-            OutlinedTextField(
-                value = searchQuery,
-                onValueChange = onQueryChange,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .focusRequester(focusRequester),
-                placeholder = {
-                    Text(
-                        stringResource(R.string.onboarding_channels_search_placeholder),
-                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.55f)
-                    )
-                },
-                leadingIcon = {
-                    Icon(
-                        Icons.Outlined.Search,
-                        contentDescription = null,
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                },
-                trailingIcon = if (isSearching) {
-                    { CircularProgressIndicator(modifier = Modifier.size(18.dp), strokeWidth = 2.dp) }
-                } else null,
-                singleLine = true,
-                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
-                keyboardActions = KeyboardActions(onSearch = { focusManager.clearFocus() }),
-                shape = RoundedCornerShape(28.dp),
-                colors = OutlinedTextFieldDefaults.colors(
-                    focusedBorderColor = MaterialTheme.colorScheme.primary,
-                    unfocusedBorderColor = MaterialTheme.colorScheme.outlineVariant
-                )
-            )
-        }
+        Spacer(modifier = Modifier.height(10.dp))
 
-        if (searchQuery.isBlank()) {
-            item {
-                ChannelsPlaceholder(
-                    text = stringResource(R.string.onboarding_channels_empty_prompt),
-                    strong = false
-                )
-            }
-        } else if (searchResults.isEmpty() && !isSearching) {
-            item {
-                ChannelsPlaceholder(
-                    text = stringResource(R.string.onboarding_channels_no_results, searchQuery),
-                    strong = true
-                )
-            }
-        }
-
-        items(searchResults, key = { it.channelId }) { result ->
-            ChannelResultRow(
-                result = result,
-                isSubscribed = subscribedInSession.contains(result.channelId),
-                onToggle = { onSubscribeToggle(result) }
-            )
-        }
-
-        if (subscribedInSession.isNotEmpty()) {
-            item {
+        OutlinedTextField(
+            value = searchQuery,
+            onValueChange = onQueryChange,
+            modifier = Modifier
+                .fillMaxWidth()
+                .focusRequester(focusRequester),
+            placeholder = {
                 Text(
-                    text = stringResource(R.string.onboarding_channels_added_count, subscribedInSession.size),
-                    style = MaterialTheme.typography.labelLarge,
-                    fontWeight = FontWeight.SemiBold,
-                    color = MaterialTheme.colorScheme.primary,
-                    modifier = Modifier.padding(top = 4.dp)
+                    stringResource(R.string.onboarding_channels_search_placeholder),
+                    color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.55f)
+                )
+            },
+            leadingIcon = {
+                Icon(
+                    Icons.Outlined.Search,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            },
+            trailingIcon = if (isSearching) {
+                { CircularProgressIndicator(modifier = Modifier.size(18.dp), strokeWidth = 2.dp) }
+            } else null,
+            singleLine = true,
+            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
+            keyboardActions = KeyboardActions(onSearch = { focusManager.clearFocus() }),
+            shape = RoundedCornerShape(28.dp),
+            colors = OutlinedTextFieldDefaults.colors(
+                focusedBorderColor = MaterialTheme.colorScheme.primary,
+                unfocusedBorderColor = MaterialTheme.colorScheme.outlineVariant
+            )
+        )
+
+        Spacer(modifier = Modifier.height(10.dp))
+
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f),
+            verticalArrangement = Arrangement.spacedBy(10.dp),
+            contentPadding = PaddingValues(bottom = 8.dp)
+        ) {
+            if (searchQuery.isBlank()) {
+                item {
+                    ChannelsPlaceholder(
+                        text = stringResource(R.string.onboarding_channels_empty_prompt),
+                        strong = false
+                    )
+                }
+            } else if (searchResults.isEmpty() && !isSearching) {
+                item {
+                    ChannelsPlaceholder(
+                        text = stringResource(R.string.onboarding_channels_no_results, searchQuery),
+                        strong = true
+                    )
+                }
+            }
+
+            items(searchResults, key = { it.channelId }) { result ->
+                ChannelResultRow(
+                    result = result,
+                    isSubscribed = subscribedInSession.contains(result.channelId),
+                    onToggle = { onSubscribeToggle(result) }
                 )
             }
-        }
 
-        item { Spacer(Modifier.height(8.dp)) }
+            if (subscribedInSession.isNotEmpty()) {
+                item {
+                    Text(
+                        text = stringResource(R.string.onboarding_channels_added_count, subscribedInSession.size),
+                        style = MaterialTheme.typography.labelLarge,
+                        fontWeight = FontWeight.SemiBold,
+                        color = MaterialTheme.colorScheme.primary,
+                        modifier = Modifier.padding(top = 4.dp)
+                    )
+                }
+            }
+
+            item { Spacer(Modifier.height(8.dp)) }
+        }
     }
 }
 


### PR DESCRIPTION
**Describe the bug**
When launching the app in a freeform/floating window (e.g. pop-up view) and tapping the search field in the `ChannelsStep`, the app crashes with a `StackOverflowError` in `OnPositionedDispatcher.dispatchHierarchy`.

**Root cause**
The crash is caused by a known Jetpack Compose bug where an `OutlinedTextField` inside a `LazyColumn` constantly requests focus and triggers infinite `BringIntoViewRequester` measurements under tight constraints (like when the keyboard appears in a small window).

**Solution**
Refactored the layout in `ChannelsStep.kt`:
- Replaced the root `LazyColumn` with a `Column`.
- Extracted `StepHeader` and `OutlinedTextField` into the static part of the `Column`.
- Placed the search results into a nested `LazyColumn` with `weight(1f)`.

This breaks the infinite measurement cycle and also improves the UX (the search bar no longer scrolls out of view when scrolling through channel results).