### PR TITLE
refactor(di): migrate History, LikedVideos, and Search ViewModels to Hilt injection

### DIFF
--- a/.agent/skills/unit-testing/SKILL.md
+++ b/.agent/skills/unit-testing/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: unit-testing
+description: Guidelines, patterns, and best practices for writing Kotlin unit tests for ViewModels, Repositories, and Utilities in the Flow Android project.
+---
+
+# Kotlin Unit Testing Guidelines & Best Practices for Flow
+
+This skill outlines the standards and conventions for writing unit tests in the Flow codebase (`io.github.aedev.flow`).
+
+## 1. Naming Conventions
+
+### Test Class Naming
+- Test class names MUST mirror the target class with a `Test` suffix.
+  - Example: `LikedVideosViewModel` → `LikedVideosViewModelTest`
+  - Example: `HistoryViewModel` → `HistoryViewModelTest`
+  - Example: `SearchViewModel` → `SearchViewModelTest`
+
+### Test Method Naming
+- Use backtick-quoted descriptive phrases outlining the scenario and expected outcome:
+  - Format: `` `[given condition or action] [expected result]` ``
+  - Good: `` `initial state loads liked videos from repository` ``
+  - Good: `` `removeLike calls repository and updates state` ``
+  - Good: `` `search with query updates results flow` ``
+  - Bad: `testRemoveLike()`, `test1()`
+
+---
+
+## 2. Mocking Framework & Cleanup Rules
+
+- **Framework**: Use **MockK** (`io.mockk.*`).
+- **Initialization**: Create mocks in `@Before` or as class properties via `mockk(relaxed = true)` or `mockk()`.
+- **Teardown / Cleanup**: ALWAYS clean up mocks in an `@After` method using `unmockkAll()` or `clearAllMocks()` to ensure isolated test execution and prevent memory leaks/polluted mock states across tests.
+
+```kotlin
+@Before
+fun setUp() {
+    repository = mockk(relaxed = true)
+}
+
+@After
+fun tearDown() {
+    unmockkAll()
+}
+```
+
+---
+
+## 3. Coroutines & ViewModel Testing
+
+ViewModel unit tests run on the JVM without an Android Main Looper. Since `viewModelScope` uses `Dispatchers.Main`, you MUST replace the Main dispatcher during tests:
+
+- Use `Dispatchers.setMain(testDispatcher)` in `@Before` (or via a JUnit `TestRule`).
+- Use `Dispatchers.resetMain()` in `@After`.
+- Wrap suspend test logic inside `runTest` from `kotlinx.coroutines.test`.
+
+```kotlin
+@OptIn(ExperimentalCoroutinesApi::class)
+class MyViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+        unmockkAll()
+    }
+}
+```
+
+---
+
+## 4. Assertions & AAA Pattern
+
+- **Assertion Library**: Use **Google Truth** (`com.google.common.truth.Truth.assertThat`).
+- **AAA Pattern**: Structure tests clearly with **Arrange**, **Act**, and **Assert**:
+
+```kotlin
+@Test
+fun `removeLike calls repository to remove item`() = runTest {
+    // Arrange
+    val videoId = "test_id_123"
+    coEvery { repository.removeLikeState(videoId) } returns Unit
+
+    // Act
+    viewModel.removeLike(videoId)
+    testScheduler.advanceUntilIdle()
+
+    // Assert
+    coVerify(exactly = 1) { repository.removeLikeState(videoId) }
+}
+```
+
+---
+
+## 5. Summary Checklist Before Shipping Tests
+1. ✅ Test file resides under `app/src/test/java/...` matching package structure of source class.
+2. ✅ Method names use backtick-quoted descriptive sentences.
+3. ✅ MockK is used for dependencies with `unmockkAll()` in `@After`.
+4. ✅ Main dispatcher rule/setup is present for ViewModel tests.
+5. ✅ Google Truth (`assertThat`) is used for assertions.
+6. ✅ Test passes cleanly via `./gradlew :app:testGithubDebugUnitTest`.

--- a/app/src/main/java/io/github/aedev/flow/data/recommendation/MusicRecommendationAlgorithm.kt
+++ b/app/src/main/java/io/github/aedev/flow/data/recommendation/MusicRecommendationAlgorithm.kt
@@ -2,8 +2,8 @@ package io.github.aedev.flow.data.recommendation
 
 import android.content.Context
 import android.util.Log
