### PR TITLE
fix(lint): update ratchet baseline

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,8 +14,8 @@ plugins {
 }
 
 spotless {
-    // Adopt formatting incrementally from the last pre-lint revision.
-    ratchetFrom("628a7332219f24631d0cbfd5181df224a99e31ed")
+    // Adopt formatting incrementally from the main commit that introduced linting.
+    ratchetFrom("52c4928e5af05141080f46f6c1e41cbf9c457023")
     lineEndings = LineEnding.UNIX
 
     kotlin {


### PR DESCRIPTION
## Summary

Users reported scrolling that felt less smooth than comparable clients, and phones heating up during playback. This branch addresses both.

The common cause was per-frame work that didn't need to be per-frame: Compose animations driving redraws at the display refresh rate, position tickers emitting at 20 Hz into state the UI reads once a second, and per-card collectors re-reading the same preference file. These are consolidated onto adaptive or event-driven updates.

Main implementation decisions:

- Ambient mode replaces a crossfade and two colour tweens with a single exponential filter over the pixel buffer in linear light, emitting only while it is converging rather than every vsync.
- Playback position publishes on one adaptive tick; precise updates are acquired only by the components that need them.
- Card preferences and watch progress are collected once at the composition root and read per video id via `derivedStateOf`, so one progress write no longer recomposes every visible card.
- Cold-start work moved off the main thread, plus a shipped baseline profile and Compose strong skipping.

Build and CI, in the same branch:

- Automated Kotlin formatting checks with ktlint and Spotless
- Smaller APKs via ABI-specific releases, resource shrinking, and dependency cleanup
- ABI-aware app updates and GitHub/FOSS release packaging
- Faster builds with KSP, Gradle caching, improved parallelism, and CI daemon reuse
- Obsolete playback and download code removed

## Change type

- [ ] Bug fix
- [ ] Feature
- [x] Refactor or maintenance
- [x] Build, packaging, or CI
- [ ] Documentation

Measured on release builds:

- Cold start 334 ms → 257 ms
- Idle CPU 5.53% → 0.22% of one core
- Scroll p99 frame 25.5 ms → 13.0 ms, janky frames 0.10% → 0.04%
- Ambient playback renders 5.2× fewer frames, −22% CPU

## Validation

- [x] `./gradlew :app:assembleGithubDebug` — run via `installGithubDebug`
- [x] `./gradlew :app:testGithubDebugUnitTest` — 499 tests pass
- [ ] I ran any additional flavor-specific build or test tasks affected by this change. — `foss` not built
- [x] I manually tested the affected behavior on an Android device or emulator.

**Test device and Android version:** Xiaomi 2311DRK48G, Android 16

## Risk and compatibility

Ambient mode was rewritten onto a new capture and filtering path — the main thing to watch. Build changes alter release packaging (ABI splits, resource shrinking) and add a formatting gate to CI. Known limitation: the shipped baseline profile predates the startup changes and should be regenerated before tagging.

- [x] The change does not introduce secrets, private data, or unexpected telemetry.
- [x] New user-facing text uses Android string resources.
- [x] Dependency and lockfile changes are intentional and limited to this PR.
- [x] Room schema changes include the required version bump and migration, or this PR does not change the Room schema.
- [x] Breaking changes and upgrade steps are clearly documented.
