### PR TITLE
build(gradle): remove deprecated enableJetifier flag

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,4 @@
 android.useAndroidX=true
-android.enableJetifier=true
 kotlin.code.style=official
 # Increase memory for R8/ProGuard and Kotlin compiler daemon
 org.gradle.jvmargs=-Xmx4096m -XX:MaxMetaspaceSize=1024m -Dfile.encoding=UTF-8


### PR DESCRIPTION
## Summary

This PR removes the deprecated `android.enableJetifier=true` flag from `gradle.properties`.

### Why:
- **Full AndroidX Migration:** All dependencies used across product flavors (`github` and `foss`) have migrated to native AndroidX artifacts.
- **Build Performance:** Disabling Jetifier speeds up Gradle sync, compilation, and dependency resolution by eliminating unnecessary bytecode transformation passes on third-party dependencies.
- **AGP Compatibility:** Jetifier was deprecated in AGP 7.0 and is removed in modern Android Gradle Plugin releases.

References:
- [Google Developer Documentation - Enable AndroidX & Disable Jetifier](https://developer.android.com/studio/build/enable-androidx#enable-androidx)

## Related issue

N/A

## Change type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor or maintenance
- [x] Build, packaging, or CI
- [ ] Documentation

## Validation

- [x] `./gradlew :app:assembleGithubDebug`
- [ ] `./gradlew :app:testGithubDebugUnitTest`
- [x] I ran any additional flavor-specific build or test tasks affected by this change (`./gradlew :app:assembleFossDebug`).
- [ ] I manually tested the affected behavior on an Android device or emulator.

**Test device and Android version:** N/A (Build/tooling configuration change)

### Verification Details:
1. **Multi-Flavor Build Check:** Ran `./gradlew :app:assembleGithubDebug :app:assembleFossDebug` successfully (`BUILD SUCCESSFUL in 4m 41s`).
2. **Dependency Tree Verification:** Inspected resolved runtime dependency graphs across both `github` and `foss` flavors (`:app:dependencies`) to confirm zero legacy `com.android.support` artifacts exist in the classpath.

## Screenshots or recordings

N/A (No visual/UI changes)

## Risk and compatibility

- [x] The change does not introduce secrets, private data, or unexpected telemetry.
- [x] New user-facing text uses Android string resources.
- [x] Dependency and lockfile changes are intentional and limited to this PR.
- [x] Room schema changes include the required version bump and migration, or this PR does not change the Room schema.
- [x] Breaking changes and upgrade steps are clearly documented.