+import dagger.hilt.android.qualifiers.ApplicationContext
 import io.github.aedev.flow.data.local.LikedVideosRepository
-import io.github.aedev.flow.data.local.ViewHistory
 import io.github.aedev.flow.data.music.PlaylistRepository
 import io.github.aedev.flow.innertube.YouTube
 import io.github.aedev.flow.innertube.models.SongItem
@@ -12,7 +12,6 @@ import io.github.aedev.flow.innertube.models.PlaylistItem
 import io.github.aedev.flow.innertube.models.YTItem
 import io.github.aedev.flow.innertube.models.WatchEndpoint
 import io.github.aedev.flow.innertube.pages.HomePage
-import io.github.aedev.flow.data.local.entity.MusicHomeChipEntity
 import io.github.aedev.flow.ui.screens.music.MusicTrack
 import io.github.aedev.flow.ui.screens.music.MusicItemType
 import kotlinx.coroutines.Dispatchers
@@ -45,11 +44,9 @@ data class MusicSection(
  */
 @Singleton
 class MusicRecommendationAlgorithm @Inject constructor(
-    private val context: Context,
+    @ApplicationContext private val context: Context,
     private val playlistRepository: PlaylistRepository,
     private val likedVideosRepository: LikedVideosRepository,
-    private val subscriptionRepository: io.github.aedev.flow.data.local.SubscriptionRepository,
-    private val viewHistory: ViewHistory,
     private val youTube: YouTube,
     private val cacheDao: io.github.aedev.flow.data.local.dao.CacheDao
 ) {

--- a/app/src/main/java/io/github/aedev/flow/di/AppModule.kt
+++ b/app/src/main/java/io/github/aedev/flow/di/AppModule.kt
@@ -22,12 +22,6 @@ object AppModule {
 
     @Provides
     @Singleton
-    fun provideContext(@ApplicationContext context: Context): Context {
-        return context
-    }
-
-    @Provides
-    @Singleton
     fun provideYouTube(): YouTube {
         return YouTube
     }

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/history/HistoryScreen.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/history/HistoryScreen.kt
@@ -65,7 +65,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 import coil.compose.AsyncImage
 import io.github.aedev.flow.R
 import io.github.aedev.flow.data.local.VideoHistoryEntry
@@ -88,9 +88,8 @@ fun HistoryScreen(
     onShortClick: (String) -> Unit = {},
     onMusicClick: (MusicTrack, List<MusicTrack>) -> Unit = { track, _ -> onVideoClick(track) },
     modifier: Modifier = Modifier,
-    viewModel: HistoryViewModel = viewModel()
+    viewModel: HistoryViewModel = hiltViewModel()
 ) {
-    val context = LocalContext.current
     val uiState by viewModel.uiState.collectAsState()
     val searchFocusRequester = remember { FocusRequester() }
 
@@ -101,10 +100,6 @@ fun HistoryScreen(
     var selectedFilter by rememberSaveable { mutableStateOf(HistoryContentFilter.All) }
     var selectedSort by rememberSaveable { mutableStateOf(HistorySort.Newest) }
     var selectedYear by rememberSaveable { mutableStateOf<Int?>(null) }
-
-    LaunchedEffect(Unit) {
-        viewModel.initialize(context)
-    }
 
     val availableYears = remember(uiState.historyEntries) {
         uiState.historyEntries

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/history/HistoryViewModel.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/history/HistoryViewModel.kt
@@ -1,14 +1,15 @@
 package io.github.aedev.flow.ui.screens.history
 
-import android.content.Context
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import io.github.aedev.flow.data.local.AppDatabase
+import dagger.hilt.android.lifecycle.HiltViewModel
 import io.github.aedev.flow.data.local.ViewHistory
 import io.github.aedev.flow.data.local.VideoHistoryEntry
 import io.github.aedev.flow.data.local.entity.WatchHistoryEntity
 import io.github.aedev.flow.data.local.entity.VideoEntity
+import io.github.aedev.flow.data.local.dao.VideoDao
+import io.github.aedev.flow.data.local.dao.WatchHistoryDao
 import io.github.aedev.flow.data.model.Video
 import io.github.aedev.flow.data.repository.YouTubeRepository
 import io.github.aedev.flow.utils.ThumbnailUrlResolver
@@ -17,21 +18,22 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 import java.util.concurrent.atomic.AtomicBoolean
+import javax.inject.Inject
 
-class HistoryViewModel : ViewModel() {
+@HiltViewModel
+class HistoryViewModel @Inject constructor(
+    private val viewHistory: ViewHistory,
+    private val youTubeRepository: YouTubeRepository,
+    private val videoDao: VideoDao,
+    private val watchHistoryDao: WatchHistoryDao,
+) : ViewModel() {
 
-    private lateinit var viewHistory: ViewHistory
-    private val youTubeRepository = YouTubeRepository.getInstance()
     private val isEnriching = AtomicBoolean(false)
 
     private val _uiState = MutableStateFlow(HistoryUiState())
     val uiState: StateFlow<HistoryUiState> = _uiState.asStateFlow()
 
-    fun initialize(context: Context) {
-        viewHistory = ViewHistory.getInstance(context)
-        val videoDao = AppDatabase.getDatabase(context).videoDao()
-        val watchHistoryDao = AppDatabase.getDatabase(context).watchHistoryDao()
-
+    init {
         // Load history and enrich any entries that are missing metadata
         viewModelScope.launch {
             _uiState.update { it.copy(isLoading = true) }
@@ -96,7 +98,7 @@ class HistoryViewModel : ViewModel() {
                     .distinctBy { it.videoId }
                     .take(30)
                 if (stubs.isNotEmpty()) {
-                    enrichFromApi(stubs, videoDao, watchHistoryDao)
+                    enrichFromApi(stubs)
                 }
             }
         }
@@ -104,8 +106,6 @@ class HistoryViewModel : ViewModel() {
 
     private fun enrichFromApi(
         stubs: List<VideoHistoryEntry>,
-        videoDao: io.github.aedev.flow.data.local.dao.VideoDao,
-        watchHistoryDao: io.github.aedev.flow.data.local.dao.WatchHistoryDao
     ) {
         if (!isEnriching.compareAndSet(false, true)) return
         viewModelScope.launch(Dispatchers.IO) {

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/likedvideos/LikedVideosScreen.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/likedvideos/LikedVideosScreen.kt
@@ -46,13 +46,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 import coil.compose.AsyncImage
 import io.github.aedev.flow.R
 import io.github.aedev.flow.data.local.LikedVideoInfo
@@ -66,15 +65,10 @@ fun LikesScreen(
     onBackClick: () -> Unit,
     onMusicClick: (MusicTrack, List<MusicTrack>) -> Unit = { track, _ -> onVideoClick(track) },
     modifier: Modifier = Modifier,
-    viewModel: LikedVideosViewModel = viewModel()
+    viewModel: LikedVideosViewModel = hiltViewModel()
 ) {
-    val context = LocalContext.current
     val uiState by viewModel.uiState.collectAsState()
     var selectedFilter by rememberSaveable { mutableStateOf(LikesFilter.Videos) }
-
-    LaunchedEffect(Unit) {
-        viewModel.initialize(context)
-    }
 
     val displayLikes = remember(uiState.likedVideos, selectedFilter) {
         uiState.likedVideos.filter { selectedFilter.matches(it) }

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/likedvideos/LikedVideosViewModel.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/likedvideos/LikedVideosViewModel.kt
@@ -1,23 +1,23 @@
 package io.github.aedev.flow.ui.screens.likedvideos
 
-import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
 import io.github.aedev.flow.data.local.LikedVideosRepository
 import io.github.aedev.flow.data.local.LikedVideoInfo
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
+import javax.inject.Inject
 
-class LikedVideosViewModel : ViewModel() {
-    
-    private lateinit var likedVideosRepository: LikedVideosRepository
-    
+@HiltViewModel
+class LikedVideosViewModel @Inject constructor(
+    private val likedVideosRepository: LikedVideosRepository,
+) : ViewModel() {
+
     private val _uiState = MutableStateFlow(LikedVideosUiState())
     val uiState: StateFlow<LikedVideosUiState> = _uiState.asStateFlow()
-    
-    fun initialize(context: Context) {
-        likedVideosRepository = LikedVideosRepository.getInstance(context)
-        
+
+    init {
         // Load all likes so the screen can switch between videos and music locally.
         viewModelScope.launch {
             _uiState.update { it.copy(isLoading = true) }
@@ -31,7 +31,7 @@ class LikedVideosViewModel : ViewModel() {
             }
         }
     }
-    
+
     fun removeLike(videoId: String) {
         viewModelScope.launch {
             likedVideosRepository.removeLikeState(videoId)

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/search/SearchScreen.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/search/SearchScreen.kt
@@ -37,7 +37,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.*
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.platform.LocalFocusManager
-import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.paging.LoadState
 import androidx.paging.compose.collectAsLazyPagingItems
 import coil.compose.AsyncImage
@@ -64,7 +64,7 @@ fun SearchScreen(
     onChannelClick: (Channel) -> Unit,
     onPlaylistClick: (Playlist) -> Unit,
     modifier: Modifier = Modifier,
-    viewModel: SearchViewModel = viewModel()
+    viewModel: SearchViewModel = hiltViewModel()
 ) {
     val context = LocalContext.current
     val searchHistoryRepo = remember { SearchHistoryRepository(context) }

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/search/SearchViewModel.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/search/SearchViewModel.kt
@@ -11,8 +11,10 @@ import io.github.aedev.flow.data.local.SearchFilter
 import io.github.aedev.flow.data.paging.SearchPagingSource
 import io.github.aedev.flow.data.paging.SearchResultItem
 import io.github.aedev.flow.data.repository.YouTubeRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.*
+import javax.inject.Inject
 
 // ── UI state ─────────────────────────────────────────────────────────────────
 
@@ -23,9 +25,10 @@ data class SearchUiState(
 
 // ── ViewModel ─────────────────────────────────────────────────────────────────
 
+@HiltViewModel
 @OptIn(ExperimentalCoroutinesApi::class)
-class SearchViewModel(
-    private val repository: YouTubeRepository = YouTubeRepository.getInstance()
+class SearchViewModel @Inject constructor(
+    private val repository: YouTubeRepository,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(SearchUiState())

--- a/app/src/main/java/io/github/aedev/flow/ui/tv/FlowTvApp.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/tv/FlowTvApp.kt
@@ -14,7 +14,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.media3.common.util.UnstableApi
 import androidx.navigation.compose.rememberNavController
 import io.github.aedev.flow.data.model.Video
@@ -41,8 +40,8 @@ fun FlowTvApp(
     val activity = context as ComponentActivity
     val homeViewModel: HomeViewModel = hiltViewModel(activity)
     val playerViewModel: VideoPlayerViewModel = hiltViewModel(activity)
-    val subscriptionsViewModel: SubscriptionsViewModel = viewModel(viewModelStoreOwner = activity)
-    val searchViewModel: SearchViewModel = viewModel(viewModelStoreOwner = activity)
+    val subscriptionsViewModel: SubscriptionsViewModel = hiltViewModel(activity)
+    val searchViewModel: SearchViewModel = hiltViewModel(activity)
     val musicViewModel: MusicViewModel = hiltViewModel(activity)
     val musicPlayerViewModel: MusicPlayerViewModel = hiltViewModel(activity)
     val navController = rememberNavController()

--- a/app/src/test/java/io/github/aedev/flow/ui/screens/history/HistoryViewModelTest.kt
+++ b/app/src/test/java/io/github/aedev/flow/ui/screens/history/HistoryViewModelTest.kt
@@ -1,0 +1,91 @@
+package io.github.aedev.flow.ui.screens.history
+
+import com.google.common.truth.Truth.assertThat
+import io.github.aedev.flow.data.local.ViewHistory
+import io.github.aedev.flow.data.local.VideoHistoryEntry
+import io.github.aedev.flow.data.local.dao.VideoDao
+import io.github.aedev.flow.data.local.dao.WatchHistoryDao
+import io.github.aedev.flow.data.repository.YouTubeRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import io.mockk.unmockkAll
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class HistoryViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+    private val viewHistory: ViewHistory = mockk(relaxed = true)
+    private val youTubeRepository: YouTubeRepository = mockk(relaxed = true)
+    private val videoDao: VideoDao = mockk(relaxed = true)
+    private val watchHistoryDao: WatchHistoryDao = mockk(relaxed = true)
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+        unmockkAll()
+    }
+
+    @Test
+    fun `initial state loads history entries`() = runTest {
+        val historyList = listOf(
+            VideoHistoryEntry(
+                videoId = "vid_1",
+                title = "Video Title",
+                channelName = "Channel Name",
+                channelId = "ch_1",
+                thumbnailUrl = "https://example.com/thumb.jpg",
+                duration = 60000,
+                position = 30000,
+                timestamp = 1000L
+            )
+        )
+        coEvery { viewHistory.getAllHistory() } returns flowOf(historyList)
+        coEvery { videoDao.getVideo("vid_1") } returns null
+
+        val viewModel = HistoryViewModel(viewHistory, youTubeRepository, videoDao, watchHistoryDao)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        val uiState = viewModel.uiState.value
+        assertThat(uiState.isLoading).isFalse()
+        assertThat(uiState.historyEntries.size).isEqualTo(1)
+        assertThat(uiState.historyEntries.first().videoId).isEqualTo("vid_1")
+    }
+
+    @Test
+    fun `clearHistory delegates to viewHistory clearAllHistory`() = runTest {
+        coEvery { viewHistory.getAllHistory() } returns flowOf(emptyList())
+
+        val viewModel = HistoryViewModel(viewHistory, youTubeRepository, videoDao, watchHistoryDao)
+        viewModel.clearHistory()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        coVerify(exactly = 1) { viewHistory.clearAllHistory() }
+    }
+
+    @Test
+    fun `removeFromHistory delegates to viewHistory clearVideoHistory`() = runTest {
+        coEvery { viewHistory.getAllHistory() } returns flowOf(emptyList())
+
+        val viewModel = HistoryViewModel(viewHistory, youTubeRepository, videoDao, watchHistoryDao)
+        viewModel.removeFromHistory("vid_123")
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        coVerify(exactly = 1) { viewHistory.clearVideoHistory("vid_123") }
+    }
+}

--- a/app/src/test/java/io/github/aedev/flow/ui/screens/likedvideos/LikedVideosViewModelTest.kt
+++ b/app/src/test/java/io/github/aedev/flow/ui/screens/likedvideos/LikedVideosViewModelTest.kt
@@ -1,0 +1,71 @@
+package io.github.aedev.flow.ui.screens.likedvideos
+
+import com.google.common.truth.Truth.assertThat
+import io.github.aedev.flow.data.local.LikedVideoInfo
+import io.github.aedev.flow.data.local.LikedVideosRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import io.mockk.unmockkAll
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class LikedVideosViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+    private val repository: LikedVideosRepository = mockk(relaxed = true)
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+        unmockkAll()
+    }
+
+    @Test
+    fun `initial state loads liked videos from repository`() = runTest {
+        val sampleLikes = listOf(
+            LikedVideoInfo(
+                videoId = "vid_1",
+                title = "Sample Video",
+                thumbnail = "https://example.com/thumb.jpg",
+                channelName = "Sample Channel",
+                likedAt = 1000L,
+                isMusic = false
+            )
+        )
+        coEvery { repository.getAllLikedVideos() } returns flowOf(sampleLikes)
+
+        val viewModel = LikedVideosViewModel(repository)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        val uiState = viewModel.uiState.value
+        assertThat(uiState.isLoading).isFalse()
+        assertThat(uiState.likedVideos).isEqualTo(sampleLikes)
+    }
+
+    @Test
+    fun `removeLike delegates to repository to remove video`() = runTest {
+        coEvery { repository.getAllLikedVideos() } returns flowOf(emptyList())
+        coEvery { repository.removeLikeState("vid_1") } returns Unit
+
+        val viewModel = LikedVideosViewModel(repository)
+        viewModel.removeLike("vid_1")
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        coVerify(exactly = 1) { repository.removeLikeState("vid_1") }
+    }
+}

--- a/app/src/test/java/io/github/aedev/flow/ui/screens/search/SearchViewModelTest.kt
+++ b/app/src/test/java/io/github/aedev/flow/ui/screens/search/SearchViewModelTest.kt
@@ -1,0 +1,98 @@
+package io.github.aedev.flow.ui.screens.search
+
+import com.google.common.truth.Truth.assertThat
+import io.github.aedev.flow.data.local.ContentType
+import io.github.aedev.flow.data.local.SearchFilter
+import io.github.aedev.flow.data.repository.YouTubeRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import io.mockk.unmockkAll
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class SearchViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+    private val repository: YouTubeRepository = mockk(relaxed = true)
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+        unmockkAll()
+    }
+
+    @Test
+    fun `initial ui state has empty query and null filters`() {
+        val viewModel = SearchViewModel(repository)
+        assertThat(viewModel.uiState.value.query).isEmpty()
+        assertThat(viewModel.uiState.value.filters).isNull()
+    }
+
+    @Test
+    fun `search with valid query updates uiState`() {
+        val viewModel = SearchViewModel(repository)
+        viewModel.search("Kotlin Compose")
+
+        val uiState = viewModel.uiState.value
+        assertThat(uiState.query).isEqualTo("Kotlin Compose")
+    }
+
+    @Test
+    fun `search with empty query resets uiState`() {
+        val viewModel = SearchViewModel(repository)
+        viewModel.search("Kotlin")
+        viewModel.search("")
+
+        val uiState = viewModel.uiState.value
+        assertThat(uiState.query).isEmpty()
+        assertThat(uiState.filters).isNull()
+    }
+
+    @Test
+    fun `updateFilters updates filters in uiState when query is active`() {
+        val viewModel = SearchViewModel(repository)
+        viewModel.search("Music")
+
+        val filter = SearchFilter(contentType = ContentType.VIDEOS)
+        viewModel.updateFilters(filter)
+
+        assertThat(viewModel.uiState.value.filters).isEqualTo(filter)
+    }
+
+    @Test
+    fun `clearSearch resets search query and filters`() {
+        val viewModel = SearchViewModel(repository)
+        viewModel.search("Android", SearchFilter(contentType = ContentType.PLAYLISTS))
+
+        viewModel.clearSearch()
+
+        assertThat(viewModel.uiState.value.query).isEmpty()
+        assertThat(viewModel.uiState.value.filters).isNull()
+    }
+
+    @Test
+    fun `getSearchSuggestions calls YouTubeRepository for valid query`() = runTest {
+        val suggestions = listOf("kotlin tutorial", "kotlin android")
+        coEvery { repository.getSearchSuggestions("kotlin") } returns suggestions
+
+        val viewModel = SearchViewModel(repository)
+        val result = viewModel.getSearchSuggestions("kotlin")
+
+        assertThat(result).isEqualTo(suggestions)
+        coVerify(exactly = 1) { repository.getSearchSuggestions("kotlin") }
+    }
+}


### PR DESCRIPTION
## Summary

This PR improves Dependency Injection (DI) across the app by converting `HistoryViewModel`, `LikedVideosViewModel`, and `SearchViewModel` to use Hilt `@HiltViewModel` constructor injection, and removing a redundant `@Provides @Singleton fun provideContext(...)` method from `AppModule`.

Key improvements:
- **`AppModule`**: Removed redundant context provider method (Hilt inherently provides `@ApplicationContext Context`).
- **`HistoryViewModel` & `HistoryScreen`**: Converted to `@HiltViewModel` constructor injection (`ViewHistory`, `YouTubeRepository`, `VideoDao`, `WatchHistoryDao`), removing imperative manual `initialize(context)` calls and using `hiltViewModel()`.
- **`LikedVideosViewModel` & `LikedVideosScreen`**: Converted to `@HiltViewModel` constructor injection (`LikedVideosRepository`), removing `initialize(context)` and using `hiltViewModel()`.
- **`SearchViewModel` & `SearchScreen`**: Converted to `@HiltViewModel` constructor injection (`YouTubeRepository`), using `hiltViewModel()`.
- **`FlowTvApp`**: Updated `subscriptionsViewModel` and `searchViewModel` to use `hiltViewModel(activity)`.
- **Unit Tests & Skill**: Added comprehensive unit tests for all 3 migrated ViewModels (`HistoryViewModelTest`, `LikedVideosViewModelTest`, `SearchViewModelTest`) enabled by constructor injection, along with a `.agent/skills/unit-testing/SKILL.md` guide.

## Logic Changes Flag
> **Logic Changes Status**: **NO LOGIC CHANGES**.
> All ViewModel internal behavior, UI state management, and business logic remain 100% identical. This PR is strictly a structural DI refactoring and addition of unit tests.

## Change type

- [x] Refactor or maintenance
- [x] Documentation

## Validation

- [x] `./gradlew :app:assembleGithubDebug` (Successful build)
- [x] `./gradlew :app:compileGithubDebugKotlin` (Successful compilation)
- [x] `./gradlew :app:testGithubDebugUnitTest` (All unit tests passed cleanly)

## Risk and compatibility

- [x] The change does not introduce secrets, private data, or unexpected telemetry.
- [x] Dependency and lockfile changes are intentional and limited to this PR.
- [x] Room schema changes include the required version bump and migration, or this PR does not change the Room schema.
