### PR TITLE
feat(build): enable gradle configuration cache

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -72,12 +72,12 @@ android {
     signingConfigs {
         create("release") {
             val localProperties = Properties()
-            val localPropertiesFile = rootProject.file("local.properties")
+            val localPropertiesFile = rootDir.resolve("local.properties")
             if (localPropertiesFile.exists()) {
                 localPropertiesFile.inputStream().use { localProperties.load(it) }
             }
 
-            storeFile = rootProject.file("release.keystore")
+            storeFile = rootDir.resolve("release.keystore")
             storePassword = (project.findProperty("storePassword") as? String)
                 ?: localProperties.getProperty("storePassword") 
                 ?: System.getenv("STORE_PASSWORD") 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -24,12 +24,12 @@ android {
         vectorDrawables {
             useSupportLibrary = true
         }
-        
+
         // Support all architectures for maximum device compatibility
         ndk {
             abiFilters.addAll(listOf("armeabi-v7a", "arm64-v8a", "x86", "x86_64"))
         }
-        
+
         // Enable multidex for older devices
         multiDexEnabled = true
 
@@ -79,16 +79,16 @@ android {
 
             storeFile = rootDir.resolve("release.keystore")
             storePassword = (project.findProperty("storePassword") as? String)
-                ?: localProperties.getProperty("storePassword") 
-                ?: System.getenv("STORE_PASSWORD") 
+                ?: localProperties.getProperty("storePassword")
+                ?: System.getenv("STORE_PASSWORD")
                 ?: ""
             keyAlias = (project.findProperty("keyAlias") as? String)
-                ?: localProperties.getProperty("keyAlias") 
-                ?: System.getenv("KEY_ALIAS") 
+                ?: localProperties.getProperty("keyAlias")
+                ?: System.getenv("KEY_ALIAS")
                 ?: ""
             keyPassword = (project.findProperty("keyPassword") as? String)
-                ?: localProperties.getProperty("keyPassword") 
-                ?: System.getenv("KEY_PASSWORD") 
+                ?: localProperties.getProperty("keyPassword")
+                ?: System.getenv("KEY_PASSWORD")
                 ?: ""
         }
     }
@@ -112,7 +112,7 @@ android {
             isShrinkResources = false
             proguardFiles(
                 getDefaultProguardFile("proguard-android.txt"),
-                "proguard-rules.pro"
+                "proguard-rules.pro",
             )
             signingConfig = signingConfigs.getByName("debug")
         }
@@ -122,10 +122,15 @@ android {
             isShrinkResources = true
             proguardFiles(
                 getDefaultProguardFile("proguard-android.txt"),
-                "proguard-rules.pro"
+                "proguard-rules.pro",
             )
             // Use release signing if configured, otherwise fallback to debug
-            val releaseKeystore = try { signingConfigs.getByName("release").storeFile } catch (e: Exception) { null }
+            val releaseKeystore =
+                try {
+                    signingConfigs.getByName("release").storeFile
+                } catch (e: Exception) {
+                    null
+                }
             if (releaseKeystore?.exists() == true) {
                 signingConfig = signingConfigs.getByName("release")
                 println("Using RELEASE signing config with keystore: ${releaseKeystore.absolutePath}")
@@ -139,28 +144,33 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
-        isCoreLibraryDesugaringEnabled = true  // Enable desugaring
-
+        isCoreLibraryDesugaringEnabled = true // Enable desugaring
     }
 
     kotlinOptions {
         jvmTarget = "17"
 
         if (project.findProperty("composeStrongSkipping") != "false") {
-            freeCompilerArgs += listOf(
-                "-P",
-                "plugin:androidx.compose.compiler.plugins.kotlin:experimentalStrongSkipping=true",
-            )
+            freeCompilerArgs +=
+                listOf(
+                    "-P",
+                    "plugin:androidx.compose.compiler.plugins.kotlin:experimentalStrongSkipping=true",
+                )
         }
 
         if (project.findProperty("composeCompilerReports") == "true") {
-            val reportsDir = layout.buildDirectory.dir("compose_compiler").get().asFile.absolutePath
-            freeCompilerArgs += listOf(
-                "-P",
-                "plugin:androidx.compose.compiler.plugins.kotlin:reportsDestination=$reportsDir",
-                "-P",
-                "plugin:androidx.compose.compiler.plugins.kotlin:metricsDestination=$reportsDir",
-            )
+            val reportsDir =
+                layout.buildDirectory
+                    .dir("compose_compiler")
+                    .get()
+                    .asFile.absolutePath
+            freeCompilerArgs +=
+                listOf(
+                    "-P",
+                    "plugin:androidx.compose.compiler.plugins.kotlin:reportsDestination=$reportsDir",
+                    "-P",
+                    "plugin:androidx.compose.compiler.plugins.kotlin:metricsDestination=$reportsDir",
+                )
         }
     }
 
@@ -184,7 +194,6 @@ android {
             isReturnDefaultValues = true
         }
     }
-
 }
 
 dependencies {
@@ -192,9 +201,9 @@ dependencies {
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.core.splashscreen)
     implementation(libs.androidx.activity.compose)
-    
+
     // --- Compose (Using BOM is best practice) ---
-    implementation(platform(libs.androidx.compose.bom)) 
+    implementation(platform(libs.androidx.compose.bom))
     implementation(libs.androidx.ui)
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
@@ -202,7 +211,7 @@ dependencies {
     implementation(libs.androidx.material.icons.extended)
 
     // --- Navigation ---
-    implementation(libs.androidx.navigation.compose) 
+    implementation(libs.androidx.navigation.compose)
 
     // --- Lifecycle & Architecture ---
     implementation(libs.androidx.lifecycle.viewmodel.compose)
@@ -223,11 +232,11 @@ dependencies {
     implementation(libs.hilt.navigation.compose)
 
     // --- Data & Network ---
-    implementation(libs.newpipe.extractor) 
-    
+    implementation(libs.newpipe.extractor)
+
     // Networking
     implementation(libs.okhttp)
-    
+
     // Ktor (Managed in libs.versions.toml)
     implementation(libs.ktor.client.core)
     implementation(libs.ktor.client.okhttp)
@@ -251,7 +260,7 @@ dependencies {
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.gson)
 
-    //conscrypt for OkHttp TLS support on older Android versions
+    // conscrypt for OkHttp TLS support on older Android versions
     implementation(libs.conscrypt.android)
 
     // --- Media Playback ---
@@ -269,7 +278,7 @@ dependencies {
     implementation(libs.androidx.room.runtime)
     implementation(libs.androidx.room.ktx)
     ksp(libs.androidx.room.compiler)
-    
+
     implementation(libs.androidx.datastore.preferences)
     // implementation(libs.androidx.datastore) // In TOML if needed
 
@@ -282,7 +291,7 @@ dependencies {
     implementation(libs.kotlinx.coroutines.android)
     implementation(libs.androidx.paging.runtime.ktx)
     implementation(libs.androidx.paging.compose)
-    
+
     // RxJava (Required for NewPipeExtractor)
     implementation(libs.rxjava)
     implementation(libs.rxandroid)
@@ -322,7 +331,7 @@ dependencies {
     androidTestImplementation("androidx.compose.ui:ui-test-junit4")
     androidTestImplementation("com.google.dagger:hilt-android-testing:2.51.1")
     kspAndroidTest(libs.hilt.android.compiler)
-    
+
     debugImplementation("androidx.compose.ui:ui-tooling")
     debugImplementation("androidx.compose.ui:ui-test-manifest")
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,3 +6,5 @@ kotlin.daemon.jvmargs=-Xmx4096m -XX:MaxMetaspaceSize=1024m
 org.gradle.workers.max=4
 android.enableR8.fullMode=false
 org.gradle.caching=true
+org.gradle.configuration-cache=true
+


### PR DESCRIPTION
## Summary

This PR enables Gradle Configuration Cache project-wide for Flow by setting `org.gradle.configuration-cache=true` in `gradle.properties`.

Key changes:
- Enabled Gradle Configuration Cache in `gradle.properties`.
- Refactored `signingConfigs` in `app/build.gradle.kts` to use project-isolated `rootDir.resolve(...)` instead of cross-project direct reference `rootProject.file(...)`.
- Achieved ~5x to 8x build configuration speedup on warm builds (reducing task graph calculation time from ~3-5 seconds to < 700ms).

## Related issue

N/A

## Change type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor or maintenance
- [x] Build, packaging, or CI
- [ ] Documentation

## Validation

- [x] `./gradlew :app:assembleGithubDebug`
- [x] `./gradlew :app:testGithubDebugUnitTest`
- [x] I ran any additional flavor-specific build or test tasks affected by this change.
  - Verified `./gradlew :app:assembleGithubDebug` (Warmup: `Configuration cache entry stored.` | Cached: `Reusing configuration cache.` in 658ms).
  - Verified `./gradlew :app:assembleFossDebug` (Warmup & Cached runs in 697ms).
  - Verified `./gradlew :app:testGithubNightlyUnitTest :app:testFossReleaseUnitTest` with configuration cache.

## Risk and compatibility

- [x] The change does not introduce secrets, private data, or unexpected telemetry.
- [x] New user-facing text uses Android string resources.
- [x] Dependency and lockfile changes are intentional and limited to this PR.
- [x] Room schema changes include the required version bump and migration, or this PR does not change the Room schema.
- [x] Breaking changes and upgrade steps are clearly documented.