### PR TITLE
[Stacked on #859] style: apply spotless formatting and ktlint suppressions

### DIFF
--- a/.agent/skills/unit-testing/SKILL.md
+++ b/.agent/skills/unit-testing/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: unit-testing
+description: Guidelines, patterns, and best practices for writing Kotlin unit tests for ViewModels, Repositories, and Utilities in the Flow Android project.
+---
+
+# Kotlin Unit Testing Guidelines & Best Practices for Flow
+
+This skill outlines the standards and conventions for writing unit tests in the Flow codebase (`io.github.aedev.flow`).
+
+## 1. Naming Conventions
+
+### Test Class Naming
+- Test class names MUST mirror the target class with a `Test` suffix.
+  - Example: `LikedVideosViewModel` → `LikedVideosViewModelTest`
+  - Example: `HistoryViewModel` → `HistoryViewModelTest`
+  - Example: `SearchViewModel` → `SearchViewModelTest`
+
+### Test Method Naming
+- Use backtick-quoted descriptive phrases outlining the scenario and expected outcome:
+  - Format: `` `[given condition or action] [expected result]` ``
+  - Good: `` `initial state loads liked videos from repository` ``
+  - Good: `` `removeLike calls repository and updates state` ``
+  - Good: `` `search with query updates results flow` ``
+  - Bad: `testRemoveLike()`, `test1()`
+
+---
+
+## 2. Mocking Framework & Cleanup Rules
+
+- **Framework**: Use **MockK** (`io.mockk.*`).
+- **Initialization**: Create mocks in `@Before` or as class properties via `mockk(relaxed = true)` or `mockk()`.
+- **Teardown / Cleanup**: ALWAYS clean up mocks in an `@After` method using `unmockkAll()` or `clearAllMocks()` to ensure isolated test execution and prevent memory leaks/polluted mock states across tests.
+
+```kotlin
+@Before
+fun setUp() {
+    repository = mockk(relaxed = true)
+}
+
+@After
+fun tearDown() {
+    unmockkAll()
+}
+```
+
+---
+
+## 3. Coroutines & ViewModel Testing
+
+ViewModel unit tests run on the JVM without an Android Main Looper. Since `viewModelScope` uses `Dispatchers.Main`, you MUST replace the Main dispatcher during tests:
+
+- Use `Dispatchers.setMain(testDispatcher)` in `@Before` (or via a JUnit `TestRule`).
+- Use `Dispatchers.resetMain()` in `@After`.
+- Wrap suspend test logic inside `runTest` from `kotlinx.coroutines.test`.
+
+```kotlin
+@OptIn(ExperimentalCoroutinesApi::class)
+class MyViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+        unmockkAll()
+    }
+}
+```
+
+---
+
+## 4. Assertions & AAA Pattern
+
+- **Assertion Library**: Use **Google Truth** (`com.google.common.truth.Truth.assertThat`).
+- **AAA Pattern**: Structure tests clearly with **Arrange**, **Act**, and **Assert**:
+
+```kotlin
+@Test
+fun `removeLike calls repository to remove item`() = runTest {
+    // Arrange
+    val videoId = "test_id_123"
+    coEvery { repository.removeLikeState(videoId) } returns Unit
+
+    // Act
+    viewModel.removeLike(videoId)
+    testScheduler.advanceUntilIdle()
+
+    // Assert
+    coVerify(exactly = 1) { repository.removeLikeState(videoId) }
+}
+```
+
+---
+
+## 5. Summary Checklist Before Shipping Tests
+1. ✅ Test file resides under `app/src/test/java/...` matching package structure of source class.
+2. ✅ Method names use backtick-quoted descriptive sentences.
+3. ✅ MockK is used for dependencies with `unmockkAll()` in `@After`.
+4. ✅ Main dispatcher rule/setup is present for ViewModel tests.
+5. ✅ Google Truth (`assertThat`) is used for assertions.
+6. ✅ Test passes cleanly via `./gradlew :app:testGithubDebugUnitTest`.

--- a/app/src/main/java/io/github/aedev/flow/data/recommendation/MusicRecommendationAlgorithm.kt
+++ b/app/src/main/java/io/github/aedev/flow/data/recommendation/MusicRecommendationAlgorithm.kt
@@ -2,8 +2,8 @@ package io.github.aedev.flow.data.recommendation
 
 import android.content.Context
 import android.util.Log
+import dagger.hilt.android.qualifiers.ApplicationContext
 import io.github.aedev.flow.data.local.LikedVideosRepository
-import io.github.aedev.flow.data.local.ViewHistory
 import io.github.aedev.flow.data.music.PlaylistRepository
 import io.github.aedev.flow.innertube.YouTube
 import io.github.aedev.flow.innertube.models.SongItem
@@ -12,7 +12,6 @@ import io.github.aedev.flow.innertube.models.PlaylistItem
 import io.github.aedev.flow.innertube.models.YTItem
 import io.github.aedev.flow.innertube.models.WatchEndpoint
 import io.github.aedev.flow.innertube.pages.HomePage
-import io.github.aedev.flow.data.local.entity.MusicHomeChipEntity
 import io.github.aedev.flow.ui.screens.music.MusicTrack
 import io.github.aedev.flow.ui.screens.music.MusicItemType
 import kotlinx.coroutines.Dispatchers
@@ -45,11 +44,9 @@ data class MusicSection(
  */
 @Singleton
 class MusicRecommendationAlgorithm @Inject constructor(
-    private val context: Context,
+    @ApplicationContext private val context: Context,
     private val playlistRepository: PlaylistRepository,
     private val likedVideosRepository: LikedVideosRepository,
-    private val subscriptionRepository: io.github.aedev.flow.data.local.SubscriptionRepository,
-    private val viewHistory: ViewHistory,
     private val youTube: YouTube,
     private val cacheDao: io.github.aedev.flow.data.local.dao.CacheDao
 ) {

--- a/app/src/main/java/io/github/aedev/flow/data/recommendation/MusicRecommendationAlgorithm.kt
+++ b/app/src/main/java/io/github/aedev/flow/data/recommendation/MusicRecommendationAlgorithm.kt
@@ -6,14 +6,14 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import io.github.aedev.flow.data.local.LikedVideosRepository
 import io.github.aedev.flow.data.music.PlaylistRepository
 import io.github.aedev.flow.innertube.YouTube
-import io.github.aedev.flow.innertube.models.SongItem
 import io.github.aedev.flow.innertube.models.AlbumItem
 import io.github.aedev.flow.innertube.models.PlaylistItem
-import io.github.aedev.flow.innertube.models.YTItem
+import io.github.aedev.flow.innertube.models.SongItem
 import io.github.aedev.flow.innertube.models.WatchEndpoint
+import io.github.aedev.flow.innertube.models.YTItem
 import io.github.aedev.flow.innertube.pages.HomePage
-import io.github.aedev.flow.ui.screens.music.MusicTrack
 import io.github.aedev.flow.ui.screens.music.MusicItemType
+import io.github.aedev.flow.ui.screens.music.MusicTrack
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
@@ -30,12 +30,12 @@ data class MusicSection(
     val thumbnailUrl: String? = null,
     val seedId: String? = null,
     val isArtistSeed: Boolean = false,
-    val tracks: List<MusicTrack>
+    val tracks: List<MusicTrack>,
 )
 
 /**
  * Advanced Music Recommendation Algorithm (FlowMusicAlgorithm)
- * 
+ *
  * A hybrid recommendation engine that combines:
  * 1. YouTube Music's native Home Feed (Gold Standard)
  * 2. Collaborative Filtering (Seeds + Related)
@@ -43,388 +43,437 @@ data class MusicSection(
  * 4. User Library Signals (History, Favorites)
  */
 @Singleton
-class MusicRecommendationAlgorithm @Inject constructor(
-    @ApplicationContext private val context: Context,
-    private val playlistRepository: PlaylistRepository,
-    private val likedVideosRepository: LikedVideosRepository,
-    private val youTube: YouTube,
-    private val cacheDao: io.github.aedev.flow.data.local.dao.CacheDao
-) {
+class MusicRecommendationAlgorithm
+    @Inject
+    constructor(
+        @ApplicationContext private val context: Context,
+        private val playlistRepository: PlaylistRepository,
+        private val likedVideosRepository: LikedVideosRepository,
+        private val youTube: YouTube,
+        private val cacheDao: io.github.aedev.flow.data.local.dao.CacheDao,
+    ) {
+        companion object {
+            private const val TAG = "MusicRecAlgo"
+        }
 
-    companion object {
-        private const val TAG = "MusicRecAlgo"
-    }
+        private val cachePrefs by lazy {
+            context.getSharedPreferences("music_home_cache_prefs", Context.MODE_PRIVATE)
+        }
 
+        suspend fun loadMusicHome(): Pair<List<MusicSection>, String?> =
+            withContext(Dispatchers.IO) {
+                val lastCacheTime = cachePrefs.getLong("last_cache_time", 0L)
+                val isCacheExpired = System.currentTimeMillis() - lastCacheTime > 4 * 60 * 60 * 1000L // 4 hours
 
+                val cachedSections = cacheDao.getMusicHomeSections().firstOrNull()
+                if (cachedSections != null && cachedSections.isNotEmpty()) {
+                    Log.d(TAG, "Loaded ${cachedSections.size} sections from cache (${if (isCacheExpired) "stale" else "fresh"})")
+                    val musicSections =
+                        cachedSections.map { entity ->
+                            MusicSection(
+                                title = entity.title,
+                                subtitle = entity.subtitle,
+                                tracks = deserializeTracks(entity.tracksJson),
+                            )
+                        }
+                    return@withContext musicSections to null
+                }
 
-    private val cachePrefs by lazy {
-        context.getSharedPreferences("music_home_cache_prefs", Context.MODE_PRIVATE)
-    }
-
-    suspend fun loadMusicHome(): Pair<List<MusicSection>, String?> = withContext(Dispatchers.IO) {
-        val lastCacheTime = cachePrefs.getLong("last_cache_time", 0L)
-        val isCacheExpired = System.currentTimeMillis() - lastCacheTime > 4 * 60 * 60 * 1000L // 4 hours
-        
-        val cachedSections = cacheDao.getMusicHomeSections().firstOrNull()
-        if (cachedSections != null && cachedSections.isNotEmpty()) {
-            Log.d(TAG, "Loaded ${cachedSections.size} sections from cache (${if (isCacheExpired) "stale" else "fresh"})")
-            val musicSections = cachedSections.map { entity ->
-                MusicSection(
-                    title = entity.title,
-                    subtitle = entity.subtitle,
-                    tracks = deserializeTracks(entity.tracksJson)
-                )
+                val networkResult = fetchAndCacheHome()
+                return@withContext networkResult
             }
-            return@withContext musicSections to null
-        }
 
-        val networkResult = fetchAndCacheHome()
-        return@withContext networkResult
-    }
-
-    /**
-     * Get home chips from cache
-     */
-    suspend fun getHomeChips(): List<HomePage.Chip> = withContext(Dispatchers.IO) {
-        val cachedChips = cacheDao.getMusicHomeChips().firstOrNull() ?: emptyList()
-        cachedChips.map { entity ->
-            HomePage.Chip(
-                title = entity.title,
-                endpoint = if (entity.browseId != null) io.github.aedev.flow.innertube.models.BrowseEndpoint(entity.browseId, entity.params) else null,
-                deselectEndPoint = if (entity.deselectBrowseId != null) io.github.aedev.flow.innertube.models.BrowseEndpoint(entity.deselectBrowseId, entity.deselectParams) else null
-            )
-        }
-    }
-    
-    /**
-     * Force refresh content from network and update cache
-     */
-    suspend fun refreshMusicHome(): Pair<List<MusicSection>, String?> = withContext(Dispatchers.IO) {
-        fetchAndCacheHome()
-    }
-    
-    /**
-     * Load more home content (pagination)
-     */
-    suspend fun loadHomeContinuation(continuation: String): Pair<List<MusicSection>, String?> = withContext(Dispatchers.IO) {
-        try {
-            val homePage = youTube.home(continuation = continuation).getOrNull()
-            if (homePage != null) {
-                val sections = parseHomeSections(homePage)
-                return@withContext sections to homePage.continuation
-            }
-        } catch (e: Exception) {
-            Log.e(TAG, "Error loading home continuation", e)
-        }
-        return@withContext emptyList<MusicSection>() to null
-    }
-
-    private suspend fun fetchAndCacheHome(): Pair<List<MusicSection>, String?> {
-        try {
-            val homePage = youTube.home().getOrNull()
-            if (homePage != null) {
-                val sections = parseHomeSections(homePage)
-                
-                // Cache them
-                val entities = sections.mapIndexed { index, section ->
-                    io.github.aedev.flow.data.local.entity.MusicHomeCacheEntity(
-                        sectionId = "section_$index",
-                        title = section.title,
-                        subtitle = section.subtitle,
-                        tracksJson = serializeTracks(section.tracks),
-                        orderBy = index
+        /**
+         * Get home chips from cache
+         */
+        suspend fun getHomeChips(): List<HomePage.Chip> =
+            withContext(Dispatchers.IO) {
+                val cachedChips = cacheDao.getMusicHomeChips().firstOrNull() ?: emptyList()
+                cachedChips.map { entity ->
+                    HomePage.Chip(
+                        title = entity.title,
+                        endpoint =
+                            if (entity.browseId !=
+                                null
+                            ) {
+                                io.github.aedev.flow.innertube.models
+                                    .BrowseEndpoint(entity.browseId, entity.params)
+                            } else {
+                                null
+                            },
+                        deselectEndPoint =
+                            if (entity.deselectBrowseId !=
+                                null
+                            ) {
+                                io.github.aedev.flow.innertube.models
+                                    .BrowseEndpoint(entity.deselectBrowseId, entity.deselectParams)
+                            } else {
+                                null
+                            },
                     )
                 }
-                cacheDao.clearMusicHomeCache()
-                cacheDao.insertMusicHomeSections(entities)
-                cachePrefs.edit().putLong("last_cache_time", System.currentTimeMillis()).apply()
-                
-                homePage.chips?.let { chips ->
-                    val chipEntities = chips.mapIndexed { index, chip ->
-                        io.github.aedev.flow.data.local.entity.MusicHomeChipEntity(
-                            title = chip.title,
-                            browseId = chip.endpoint?.browseId,
-                            params = chip.endpoint?.params,
-                            deselectBrowseId = chip.deselectEndPoint?.browseId,
-                            deselectParams = chip.deselectEndPoint?.params,
-                            orderBy = index
-                        )
-                    }
-                    cacheDao.clearMusicHomeChips()
-                    cacheDao.insertMusicHomeChips(chipEntities)
-                }
-                
-                return sections to homePage.continuation
             }
-        } catch (e: Exception) {
-            Log.e(TAG, "Error fetching Music Home", e)
-        }
-        return emptyList<MusicSection>() to null
-    }
 
-    private fun serializeTracks(tracks: List<MusicTrack>): String {
-        val jsonArray = org.json.JSONArray()
-        tracks.forEach { track ->
-            val obj = org.json.JSONObject()
-            obj.put("id", track.videoId)
-            obj.put("title", track.title)
-            obj.put("artist", track.artist)
-            obj.put("thumb", track.thumbnailUrl)
-            obj.put("dur", track.duration)
-            obj.put("cid", track.channelId)
-            obj.put("views", track.views)
-            obj.put("album", track.album)
-            obj.put("expl", track.isExplicit)
-            obj.put("vid", track.isVideoSong)
-            jsonArray.put(obj)
-        }
-        return jsonArray.toString()
-    }
-    
-    private fun deserializeTracks(json: String): List<MusicTrack> {
-        val tracks = mutableListOf<MusicTrack>()
-        try {
-            val array = org.json.JSONArray(json)
-            for (i in 0 until array.length()) {
-                val obj = array.getJSONObject(i)
-                tracks.add(MusicTrack(
-                    videoId = obj.optString("id"),
-                    title = obj.optString("title"),
-                    artist = obj.optString("artist"),
-                    thumbnailUrl = obj.optString("thumb"),
-                    duration = obj.optInt("dur"),
-                    channelId = obj.optString("cid"),
-                    views = obj.optLong("views"),
-                    album = obj.optString("album"),
-                    isExplicit = obj.optBoolean("expl"),
-                    isVideoSong = obj.optBoolean("vid", false)
-                ))
+        /**
+         * Force refresh content from network and update cache
+         */
+        suspend fun refreshMusicHome(): Pair<List<MusicSection>, String?> =
+            withContext(Dispatchers.IO) {
+                fetchAndCacheHome()
             }
-        } catch (e: Exception) {
-            Log.e(TAG, "Error deserializing tracks", e)
-        }
-        return tracks
-    }
 
-    /**
-     * Generate personalized music recommendations (Quick Picks / For You).
-     * Tries to use the official "Quick Picks" or "Start Radio" from Home first.
-     * Falls back to internal algorithm if Home is unavailable.
-     */
-    suspend fun getRecommendations(limit: Int = 30): List<MusicTrack> = withContext(Dispatchers.IO) {
-        // 1. Try to get from Home Page "Quick Picks" or similar
-        try {
-            val homePage = youTube.home().getOrNull()
-            if (homePage != null) {
-                val quickPicks = homePage.sections.find { 
-                    it.title.contains("Quick picks", true) || 
-                    it.title.contains("Start radio", true) ||
-                    it.title.contains("Mixed for you", true) ||
-                    it.title.contains("Recommended", true) ||
-                    it.title.contains("Listen again", true)
-                }
-                
-                if (quickPicks != null) {
-                    val tracks = quickPicks.items
-                        .filterIsInstance<SongItem>()
-                        .filterNot { it.isVideoSong }
-                        .map { mapSongItem(it) }
-                    if (tracks.isNotEmpty()) {
-                        Log.d(TAG, "Using Home Page Quick Picks: ${tracks.size}")
-                        return@withContext tracks.take(limit)
-                    }
-                }
-            }
-        } catch (e: Exception) {
-            Log.e(TAG, "Error fetching Home for recommendations", e)
-        }
-
-        // 2. Fallback: Internal Hybrid Algorithm
-        return@withContext generateFallbackRecommendations(limit)
-    }
-
-    private suspend fun generateFallbackRecommendations(limit: Int): List<MusicTrack> = coroutineScope {
-        val candidates = mutableListOf<MusicTrack>()
-        val seenIds = mutableSetOf<String>()
-
-        // Gather User Signals
-        val favorites = likedVideosRepository.getAllLikedVideos().firstOrNull()?.map { 
-             MusicTrack(
-                 videoId = it.videoId,
-                 title = it.title,
-                 artist = it.channelName,
-                 thumbnailUrl = it.thumbnail,
-                 duration = 0,
-                 channelId = "",
-                 views = 0L
-             )
-        } ?: emptyList()
-        
-        val history = playlistRepository.history.firstOrNull() ?: emptyList()
-        
-        // Seeds: Mix of history and favorites
-        val seeds = (history.take(5) + favorites.take(5)).shuffled().take(4)
-        
-        val deferreds = mutableListOf<kotlinx.coroutines.Deferred<Unit>>()
-
-        // A. Related to Seeds
-        seeds.forEach { seed ->
-            deferreds.add(async {
+        /**
+         * Load more home content (pagination)
+         */
+        suspend fun loadHomeContinuation(continuation: String): Pair<List<MusicSection>, String?> =
+            withContext(Dispatchers.IO) {
                 try {
-                    val nextResult = youTube.next(WatchEndpoint(videoId = seed.videoId)).getOrNull()
-                    val relatedEndpoint = nextResult?.relatedEndpoint
-                    if (relatedEndpoint != null) {
-                        val related = youTube.related(relatedEndpoint).getOrNull()
-                        related?.songs?.forEach { song ->
-                            addCandidate(song, candidates, seenIds)
+                    val homePage = youTube.home(continuation = continuation).getOrNull()
+                    if (homePage != null) {
+                        val sections = parseHomeSections(homePage)
+                        return@withContext sections to homePage.continuation
+                    }
+                } catch (e: Exception) {
+                    Log.e(TAG, "Error loading home continuation", e)
+                }
+                return@withContext emptyList<MusicSection>() to null
+            }
+
+        private suspend fun fetchAndCacheHome(): Pair<List<MusicSection>, String?> {
+            try {
+                val homePage = youTube.home().getOrNull()
+                if (homePage != null) {
+                    val sections = parseHomeSections(homePage)
+
+                    // Cache them
+                    val entities =
+                        sections.mapIndexed { index, section ->
+                            io.github.aedev.flow.data.local.entity.MusicHomeCacheEntity(
+                                sectionId = "section_$index",
+                                title = section.title,
+                                subtitle = section.subtitle,
+                                tracksJson = serializeTracks(section.tracks),
+                                orderBy = index,
+                            )
+                        }
+                    cacheDao.clearMusicHomeCache()
+                    cacheDao.insertMusicHomeSections(entities)
+                    cachePrefs.edit().putLong("last_cache_time", System.currentTimeMillis()).apply()
+
+                    homePage.chips?.let { chips ->
+                        val chipEntities =
+                            chips.mapIndexed { index, chip ->
+                                io.github.aedev.flow.data.local.entity.MusicHomeChipEntity(
+                                    title = chip.title,
+                                    browseId = chip.endpoint?.browseId,
+                                    params = chip.endpoint?.params,
+                                    deselectBrowseId = chip.deselectEndPoint?.browseId,
+                                    deselectParams = chip.deselectEndPoint?.params,
+                                    orderBy = index,
+                                )
+                            }
+                        cacheDao.clearMusicHomeChips()
+                        cacheDao.insertMusicHomeChips(chipEntities)
+                    }
+
+                    return sections to homePage.continuation
+                }
+            } catch (e: Exception) {
+                Log.e(TAG, "Error fetching Music Home", e)
+            }
+            return emptyList<MusicSection>() to null
+        }
+
+        private fun serializeTracks(tracks: List<MusicTrack>): String {
+            val jsonArray = org.json.JSONArray()
+            tracks.forEach { track ->
+                val obj = org.json.JSONObject()
+                obj.put("id", track.videoId)
+                obj.put("title", track.title)
+                obj.put("artist", track.artist)
+                obj.put("thumb", track.thumbnailUrl)
+                obj.put("dur", track.duration)
+                obj.put("cid", track.channelId)
+                obj.put("views", track.views)
+                obj.put("album", track.album)
+                obj.put("expl", track.isExplicit)
+                obj.put("vid", track.isVideoSong)
+                jsonArray.put(obj)
+            }
+            return jsonArray.toString()
+        }
+
+        private fun deserializeTracks(json: String): List<MusicTrack> {
+            val tracks = mutableListOf<MusicTrack>()
+            try {
+                val array = org.json.JSONArray(json)
+                for (i in 0 until array.length()) {
+                    val obj = array.getJSONObject(i)
+                    tracks.add(
+                        MusicTrack(
+                            videoId = obj.optString("id"),
+                            title = obj.optString("title"),
+                            artist = obj.optString("artist"),
+                            thumbnailUrl = obj.optString("thumb"),
+                            duration = obj.optInt("dur"),
+                            channelId = obj.optString("cid"),
+                            views = obj.optLong("views"),
+                            album = obj.optString("album"),
+                            isExplicit = obj.optBoolean("expl"),
+                            isVideoSong = obj.optBoolean("vid", false),
+                        ),
+                    )
+                }
+            } catch (e: Exception) {
+                Log.e(TAG, "Error deserializing tracks", e)
+            }
+            return tracks
+        }
+
+        /**
+         * Generate personalized music recommendations (Quick Picks / For You).
+         * Tries to use the official "Quick Picks" or "Start Radio" from Home first.
+         * Falls back to internal algorithm if Home is unavailable.
+         */
+        suspend fun getRecommendations(limit: Int = 30): List<MusicTrack> =
+            withContext(Dispatchers.IO) {
+                // 1. Try to get from Home Page "Quick Picks" or similar
+                try {
+                    val homePage = youTube.home().getOrNull()
+                    if (homePage != null) {
+                        val quickPicks =
+                            homePage.sections.find {
+                                it.title.contains("Quick picks", true) ||
+                                    it.title.contains("Start radio", true) ||
+                                    it.title.contains("Mixed for you", true) ||
+                                    it.title.contains("Recommended", true) ||
+                                    it.title.contains("Listen again", true)
+                            }
+
+                        if (quickPicks != null) {
+                            val tracks =
+                                quickPicks.items
+                                    .filterIsInstance<SongItem>()
+                                    .filterNot { it.isVideoSong }
+                                    .map { mapSongItem(it) }
+                            if (tracks.isNotEmpty()) {
+                                Log.d(TAG, "Using Home Page Quick Picks: ${tracks.size}")
+                                return@withContext tracks.take(limit)
+                            }
                         }
                     }
                 } catch (e: Exception) {
-                    Log.e(TAG, "Error fetching related for ${seed.title}", e)
+                    Log.e(TAG, "Error fetching Home for recommendations", e)
                 }
-                Unit
-            })
+
+                // 2. Fallback: Internal Hybrid Algorithm
+                return@withContext generateFallbackRecommendations(limit)
+            }
+
+        private suspend fun generateFallbackRecommendations(limit: Int): List<MusicTrack> =
+            coroutineScope {
+                val candidates = mutableListOf<MusicTrack>()
+                val seenIds = mutableSetOf<String>()
+
+                // Gather User Signals
+                val favorites =
+                    likedVideosRepository.getAllLikedVideos().firstOrNull()?.map {
+                        MusicTrack(
+                            videoId = it.videoId,
+                            title = it.title,
+                            artist = it.channelName,
+                            thumbnailUrl = it.thumbnail,
+                            duration = 0,
+                            channelId = "",
+                            views = 0L,
+                        )
+                    } ?: emptyList()
+
+                val history = playlistRepository.history.firstOrNull() ?: emptyList()
+
+                // Seeds: Mix of history and favorites
+                val seeds = (history.take(5) + favorites.take(5)).shuffled().take(4)
+
+                val deferreds = mutableListOf<kotlinx.coroutines.Deferred<Unit>>()
+
+                // A. Related to Seeds
+                seeds.forEach { seed ->
+                    deferreds.add(
+                        async {
+                            try {
+                                val nextResult = youTube.next(WatchEndpoint(videoId = seed.videoId)).getOrNull()
+                                val relatedEndpoint = nextResult?.relatedEndpoint
+                                if (relatedEndpoint != null) {
+                                    val related = youTube.related(relatedEndpoint).getOrNull()
+                                    related?.songs?.forEach { song ->
+                                        addCandidate(song, candidates, seenIds)
+                                    }
+                                }
+                            } catch (e: Exception) {
+                                Log.e(TAG, "Error fetching related for ${seed.title}", e)
+                            }
+                            Unit
+                        },
+                    )
+                }
+
+                // B. Charts (Trending)
+                deferreds.add(
+                    async {
+                        try {
+                            val charts = youTube.getChartsPage().getOrNull()
+                            charts?.sections?.forEach { section ->
+                                if (section.title.contains("Top", true) || section.title.contains("Trending", true)) {
+                                    section.items.filterIsInstance<SongItem>().forEach { song ->
+                                        addCandidate(song, candidates, seenIds)
+                                    }
+                                }
+                            }
+                        } catch (e: Exception) {
+                            Log.e(TAG, "Error fetching charts", e)
+                        }
+                        Unit
+                    },
+                )
+
+                deferreds.awaitAll()
+
+                // Scoring & Ranking (Simple version: Shuffle for now, but could be enhanced)
+                val finalRecommendations = candidates.shuffled().take(limit)
+                Log.d(TAG, "Generated ${finalRecommendations.size} fallback recommendations")
+                return@coroutineScope finalRecommendations
+            }
+
+        fun parseHomeSections(homePage: HomePage): List<MusicSection> =
+            homePage.sections.mapNotNull { section ->
+                // Broaden filter to include Songs, Albums, Playlists
+                val tracks = section.items.mapNotNull { mapYTItem(it) }
+
+                if (tracks.isNotEmpty()) {
+                    MusicSection(
+                        title = section.title,
+                        subtitle = section.label,
+                        tracks = tracks,
+                    )
+                } else {
+                    null
+                }
+            }
+
+        private fun mapYTItem(item: YTItem): MusicTrack? =
+            when (item) {
+                is SongItem -> {
+                    mapSongItem(item)
+                }
+
+                is AlbumItem -> {
+                    MusicTrack(
+                        videoId = item.id,
+                        title = item.title,
+                        artist = item.artists?.joinToString(", ") { it.name } ?: "",
+                        thumbnailUrl = item.thumbnail,
+                        duration = 0,
+                        channelId = "",
+                        views = 0L,
+                        album = "Album",
+                        isExplicit = item.explicit,
+                        itemType = MusicItemType.ALBUM,
+                    )
+                }
+
+                is PlaylistItem -> {
+                    MusicTrack(
+                        videoId = item.id, // Playlist ID
+                        title = item.title,
+                        artist = item.author?.name ?: "",
+                        thumbnailUrl = item.thumbnail ?: "",
+                        duration = 0,
+                        channelId = "",
+                        views = 0L,
+                        album = "Playlist",
+                        itemType = MusicItemType.PLAYLIST,
+                    )
+                }
+
+                else -> {
+                    null
+                }
+            }
+
+        private fun addCandidate(
+            song: SongItem,
+            candidates: MutableList<MusicTrack>,
+            seenIds: MutableSet<String>,
+        ) {
+            synchronized(seenIds) {
+                if (song.id !in seenIds && !song.isVideoSong) {
+                    seenIds.add(song.id)
+                    candidates.add(mapSongItem(song))
+                }
+            }
         }
 
-        // B. Charts (Trending)
-        deferreds.add(async {
-            try {
-                val charts = youTube.getChartsPage().getOrNull()
-                charts?.sections?.forEach { section ->
-                    if (section.title.contains("Top", true) || section.title.contains("Trending", true)) {
-                            section.items.filterIsInstance<SongItem>().forEach { song ->
-                                addCandidate(song, candidates, seenIds)
-                            }
+        private fun mapSongItem(song: SongItem): MusicTrack =
+            MusicTrack(
+                videoId = song.id,
+                title = song.title,
+                artist = song.artists.joinToString(", ") { it.name },
+                thumbnailUrl = song.thumbnail,
+                duration = song.duration ?: 0,
+                channelId = song.artists.firstOrNull()?.id ?: "",
+                views = parseViewCount(song.viewCountText),
+                album = song.album?.name ?: "",
+                isExplicit = song.explicit,
+                isVideoSong = song.isVideoSong,
+            )
+
+        suspend fun getGenreContent(genre: String): List<MusicTrack> =
+            withContext(Dispatchers.IO) {
+                try {
+                    // Search for the genre to get relevant songs
+                    val searchResults = youTube.search(query = "$genre music", filter = YouTube.SearchFilter.FILTER_SONG).getOrNull()
+                    if (searchResults != null) {
+                        return@withContext searchResults.items
+                            .filterIsInstance<SongItem>()
+                            .filterNot { it.isVideoSong }
+                            .map { mapSongItem(it) }
+                    }
+                } catch (e: Exception) {
+                    Log.e(TAG, "Error fetching genre content for $genre", e)
+                }
+                return@withContext emptyList()
+            }
+
+        private fun parseViewCount(text: String?): Long {
+            if (text.isNullOrEmpty()) return 0L
+            // Remove "views" and commas
+            val cleanText =
+                text
+                    .replace(" views", "", ignoreCase = true)
+                    .replace(" view", "", ignoreCase = true)
+                    .replace(",", "")
+                    .trim()
+
+            return try {
+                when {
+                    cleanText.endsWith("M", ignoreCase = true) -> {
+                        (cleanText.dropLast(1).toDouble() * 1_000_000).toLong()
+                    }
+
+                    cleanText.endsWith("K", ignoreCase = true) -> {
+                        (cleanText.dropLast(1).toDouble() * 1_000).toLong()
+                    }
+
+                    cleanText.endsWith("B", ignoreCase = true) -> {
+                        (cleanText.dropLast(1).toDouble() * 1_000_000_000).toLong()
+                    }
+
+                    else -> {
+                        cleanText.toLongOrNull() ?: 0L
                     }
                 }
             } catch (e: Exception) {
-                Log.e(TAG, "Error fetching charts", e)
-            }
-            Unit
-        })
-
-        deferreds.awaitAll()
-
-        // Scoring & Ranking (Simple version: Shuffle for now, but could be enhanced)
-        val finalRecommendations = candidates.shuffled().take(limit)
-        Log.d(TAG, "Generated ${finalRecommendations.size} fallback recommendations")
-        return@coroutineScope finalRecommendations
-    }
-
-    fun parseHomeSections(homePage: HomePage): List<MusicSection> {
-        return homePage.sections.mapNotNull { section ->
-            // Broaden filter to include Songs, Albums, Playlists
-            val tracks = section.items.mapNotNull { mapYTItem(it) }
-            
-            if (tracks.isNotEmpty()) {
-                MusicSection(
-                    title = section.title,
-                    subtitle = section.label,
-                    tracks = tracks
-                )
-            } else {
-                null
+                0L
             }
         }
     }
-
-    private fun mapYTItem(item: YTItem): MusicTrack? {
-        return when (item) {
-            is SongItem -> mapSongItem(item)
-            is AlbumItem -> MusicTrack(
-                videoId = item.id,
-                title = item.title,
-                artist = item.artists?.joinToString(", ") { it.name } ?: "",
-                thumbnailUrl = item.thumbnail,
-                duration = 0,
-                channelId = "",
-                views = 0L,
-                album = "Album",
-                isExplicit = item.explicit,
-                itemType = MusicItemType.ALBUM
-            )
-            is PlaylistItem -> MusicTrack(
-                videoId = item.id, // Playlist ID
-                title = item.title,
-                artist = item.author?.name ?: "",
-                thumbnailUrl = item.thumbnail ?: "",
-                duration = 0,
-                channelId = "",
-                views = 0L,
-                album = "Playlist",
-                itemType = MusicItemType.PLAYLIST
-            )
-            else -> null
-        }
-    }
-
-    private fun addCandidate(
-        song: SongItem, 
-        candidates: MutableList<MusicTrack>, 
-        seenIds: MutableSet<String>
-    ) {
-        synchronized(seenIds) {
-            if (song.id !in seenIds && !song.isVideoSong) {
-                seenIds.add(song.id)
-                candidates.add(mapSongItem(song))
-            }
-        }
-    }
-
-    private fun mapSongItem(song: SongItem): MusicTrack {
-        return MusicTrack(
-            videoId = song.id,
-            title = song.title,
-            artist = song.artists.joinToString(", ") { it.name },
-            thumbnailUrl = song.thumbnail,
-            duration = song.duration ?: 0,
-            channelId = song.artists.firstOrNull()?.id ?: "",
-            views = parseViewCount(song.viewCountText),
-            album = song.album?.name ?: "",
-            isExplicit = song.explicit,
-            isVideoSong = song.isVideoSong
-        )
-    }
-
-    suspend fun getGenreContent(genre: String): List<MusicTrack> = withContext(Dispatchers.IO) {
-        try {
-            // Search for the genre to get relevant songs
-            val searchResults = youTube.search(query = "$genre music", filter = YouTube.SearchFilter.FILTER_SONG).getOrNull()
-            if (searchResults != null) {
-                return@withContext searchResults.items
-                    .filterIsInstance<SongItem>()
-                    .filterNot { it.isVideoSong }
-                    .map { mapSongItem(it) }
-            }
-        } catch (e: Exception) {
-            Log.e(TAG, "Error fetching genre content for $genre", e)
-        }
-        return@withContext emptyList()
-    }
-
-    private fun parseViewCount(text: String?): Long {
-        if (text.isNullOrEmpty()) return 0L
-        // Remove "views" and commas
-        val cleanText = text.replace(" views", "", ignoreCase = true)
-            .replace(" view", "", ignoreCase = true)
-            .replace(",", "")
-            .trim()
-            
-        return try {
-            when {
-                cleanText.endsWith("M", ignoreCase = true) -> {
-                    (cleanText.dropLast(1).toDouble() * 1_000_000).toLong()
-                }
-                cleanText.endsWith("K", ignoreCase = true) -> {
-                    (cleanText.dropLast(1).toDouble() * 1_000).toLong()
-                }
-                cleanText.endsWith("B", ignoreCase = true) -> {
-                    (cleanText.dropLast(1).toDouble() * 1_000_000_000).toLong()
-                }
-                else -> cleanText.toLongOrNull() ?: 0L
-            }
-        } catch (e: Exception) {
-            0L
-        }
-    }
-}

--- a/app/src/main/java/io/github/aedev/flow/di/AppModule.kt
+++ b/app/src/main/java/io/github/aedev/flow/di/AppModule.kt
@@ -1,54 +1,51 @@
 package io.github.aedev.flow.di
 
 import android.content.Context
-import io.github.aedev.flow.BuildConfig
-import io.github.aedev.flow.innertube.YouTube
 import coil.ImageLoader
 import coil.decode.VideoFrameDecoder
 import coil.disk.DiskCache
 import coil.memory.MemoryCache
 import coil.util.DebugLogger
-import okhttp3.OkHttpClient
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
+import io.github.aedev.flow.BuildConfig
+import io.github.aedev.flow.innertube.YouTube
+import okhttp3.OkHttpClient
 import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
 object AppModule {
-
     @Provides
     @Singleton
-    fun provideYouTube(): YouTube {
-        return YouTube
-    }
+    fun provideYouTube(): YouTube = YouTube
 
     @Provides
     @Singleton
     fun provideImageLoader(
         @ApplicationContext context: Context,
-        okHttpClient: OkHttpClient
-    ): ImageLoader {
-        return ImageLoader.Builder(context)
+        okHttpClient: OkHttpClient,
+    ): ImageLoader =
+        ImageLoader
+            .Builder(context)
             .okHttpClient(okHttpClient)
             .components { add(VideoFrameDecoder.Factory()) }
             .memoryCache {
-                MemoryCache.Builder(context)
+                MemoryCache
+                    .Builder(context)
                     .maxSizePercent(0.10)
                     .build()
-            }
-            .diskCache {
-                DiskCache.Builder()
+            }.diskCache {
+                DiskCache
+                    .Builder()
                     .directory(context.cacheDir.resolve("image_cache"))
                     .maxSizePercent(0.02)
                     .build()
-            }
-            .crossfade(true)
+            }.crossfade(true)
             .respectCacheHeaders(false) // Cache images even if headers say otherwise (YouTube thumbnails)
             .apply { if (BuildConfig.DEBUG) logger(DebugLogger()) }
             .build()
-    }
 }

--- a/app/src/main/java/io/github/aedev/flow/di/AppModule.kt
+++ b/app/src/main/java/io/github/aedev/flow/di/AppModule.kt
@@ -22,12 +22,6 @@ object AppModule {
 
     @Provides
     @Singleton
-    fun provideContext(@ApplicationContext context: Context): Context {
-        return context
-    }
-
-    @Provides
-    @Singleton
     fun provideYouTube(): YouTube {
         return YouTube
     }

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/history/HistoryScreen.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/history/HistoryScreen.kt
@@ -65,7 +65,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 import coil.compose.AsyncImage
 import io.github.aedev.flow.R
 import io.github.aedev.flow.data.local.VideoHistoryEntry
@@ -88,9 +88,8 @@ fun HistoryScreen(
     onShortClick: (String) -> Unit = {},
     onMusicClick: (MusicTrack, List<MusicTrack>) -> Unit = { track, _ -> onVideoClick(track) },
     modifier: Modifier = Modifier,
-    viewModel: HistoryViewModel = viewModel()
+    viewModel: HistoryViewModel = hiltViewModel()
 ) {
-    val context = LocalContext.current
     val uiState by viewModel.uiState.collectAsState()
     val searchFocusRequester = remember { FocusRequester() }
 
@@ -101,10 +100,6 @@ fun HistoryScreen(
     var selectedFilter by rememberSaveable { mutableStateOf(HistoryContentFilter.All) }
     var selectedSort by rememberSaveable { mutableStateOf(HistorySort.Newest) }
     var selectedYear by rememberSaveable { mutableStateOf<Int?>(null) }
-
-    LaunchedEffect(Unit) {
-        viewModel.initialize(context)
-    }
 
     val availableYears = remember(uiState.historyEntries) {
         uiState.historyEntries

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/history/HistoryScreen.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/history/HistoryScreen.kt
@@ -88,7 +88,7 @@ fun HistoryScreen(
     onShortClick: (String) -> Unit = {},
     onMusicClick: (MusicTrack, List<MusicTrack>) -> Unit = { track, _ -> onVideoClick(track) },
     modifier: Modifier = Modifier,
-    viewModel: HistoryViewModel = hiltViewModel()
+    viewModel: HistoryViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsState()
     val searchFocusRequester = remember { FocusRequester() }
@@ -101,57 +101,58 @@ fun HistoryScreen(
     var selectedSort by rememberSaveable { mutableStateOf(HistorySort.Newest) }
     var selectedYear by rememberSaveable { mutableStateOf<Int?>(null) }
 
-    val availableYears = remember(uiState.historyEntries) {
-        uiState.historyEntries
-            .map { historyYear(it.timestamp) }
-            .distinct()
-            .sortedDescending()
-    }
+    val availableYears =
+        remember(uiState.historyEntries) {
+            uiState.historyEntries
+                .map { historyYear(it.timestamp) }
+                .distinct()
+                .sortedDescending()
+        }
 
-    val displayEntries = remember(
-        uiState.historyEntries,
-        searchQuery,
-        selectedFilter,
-        selectedSort,
-        selectedYear
-    ) {
-        uiState.historyEntries
-            .asSequence()
-            .filter { entry -> selectedFilter.matches(entry) }
-            .filter { entry -> selectedYear == null || historyYear(entry.timestamp) == selectedYear }
-            .filter { entry ->
-                val query = searchQuery.trim()
-                query.isBlank() ||
-                    entry.title.contains(query, ignoreCase = true) ||
-                    entry.channelName.contains(query, ignoreCase = true)
-            }
-            .let { sequence ->
-                if (selectedSort == HistorySort.Newest) {
-                    sequence.sortedByDescending { it.timestamp }
-                } else {
-                    sequence.sortedBy { it.timestamp }
-                }
-            }
-            .toList()
-    }
+    val displayEntries =
+        remember(
+            uiState.historyEntries,
+            searchQuery,
+            selectedFilter,
+            selectedSort,
+            selectedYear,
+        ) {
+            uiState.historyEntries
+                .asSequence()
+                .filter { entry -> selectedFilter.matches(entry) }
+                .filter { entry -> selectedYear == null || historyYear(entry.timestamp) == selectedYear }
+                .filter { entry ->
+                    val query = searchQuery.trim()
+                    query.isBlank() ||
+                        entry.title.contains(query, ignoreCase = true) ||
+                        entry.channelName.contains(query, ignoreCase = true)
+                }.let { sequence ->
+                    if (selectedSort == HistorySort.Newest) {
+                        sequence.sortedByDescending { it.timestamp }
+                    } else {
+                        sequence.sortedBy { it.timestamp }
+                    }
+                }.toList()
+        }
 
     Scaffold(
         contentWindowInsets = WindowInsets(0.dp),
         topBar = {
             Surface(
                 modifier = Modifier.fillMaxWidth(),
-                color = MaterialTheme.colorScheme.background
+                color = MaterialTheme.colorScheme.background,
             ) {
                 Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 4.dp, vertical = 8.dp),
-                    verticalAlignment = Alignment.CenterVertically
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 4.dp, vertical = 8.dp),
+                    verticalAlignment = Alignment.CenterVertically,
                 ) {
                     IconButton(onClick = onBackClick) {
                         Icon(
                             imageVector = Icons.Default.ArrowBack,
-                            contentDescription = stringResource(R.string.btn_back)
+                            contentDescription = stringResource(R.string.btn_back),
                         )
                     }
                     Text(
@@ -159,18 +160,18 @@ fun HistoryScreen(
                         style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis,
-                        modifier = Modifier.weight(1f)
+                        modifier = Modifier.weight(1f),
                     )
                     Box {
                         IconButton(onClick = { showMenu = true }) {
                             Icon(
                                 imageVector = Icons.Default.MoreVert,
-                                contentDescription = stringResource(R.string.more_options)
+                                contentDescription = stringResource(R.string.more_options),
                             )
                         }
                         DropdownMenu(
                             expanded = showMenu,
-                            onDismissRequest = { showMenu = false }
+                            onDismissRequest = { showMenu = false },
                         ) {
                             DropdownMenuItem(
                                 text = { Text(stringResource(R.string.history_delete_shorts)) },
@@ -178,7 +179,7 @@ fun HistoryScreen(
                                 onClick = {
                                     showMenu = false
                                     showClearShortsDialog = true
-                                }
+                                },
                             )
                             DropdownMenuItem(
                                 text = { Text(stringResource(R.string.clear_all)) },
@@ -186,25 +187,26 @@ fun HistoryScreen(
                                 onClick = {
                                     showMenu = false
                                     showClearDialog = true
-                                }
+                                },
                             )
                         }
                     }
                 }
             }
         },
-        containerColor = MaterialTheme.colorScheme.background
+        containerColor = MaterialTheme.colorScheme.background,
     ) { paddingValues ->
         Column(
-            modifier = modifier
-                .fillMaxSize()
-                .background(MaterialTheme.colorScheme.background)
-                .padding(paddingValues)
+            modifier =
+                modifier
+                    .fillMaxSize()
+                    .background(MaterialTheme.colorScheme.background)
+                    .padding(paddingValues),
         ) {
             HistorySearchField(
                 query = searchQuery,
                 onQueryChange = { searchQuery = it },
-                focusRequester = searchFocusRequester
+                focusRequester = searchFocusRequester,
             )
 
             HistoryFilterRow(
@@ -214,14 +216,14 @@ fun HistoryScreen(
                 onSortSelected = { selectedSort = it },
                 selectedYear = selectedYear,
                 availableYears = availableYears,
-                onYearSelected = { selectedYear = it }
+                onYearSelected = { selectedYear = it },
             )
 
             when {
                 uiState.isLoading -> {
                     Box(
                         modifier = Modifier.fillMaxSize(),
-                        contentAlignment = Alignment.Center
+                        contentAlignment = Alignment.Center,
                     ) {
                         CircularProgressIndicator()
                     }
@@ -235,7 +237,7 @@ fun HistoryScreen(
                     EmptyHistoryState(
                         modifier = Modifier.fillMaxSize(),
                         title = stringResource(R.string.history_no_results),
-                        body = stringResource(R.string.history_no_results_body)
+                        body = stringResource(R.string.history_no_results_body),
                     )
                 }
 
@@ -247,7 +249,7 @@ fun HistoryScreen(
                         onVideoClick = onVideoClick,
                         onShortClick = onShortClick,
                         onMusicClick = onMusicClick,
-                        onRemove = viewModel::removeFromHistory
+                        onRemove = viewModel::removeFromHistory,
                     )
                 }
             }
@@ -264,7 +266,7 @@ fun HistoryScreen(
                     onClick = {
                         viewModel.clearHistory()
                         showClearDialog = false
-                    }
+                    },
                 ) {
                     Text(stringResource(R.string.clear))
                 }
@@ -273,7 +275,7 @@ fun HistoryScreen(
                 TextButton(onClick = { showClearDialog = false }) {
                     Text(stringResource(R.string.cancel))
                 }
-            }
+            },
         )
     }
 
@@ -287,7 +289,7 @@ fun HistoryScreen(
                     onClick = {
                         viewModel.clearShortsHistory()
                         showClearShortsDialog = false
-                    }
+                    },
                 ) {
                     Text(stringResource(R.string.clear))
                 }
@@ -296,7 +298,7 @@ fun HistoryScreen(
                 TextButton(onClick = { showClearShortsDialog = false }) {
                     Text(stringResource(R.string.cancel))
                 }
-            }
+            },
         )
     }
 }
@@ -305,20 +307,21 @@ fun HistoryScreen(
 private fun HistorySearchField(
     query: String,
     onQueryChange: (String) -> Unit,
-    focusRequester: FocusRequester
+    focusRequester: FocusRequester,
 ) {
     TextField(
         value = query,
         onValueChange = onQueryChange,
-        modifier = Modifier
-            .fillMaxWidth()
-            .focusRequester(focusRequester)
-            .padding(horizontal = 16.dp, vertical = 8.dp),
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .focusRequester(focusRequester)
+                .padding(horizontal = 16.dp, vertical = 8.dp),
         placeholder = { Text(stringResource(R.string.search_watch_history)) },
         leadingIcon = {
             Icon(
                 imageVector = Icons.Default.Search,
-                contentDescription = null
+                contentDescription = null,
             )
         },
         trailingIcon = {
@@ -326,19 +329,20 @@ private fun HistorySearchField(
                 IconButton(onClick = { onQueryChange("") }) {
                     Icon(
                         imageVector = Icons.Default.Close,
-                        contentDescription = stringResource(R.string.clear)
+                        contentDescription = stringResource(R.string.clear),
                     )
                 }
             }
         },
         singleLine = true,
         shape = RoundedCornerShape(16.dp),
-        colors = TextFieldDefaults.colors(
-            focusedContainerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.55f),
-            unfocusedContainerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.55f),
-            focusedIndicatorColor = Color.Transparent,
-            unfocusedIndicatorColor = Color.Transparent
-        )
+        colors =
+            TextFieldDefaults.colors(
+                focusedContainerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.55f),
+                unfocusedContainerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.55f),
+                focusedIndicatorColor = Color.Transparent,
+                unfocusedIndicatorColor = Color.Transparent,
+            ),
     )
 }
 
@@ -350,7 +354,7 @@ private fun HistoryFilterRow(
     onSortSelected: (HistorySort) -> Unit,
     selectedYear: Int?,
     availableYears: List<Int>,
-    onYearSelected: (Int?) -> Unit
+    onYearSelected: (Int?) -> Unit,
 ) {
     var sortExpanded by remember { mutableStateOf(false) }
     var yearExpanded by remember { mutableStateOf(false) }
@@ -358,13 +362,13 @@ private fun HistoryFilterRow(
     LazyRow(
         modifier = Modifier.fillMaxWidth(),
         contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
-        horizontalArrangement = Arrangement.spacedBy(8.dp)
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
     ) {
         items(HistoryContentFilter.values().toList()) { filter ->
             FilterChip(
                 selected = selectedFilter == filter,
                 onClick = { onFilterSelected(filter) },
-                label = { Text(filter.label()) }
+                label = { Text(filter.label()) },
             )
         }
 
@@ -373,11 +377,11 @@ private fun HistoryFilterRow(
                 FilterChip(
                     selected = selectedSort != HistorySort.Newest,
                     onClick = { sortExpanded = true },
-                    label = { Text(selectedSort.label()) }
+                    label = { Text(selectedSort.label()) },
                 )
                 DropdownMenu(
                     expanded = sortExpanded,
-                    onDismissRequest = { sortExpanded = false }
+                    onDismissRequest = { sortExpanded = false },
                 ) {
                     HistorySort.values().forEach { sort ->
                         DropdownMenuItem(
@@ -385,7 +389,7 @@ private fun HistoryFilterRow(
                             onClick = {
                                 sortExpanded = false
                                 onSortSelected(sort)
-                            }
+                            },
                         )
                     }
                 }
@@ -400,20 +404,20 @@ private fun HistoryFilterRow(
                     label = {
                         Text(
                             selectedYear?.toString()
-                                ?: stringResource(R.string.history_filter_all_years)
+                                ?: stringResource(R.string.history_filter_all_years),
                         )
-                    }
+                    },
                 )
                 DropdownMenu(
                     expanded = yearExpanded,
-                    onDismissRequest = { yearExpanded = false }
+                    onDismissRequest = { yearExpanded = false },
                 ) {
                     DropdownMenuItem(
                         text = { Text(stringResource(R.string.history_filter_all_years)) },
                         onClick = {
                             yearExpanded = false
                             onYearSelected(null)
-                        }
+                        },
                     )
                     availableYears.forEach { year ->
                         DropdownMenuItem(
@@ -421,7 +425,7 @@ private fun HistoryFilterRow(
                             onClick = {
                                 yearExpanded = false
                                 onYearSelected(year)
-                            }
+                            },
                         )
                     }
                 }
@@ -438,26 +442,28 @@ private fun HistoryList(
     onVideoClick: (MusicTrack) -> Unit,
     onShortClick: (String) -> Unit,
     onMusicClick: (MusicTrack, List<MusicTrack>) -> Unit,
-    onRemove: (String) -> Unit
+    onRemove: (String) -> Unit,
 ) {
-    val groupedEntries = remember(entries) {
-        entries.groupBy { historySectionKey(it.timestamp) }
-    }
-    val musicQueue = remember(entries) {
-        entries.filter { it.isMusic }.map { it.toMusicTrack() }
-    }
+    val groupedEntries =
+        remember(entries) {
+            entries.groupBy { historySectionKey(it.timestamp) }
+        }
+    val musicQueue =
+        remember(entries) {
+            entries.filter { it.isMusic }.map { it.toMusicTrack() }
+        }
 
     LazyColumn(
         modifier = Modifier.fillMaxSize(),
         contentPadding = PaddingValues(bottom = 96.dp),
-        verticalArrangement = Arrangement.spacedBy(4.dp)
+        verticalArrangement = Arrangement.spacedBy(4.dp),
     ) {
         groupedEntries.forEach { (sectionKey, sectionEntries) ->
             item(key = "header-$sectionKey") {
                 Text(
                     text = sectionTitle(sectionEntries.first().timestamp),
                     style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.SemiBold),
-                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp)
+                    modifier = Modifier.padding(horizontal = 16.dp, vertical = 12.dp),
                 )
             }
 
@@ -468,7 +474,7 @@ private fun HistoryList(
                             entries = sectionEntries,
                             shortVideos = shortVideos,
                             onShortClick = onShortClick,
-                            onRemove = onRemove
+                            onRemove = onRemove,
                         )
                     }
                 }
@@ -479,14 +485,14 @@ private fun HistoryList(
 
                     items(
                         items = regular,
-                        key = { it.videoId }
+                        key = { it.videoId },
                     ) { entry ->
                         HistoryEntryRow(
                             entry = entry,
                             musicQueue = musicQueue,
                             onVideoClick = onVideoClick,
                             onMusicClick = onMusicClick,
-                            onRemove = onRemove
+                            onRemove = onRemove,
                         )
                     }
 
@@ -496,7 +502,7 @@ private fun HistoryList(
                                 entries = shorts,
                                 shortVideos = shortVideos,
                                 onShortClick = onShortClick,
-                                onRemove = onRemove
+                                onRemove = onRemove,
                             )
                         }
                     }
@@ -505,14 +511,14 @@ private fun HistoryList(
                 else -> {
                     items(
                         items = sectionEntries,
-                        key = { it.videoId }
+                        key = { it.videoId },
                     ) { entry ->
                         HistoryEntryRow(
                             entry = entry,
                             musicQueue = musicQueue,
                             onVideoClick = onVideoClick,
                             onMusicClick = onMusicClick,
-                            onRemove = onRemove
+                            onRemove = onRemove,
                         )
                     }
                 }
@@ -527,7 +533,7 @@ private fun HistoryEntryRow(
     musicQueue: List<MusicTrack>,
     onVideoClick: (MusicTrack) -> Unit,
     onMusicClick: (MusicTrack, List<MusicTrack>) -> Unit,
-    onRemove: (String) -> Unit
+    onRemove: (String) -> Unit,
 ) {
     val track = remember(entry) { entry.toMusicTrack() }
     if (entry.isMusic) {
@@ -539,16 +545,16 @@ private fun HistoryEntryRow(
                     Icon(
                         imageVector = Icons.Default.Delete,
                         contentDescription = stringResource(R.string.remove_from_history),
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
                 }
-            }
+            },
         )
     } else {
         HistoryVideoCard(
             entry = entry,
             onClick = { onVideoClick(track) },
-            onDeleteClick = { onRemove(entry.videoId) }
+            onDeleteClick = { onRemove(entry.videoId) },
         )
     }
 }
@@ -558,15 +564,15 @@ private fun ShortsHistoryRow(
     entries: List<VideoHistoryEntry>,
     shortVideos: Map<String, Video>,
     onShortClick: (String) -> Unit,
-    onRemove: (String) -> Unit
+    onRemove: (String) -> Unit,
 ) {
     LazyRow(
         contentPadding = PaddingValues(horizontal = 16.dp, vertical = 4.dp),
-        horizontalArrangement = Arrangement.spacedBy(12.dp)
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
     ) {
         items(
             items = entries,
-            key = { it.videoId }
+            key = { it.videoId },
         ) { entry ->
             ShortsCard(
                 video = shortVideos[entry.videoId] ?: entry.toShortVideo(),
@@ -576,10 +582,10 @@ private fun ShortsHistoryRow(
                         Icon(
                             imageVector = Icons.Default.Close,
                             contentDescription = stringResource(R.string.remove_from_history),
-                            tint = MaterialTheme.colorScheme.onSurfaceVariant
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
                         )
                     }
-                }
+                },
             )
         }
     }
@@ -590,62 +596,67 @@ private fun HistoryVideoCard(
     entry: VideoHistoryEntry,
     onClick: () -> Unit,
     onDeleteClick: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     val resolvedCollaborators by produceState<List<VideoCollaborator>>(
         initialValue = emptyList(),
         key1 = entry.videoId,
         key2 = entry.channelName,
     ) {
-        value = if (entry.channelName.hasLikelyCollaborationByline()) {
-            VideoCollaboratorResolver.resolve(entry.videoId)
-        } else {
-            emptyList()
+        value =
+            if (entry.channelName.hasLikelyCollaborationByline()) {
+                VideoCollaboratorResolver.resolve(entry.videoId)
+            } else {
+                emptyList()
+            }
+    }
+    val displayChannelName =
+        remember(entry.channelName, resolvedCollaborators) {
+            resolvedCollaborators
+                .map { it.name }
+                .filter { it.isNotBlank() }
+                .takeIf { it.size > 1 }
+                ?.joinToString(" and ")
+                ?: entry.channelName
         }
-    }
-    val displayChannelName = remember(entry.channelName, resolvedCollaborators) {
-        resolvedCollaborators
-            .map { it.name }
-            .filter { it.isNotBlank() }
-            .takeIf { it.size > 1 }
-            ?.joinToString(" and ")
-            ?: entry.channelName
-    }
 
     Row(
-        modifier = modifier
-            .fillMaxWidth()
-            .clickable(onClick = onClick)
-            .padding(vertical = 8.dp, horizontal = 16.dp),
-        horizontalArrangement = Arrangement.spacedBy(12.dp)
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .clickable(onClick = onClick)
+                .padding(vertical = 8.dp, horizontal = 16.dp),
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
     ) {
         Box(
-            modifier = Modifier
-                .width(156.dp)
-                .aspectRatio(16f / 9f)
-                .clip(RoundedCornerShape(8.dp))
-                .background(MaterialTheme.colorScheme.surfaceVariant)
+            modifier =
+                Modifier
+                    .width(156.dp)
+                    .aspectRatio(16f / 9f)
+                    .clip(RoundedCornerShape(8.dp))
+                    .background(MaterialTheme.colorScheme.surfaceVariant),
         ) {
             AsyncImage(
                 model = entry.thumbnailUrl,
                 contentDescription = null,
                 modifier = Modifier.fillMaxSize(),
-                contentScale = ContentScale.Crop
+                contentScale = ContentScale.Crop,
             )
 
             if (entry.duration > 0) {
                 Box(
-                    modifier = Modifier
-                        .align(Alignment.BottomEnd)
-                        .padding(4.dp)
-                        .background(Color.Black.copy(alpha = 0.78f), RoundedCornerShape(4.dp))
-                        .padding(horizontal = 5.dp, vertical = 2.dp)
+                    modifier =
+                        Modifier
+                            .align(Alignment.BottomEnd)
+                            .padding(4.dp)
+                            .background(Color.Black.copy(alpha = 0.78f), RoundedCornerShape(4.dp))
+                            .padding(horizontal = 5.dp, vertical = 2.dp),
                 ) {
                     Text(
                         text = formatDuration(entry.duration),
                         style = MaterialTheme.typography.labelSmall,
                         color = Color.White,
-                        fontWeight = FontWeight.Bold
+                        fontWeight = FontWeight.Bold,
                     )
                 }
             }
@@ -653,12 +664,13 @@ private fun HistoryVideoCard(
             if (entry.progressPercentage > 0) {
                 LinearProgressIndicator(
                     progress = { if (entry.progressPercentage >= 90f) 1f else entry.progressPercentage / 100f },
-                    modifier = Modifier
-                        .align(Alignment.BottomCenter)
-                        .fillMaxWidth()
-                        .height(3.dp),
+                    modifier =
+                        Modifier
+                            .align(Alignment.BottomCenter)
+                            .fillMaxWidth()
+                            .height(3.dp),
                     color = MaterialTheme.colorScheme.primary,
-                    trackColor = Color.Transparent
+                    trackColor = Color.Transparent,
                 )
             }
         }
@@ -667,7 +679,7 @@ private fun HistoryVideoCard(
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.Top
+                verticalAlignment = Alignment.Top,
             ) {
                 Text(
                     text = entry.title.ifBlank { entry.videoId },
@@ -675,20 +687,21 @@ private fun HistoryVideoCard(
                     color = MaterialTheme.colorScheme.onSurface,
                     maxLines = 2,
                     overflow = TextOverflow.Ellipsis,
-                    modifier = Modifier
-                        .weight(1f)
-                        .padding(end = 4.dp)
+                    modifier =
+                        Modifier
+                            .weight(1f)
+                            .padding(end = 4.dp),
                 )
 
                 IconButton(
                     onClick = onDeleteClick,
-                    modifier = Modifier.size(32.dp)
+                    modifier = Modifier.size(32.dp),
                 ) {
                     Icon(
                         imageVector = Icons.Default.Close,
                         contentDescription = stringResource(R.string.remove),
                         tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.size(20.dp)
+                        modifier = Modifier.size(20.dp),
                     )
                 }
             }
@@ -700,7 +713,7 @@ private fun HistoryVideoCard(
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     maxLines = 1,
-                    overflow = TextOverflow.Ellipsis
+                    overflow = TextOverflow.Ellipsis,
                 )
             }
         }
@@ -711,32 +724,32 @@ private fun HistoryVideoCard(
 private fun EmptyHistoryState(
     modifier: Modifier = Modifier,
     title: String = stringResource(R.string.empty_watch_history),
-    body: String = stringResource(R.string.empty_watch_history_body)
+    body: String = stringResource(R.string.empty_watch_history_body),
 ) {
     Column(
         modifier = modifier.padding(32.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.Center
+        verticalArrangement = Arrangement.Center,
     ) {
         Icon(
             imageVector = Icons.Outlined.History,
             contentDescription = null,
             modifier = Modifier.size(80.dp),
-            tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f)
+            tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
         )
         Spacer(modifier = Modifier.height(16.dp))
         Text(
             text = title,
             style = MaterialTheme.typography.titleLarge,
             color = MaterialTheme.colorScheme.onBackground,
-            textAlign = TextAlign.Center
+            textAlign = TextAlign.Center,
         )
         Spacer(modifier = Modifier.height(8.dp))
         Text(
             text = body,
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
-            textAlign = TextAlign.Center
+            textAlign = TextAlign.Center,
         )
     }
 }
@@ -747,60 +760,66 @@ private enum class HistoryContentFilter {
     Shorts,
     Music,
     LocalVideos,
-    LocalMusic;
+    LocalMusic,
+    ;
 
-    fun matches(entry: VideoHistoryEntry): Boolean = when (this) {
-        All -> !entry.isLocal
-        Videos -> !entry.isMusic && !entry.isShort && !entry.isLocal
-        Shorts -> !entry.isMusic && entry.isShort && !entry.isLocal
-        Music -> entry.isMusic && !entry.isLocal
-        LocalVideos -> entry.isLocal && !entry.isMusic
-        LocalMusic -> entry.isLocal && entry.isMusic
-    }
+    fun matches(entry: VideoHistoryEntry): Boolean =
+        when (this) {
+            All -> !entry.isLocal
+            Videos -> !entry.isMusic && !entry.isShort && !entry.isLocal
+            Shorts -> !entry.isMusic && entry.isShort && !entry.isLocal
+            Music -> entry.isMusic && !entry.isLocal
+            LocalVideos -> entry.isLocal && !entry.isMusic
+            LocalMusic -> entry.isLocal && entry.isMusic
+        }
 }
 
 @Composable
-private fun HistoryContentFilter.label(): String = when (this) {
-    HistoryContentFilter.All -> stringResource(R.string.view_all_button_label)
-    HistoryContentFilter.Videos -> stringResource(R.string.history_tab_videos)
-    HistoryContentFilter.Shorts -> stringResource(R.string.history_tab_shorts)
-    HistoryContentFilter.Music -> stringResource(R.string.nav_music)
-    HistoryContentFilter.LocalVideos -> stringResource(R.string.history_tab_local_videos)
-    HistoryContentFilter.LocalMusic -> stringResource(R.string.history_tab_local_music)
-}
+private fun HistoryContentFilter.label(): String =
+    when (this) {
+        HistoryContentFilter.All -> stringResource(R.string.view_all_button_label)
+        HistoryContentFilter.Videos -> stringResource(R.string.history_tab_videos)
+        HistoryContentFilter.Shorts -> stringResource(R.string.history_tab_shorts)
+        HistoryContentFilter.Music -> stringResource(R.string.nav_music)
+        HistoryContentFilter.LocalVideos -> stringResource(R.string.history_tab_local_videos)
+        HistoryContentFilter.LocalMusic -> stringResource(R.string.history_tab_local_music)
+    }
 
 private enum class HistorySort {
     Newest,
-    Oldest
+    Oldest,
 }
 
 @Composable
-private fun HistorySort.label(): String = when (this) {
-    HistorySort.Newest -> stringResource(R.string.history_sort_newest)
-    HistorySort.Oldest -> stringResource(R.string.history_sort_oldest)
-}
+private fun HistorySort.label(): String =
+    when (this) {
+        HistorySort.Newest -> stringResource(R.string.history_sort_newest)
+        HistorySort.Oldest -> stringResource(R.string.history_sort_oldest)
+    }
 
-private fun VideoHistoryEntry.toMusicTrack(): MusicTrack = MusicTrack(
-    videoId = videoId,
-    title = title,
-    artist = channelName,
-    thumbnailUrl = thumbnailUrl,
-    duration = (duration / 1000).toInt(),
-    channelId = channelId
-)
+private fun VideoHistoryEntry.toMusicTrack(): MusicTrack =
+    MusicTrack(
+        videoId = videoId,
+        title = title,
+        artist = channelName,
+        thumbnailUrl = thumbnailUrl,
+        duration = (duration / 1000).toInt(),
+        channelId = channelId,
+    )
 
-private fun VideoHistoryEntry.toShortVideo(): Video = Video(
-    id = videoId,
-    title = title,
-    channelName = channelName,
-    channelId = channelId,
-    thumbnailUrl = thumbnailUrl,
-    duration = (duration / 1000).toInt(),
-    viewCount = 0L,
-    uploadDate = "",
-    timestamp = timestamp,
-    isShort = true
-)
+private fun VideoHistoryEntry.toShortVideo(): Video =
+    Video(
+        id = videoId,
+        title = title,
+        channelName = channelName,
+        channelId = channelId,
+        thumbnailUrl = thumbnailUrl,
+        duration = (duration / 1000).toInt(),
+        viewCount = 0L,
+        uploadDate = "",
+        timestamp = timestamp,
+        isShort = true,
+    )
 
 private fun formatDuration(durationMs: Long): String {
     val totalSeconds = durationMs / 1000
@@ -815,36 +834,37 @@ private fun formatDuration(durationMs: Long): String {
     }
 }
 
-private fun historyYear(timestamp: Long): Int {
-    return Calendar.getInstance().apply { timeInMillis = timestamp }.get(Calendar.YEAR)
-}
+private fun historyYear(timestamp: Long): Int = Calendar.getInstance().apply { timeInMillis = timestamp }.get(Calendar.YEAR)
 
 private fun historySectionKey(timestamp: Long): String {
-    val calendar = Calendar.getInstance().apply {
-        timeInMillis = timestamp
-        set(Calendar.HOUR_OF_DAY, 0)
-        set(Calendar.MINUTE, 0)
-        set(Calendar.SECOND, 0)
-        set(Calendar.MILLISECOND, 0)
-    }
+    val calendar =
+        Calendar.getInstance().apply {
+            timeInMillis = timestamp
+            set(Calendar.HOUR_OF_DAY, 0)
+            set(Calendar.MINUTE, 0)
+            set(Calendar.SECOND, 0)
+            set(Calendar.MILLISECOND, 0)
+        }
     return calendar.timeInMillis.toString()
 }
 
 @Composable
 private fun sectionTitle(timestamp: Long): String {
-    val today = Calendar.getInstance().apply {
-        set(Calendar.HOUR_OF_DAY, 0)
-        set(Calendar.MINUTE, 0)
-        set(Calendar.SECOND, 0)
-        set(Calendar.MILLISECOND, 0)
-    }
-    val target = Calendar.getInstance().apply {
-        timeInMillis = timestamp
-        set(Calendar.HOUR_OF_DAY, 0)
-        set(Calendar.MINUTE, 0)
-        set(Calendar.SECOND, 0)
-        set(Calendar.MILLISECOND, 0)
-    }
+    val today =
+        Calendar.getInstance().apply {
+            set(Calendar.HOUR_OF_DAY, 0)
+            set(Calendar.MINUTE, 0)
+            set(Calendar.SECOND, 0)
+            set(Calendar.MILLISECOND, 0)
+        }
+    val target =
+        Calendar.getInstance().apply {
+            timeInMillis = timestamp
+            set(Calendar.HOUR_OF_DAY, 0)
+            set(Calendar.MINUTE, 0)
+            set(Calendar.SECOND, 0)
+            set(Calendar.MILLISECOND, 0)
+        }
     val diffDays = ((today.timeInMillis - target.timeInMillis) / (24 * 60 * 60 * 1000)).toInt()
     return when (diffDays) {
         0 -> stringResource(R.string.time_today)

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/history/HistoryViewModel.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/history/HistoryViewModel.kt
@@ -4,179 +4,192 @@ import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
-import io.github.aedev.flow.data.local.ViewHistory
 import io.github.aedev.flow.data.local.VideoHistoryEntry
-import io.github.aedev.flow.data.local.entity.WatchHistoryEntity
-import io.github.aedev.flow.data.local.entity.VideoEntity
+import io.github.aedev.flow.data.local.ViewHistory
 import io.github.aedev.flow.data.local.dao.VideoDao
 import io.github.aedev.flow.data.local.dao.WatchHistoryDao
+import io.github.aedev.flow.data.local.entity.VideoEntity
+import io.github.aedev.flow.data.local.entity.WatchHistoryEntity
 import io.github.aedev.flow.data.model.Video
 import io.github.aedev.flow.data.repository.YouTubeRepository
 import io.github.aedev.flow.utils.ThumbnailUrlResolver
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import java.util.concurrent.atomic.AtomicBoolean
 import javax.inject.Inject
 
 @HiltViewModel
-class HistoryViewModel @Inject constructor(
-    private val viewHistory: ViewHistory,
-    private val youTubeRepository: YouTubeRepository,
-    private val videoDao: VideoDao,
-    private val watchHistoryDao: WatchHistoryDao,
-) : ViewModel() {
+class HistoryViewModel
+    @Inject
+    constructor(
+        private val viewHistory: ViewHistory,
+        private val youTubeRepository: YouTubeRepository,
+        private val videoDao: VideoDao,
+        private val watchHistoryDao: WatchHistoryDao,
+    ) : ViewModel() {
+        private val isEnriching = AtomicBoolean(false)
 
-    private val isEnriching = AtomicBoolean(false)
+        private val _uiState = MutableStateFlow(HistoryUiState())
+        val uiState: StateFlow<HistoryUiState> = _uiState.asStateFlow()
 
-    private val _uiState = MutableStateFlow(HistoryUiState())
-    val uiState: StateFlow<HistoryUiState> = _uiState.asStateFlow()
+        init {
+            // Load history and enrich any entries that are missing metadata
+            viewModelScope.launch {
+                _uiState.update { it.copy(isLoading = true) }
+                viewHistory.getAllHistory().collect { history ->
+                    val enriched =
+                        history.map { entry ->
+                            var e = entry
 
-    init {
-        // Load history and enrich any entries that are missing metadata
-        viewModelScope.launch {
-            _uiState.update { it.copy(isLoading = true) }
-            viewHistory.getAllHistory().collect { history ->
-                val enriched = history.map { entry ->
-                    var e = entry
+                            val needsEnrichment = e.title.isEmpty() || e.channelName.isEmpty()
+                            val dbVideo = if (needsEnrichment || e.isShort) videoDao.getVideo(e.videoId) else null
 
-                    val needsEnrichment = e.title.isEmpty() || e.channelName.isEmpty()
-                    val dbVideo = if (needsEnrichment || e.isShort) videoDao.getVideo(e.videoId) else null
+                            if (e.thumbnailUrl.isEmpty()) {
+                                e =
+                                    e.copy(
+                                        thumbnailUrl =
+                                            ThumbnailUrlResolver.normalizeVideoThumbnail(
+                                                e.videoId,
+                                                dbVideo?.thumbnailUrl,
+                                            ),
+                                    )
+                            }
 
-                    if (e.thumbnailUrl.isEmpty()) {
-                        e = e.copy(
-                            thumbnailUrl = ThumbnailUrlResolver.normalizeVideoThumbnail(
-                                e.videoId,
-                                dbVideo?.thumbnailUrl
-                            )
-                        )
-                    }
-
-                    if (dbVideo != null) {
-                        if (e.title.isEmpty() && dbVideo.title.isNotEmpty())
-                            e = e.copy(title = dbVideo.title)
-                        if (e.channelName.isEmpty() && dbVideo.channelName.isNotEmpty())
-                            e = e.copy(channelName = dbVideo.channelName, channelId = dbVideo.channelId)
-                        if (dbVideo.thumbnailUrl.isNotEmpty() &&
-                            ThumbnailUrlResolver.isYoutubeVideoThumbnail(e.thumbnailUrl))
-                            e = e.copy(thumbnailUrl = dbVideo.thumbnailUrl)
-                    }
-                    e
-                }
-
-                val shortVideos = mutableMapOf<String, Video>()
-                enriched
-                    .filter { it.isShort }
-                    .forEach { entry ->
-                        val video = videoDao.getVideo(entry.videoId)?.toDomain()?.copy(
-                            isShort = true,
-                            isMusic = entry.isMusic,
-                            timestamp = entry.timestamp
-                        )
-                        if (video != null) {
-                            shortVideos[video.id] = video
+                            if (dbVideo != null) {
+                                if (e.title.isEmpty() && dbVideo.title.isNotEmpty()) {
+                                    e = e.copy(title = dbVideo.title)
+                                }
+                                if (e.channelName.isEmpty() && dbVideo.channelName.isNotEmpty()) {
+                                    e = e.copy(channelName = dbVideo.channelName, channelId = dbVideo.channelId)
+                                }
+                                if (dbVideo.thumbnailUrl.isNotEmpty() &&
+                                    ThumbnailUrlResolver.isYoutubeVideoThumbnail(e.thumbnailUrl)
+                                ) {
+                                    e = e.copy(thumbnailUrl = dbVideo.thumbnailUrl)
+                                }
+                            }
+                            e
                         }
-                    }
 
-                _uiState.update {
-                    it.copy(
-                        historyEntries = enriched,
-                        shortVideos = shortVideos,
-                        isLoading = false
-                    )
-                }
+                    val shortVideos = mutableMapOf<String, Video>()
+                    enriched
+                        .filter { it.isShort }
+                        .forEach { entry ->
+                            val video =
+                                videoDao.getVideo(entry.videoId)?.toDomain()?.copy(
+                                    isShort = true,
+                                    isMusic = entry.isMusic,
+                                    timestamp = entry.timestamp,
+                                )
+                            if (video != null) {
+                                shortVideos[video.id] = video
+                            }
+                        }
 
-                val stubs = enriched
-                    .filter { entry ->
-                        !entry.isLocal && (
-                            entry.title.isEmpty() ||
-                                entry.channelName.isEmpty() ||
-                                (entry.isShort && !shortVideos.containsKey(entry.videoId))
+                    _uiState.update {
+                        it.copy(
+                            historyEntries = enriched,
+                            shortVideos = shortVideos,
+                            isLoading = false,
                         )
                     }
-                    .distinctBy { it.videoId }
-                    .take(30)
-                if (stubs.isNotEmpty()) {
-                    enrichFromApi(stubs)
-                }
-            }
-        }
-    }
 
-    private fun enrichFromApi(
-        stubs: List<VideoHistoryEntry>,
-    ) {
-        if (!isEnriching.compareAndSet(false, true)) return
-        viewModelScope.launch(Dispatchers.IO) {
-            try {
-                stubs.chunked(5).forEach { chunk ->
-                    chunk.forEach { stub ->
-                        try {
-                            val video = youTubeRepository.getVideo(stub.videoId) ?: return@forEach
-                            val e = VideoEntity.fromDomain(video)
-                            videoDao.insertVideoOrIgnore(e) 
-                            videoDao.updateVideoMetadata(
-                                id = e.id,
-                                title = e.title,
-                                channelName = e.channelName,
-                                channelId = e.channelId,
-                                thumbnailUrl = e.thumbnailUrl,
-                                duration = e.duration,
-                                viewCount = e.viewCount,
-                                uploadDate = e.uploadDate,
-                                timestamp = e.timestamp,
-                                description = e.description,
-                                channelThumbnailUrl = e.channelThumbnailUrl
-                            )
-                            watchHistoryDao.upsert(
-                                WatchHistoryEntity(
-                                    videoId      = stub.videoId,
-                                    position     = stub.position,
-                                    duration     = video.duration * 1000L,
-                                    timestamp    = stub.timestamp,
-                                    title        = video.title,
-                                    thumbnailUrl = ThumbnailUrlResolver.normalizeVideoThumbnail(
-                                        stub.videoId,
-                                        video.thumbnailUrl
-                                    ),
-                                    channelName  = video.channelName,
-                                    channelId    = video.channelId,
-                                    isMusic      = stub.isMusic,
-                                    isShort      = stub.isShort || video.isShort
+                    val stubs =
+                        enriched
+                            .filter { entry ->
+                                !entry.isLocal && (
+                                    entry.title.isEmpty() ||
+                                        entry.channelName.isEmpty() ||
+                                        (entry.isShort && !shortVideos.containsKey(entry.videoId))
                                 )
-                            )
-                        } catch (_: Exception) { /* skip individual failures */ }
+                            }.distinctBy { it.videoId }
+                            .take(30)
+                    if (stubs.isNotEmpty()) {
+                        enrichFromApi(stubs)
                     }
-                    delay(300L)
                 }
-            } finally {
-                isEnriching.set(false)
+            }
+        }
+
+        private fun enrichFromApi(stubs: List<VideoHistoryEntry>) {
+            if (!isEnriching.compareAndSet(false, true)) return
+            viewModelScope.launch(Dispatchers.IO) {
+                try {
+                    stubs.chunked(5).forEach { chunk ->
+                        chunk.forEach { stub ->
+                            try {
+                                val video = youTubeRepository.getVideo(stub.videoId) ?: return@forEach
+                                val e = VideoEntity.fromDomain(video)
+                                videoDao.insertVideoOrIgnore(e)
+                                videoDao.updateVideoMetadata(
+                                    id = e.id,
+                                    title = e.title,
+                                    channelName = e.channelName,
+                                    channelId = e.channelId,
+                                    thumbnailUrl = e.thumbnailUrl,
+                                    duration = e.duration,
+                                    viewCount = e.viewCount,
+                                    uploadDate = e.uploadDate,
+                                    timestamp = e.timestamp,
+                                    description = e.description,
+                                    channelThumbnailUrl = e.channelThumbnailUrl,
+                                )
+                                watchHistoryDao.upsert(
+                                    WatchHistoryEntity(
+                                        videoId = stub.videoId,
+                                        position = stub.position,
+                                        duration = video.duration * 1000L,
+                                        timestamp = stub.timestamp,
+                                        title = video.title,
+                                        thumbnailUrl =
+                                            ThumbnailUrlResolver.normalizeVideoThumbnail(
+                                                stub.videoId,
+                                                video.thumbnailUrl,
+                                            ),
+                                        channelName = video.channelName,
+                                        channelId = video.channelId,
+                                        isMusic = stub.isMusic,
+                                        isShort = stub.isShort || video.isShort,
+                                    ),
+                                )
+                            } catch (_: Exception) {
+                                // skip individual failures
+                            }
+                        }
+                        delay(300L)
+                    }
+                } finally {
+                    isEnriching.set(false)
+                }
+            }
+        }
+
+        fun clearHistory() {
+            viewModelScope.launch {
+                viewHistory.clearAllHistory()
+            }
+        }
+
+        fun clearShortsHistory() {
+            viewModelScope.launch {
+                viewHistory.clearShortsHistory()
+            }
+        }
+
+        fun removeFromHistory(videoId: String) {
+            viewModelScope.launch {
+                viewHistory.clearVideoHistory(videoId)
             }
         }
     }
-
-    fun clearHistory() {
-        viewModelScope.launch {
-            viewHistory.clearAllHistory()
-        }
-    }
-
-    fun clearShortsHistory() {
-        viewModelScope.launch {
-            viewHistory.clearShortsHistory()
-        }
-    }
-
-    fun removeFromHistory(videoId: String) {
-        viewModelScope.launch {
-            viewHistory.clearVideoHistory(videoId)
-        }
-    }
-}
 
 data class HistoryUiState(
     val historyEntries: List<VideoHistoryEntry> = emptyList(),
     val shortVideos: Map<String, Video> = emptyMap(),
-    val isLoading: Boolean = false
+    val isLoading: Boolean = false,
 )

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/history/HistoryViewModel.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/history/HistoryViewModel.kt
@@ -1,14 +1,15 @@
 package io.github.aedev.flow.ui.screens.history
 
-import android.content.Context
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import io.github.aedev.flow.data.local.AppDatabase
+import dagger.hilt.android.lifecycle.HiltViewModel
 import io.github.aedev.flow.data.local.ViewHistory
 import io.github.aedev.flow.data.local.VideoHistoryEntry
 import io.github.aedev.flow.data.local.entity.WatchHistoryEntity
 import io.github.aedev.flow.data.local.entity.VideoEntity
+import io.github.aedev.flow.data.local.dao.VideoDao
+import io.github.aedev.flow.data.local.dao.WatchHistoryDao
 import io.github.aedev.flow.data.model.Video
 import io.github.aedev.flow.data.repository.YouTubeRepository
 import io.github.aedev.flow.utils.ThumbnailUrlResolver
@@ -17,21 +18,22 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
 import java.util.concurrent.atomic.AtomicBoolean
+import javax.inject.Inject
 
-class HistoryViewModel : ViewModel() {
+@HiltViewModel
+class HistoryViewModel @Inject constructor(
+    private val viewHistory: ViewHistory,
+    private val youTubeRepository: YouTubeRepository,
+    private val videoDao: VideoDao,
+    private val watchHistoryDao: WatchHistoryDao,
+) : ViewModel() {
 
-    private lateinit var viewHistory: ViewHistory
-    private val youTubeRepository = YouTubeRepository.getInstance()
     private val isEnriching = AtomicBoolean(false)
 
     private val _uiState = MutableStateFlow(HistoryUiState())
     val uiState: StateFlow<HistoryUiState> = _uiState.asStateFlow()
 
-    fun initialize(context: Context) {
-        viewHistory = ViewHistory.getInstance(context)
-        val videoDao = AppDatabase.getDatabase(context).videoDao()
-        val watchHistoryDao = AppDatabase.getDatabase(context).watchHistoryDao()
-
+    init {
         // Load history and enrich any entries that are missing metadata
         viewModelScope.launch {
             _uiState.update { it.copy(isLoading = true) }
@@ -96,7 +98,7 @@ class HistoryViewModel : ViewModel() {
                     .distinctBy { it.videoId }
                     .take(30)
                 if (stubs.isNotEmpty()) {
-                    enrichFromApi(stubs, videoDao, watchHistoryDao)
+                    enrichFromApi(stubs)
                 }
             }
         }
@@ -104,8 +106,6 @@ class HistoryViewModel : ViewModel() {
 
     private fun enrichFromApi(
         stubs: List<VideoHistoryEntry>,
-        videoDao: io.github.aedev.flow.data.local.dao.VideoDao,
-        watchHistoryDao: io.github.aedev.flow.data.local.dao.WatchHistoryDao
     ) {
         if (!isEnriching.compareAndSet(false, true)) return
         viewModelScope.launch(Dispatchers.IO) {

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/likedvideos/LikedVideosScreen.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/likedvideos/LikedVideosScreen.kt
@@ -46,13 +46,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 import coil.compose.AsyncImage
 import io.github.aedev.flow.R
 import io.github.aedev.flow.data.local.LikedVideoInfo
@@ -66,15 +65,10 @@ fun LikesScreen(
     onBackClick: () -> Unit,
     onMusicClick: (MusicTrack, List<MusicTrack>) -> Unit = { track, _ -> onVideoClick(track) },
     modifier: Modifier = Modifier,
-    viewModel: LikedVideosViewModel = viewModel()
+    viewModel: LikedVideosViewModel = hiltViewModel()
 ) {
-    val context = LocalContext.current
     val uiState by viewModel.uiState.collectAsState()
     var selectedFilter by rememberSaveable { mutableStateOf(LikesFilter.Videos) }
-
-    LaunchedEffect(Unit) {
-        viewModel.initialize(context)
-    }
 
     val displayLikes = remember(uiState.likedVideos, selectedFilter) {
         uiState.likedVideos.filter { selectedFilter.matches(it) }

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/likedvideos/LikedVideosScreen.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/likedvideos/LikedVideosScreen.kt
@@ -65,34 +65,37 @@ fun LikesScreen(
     onBackClick: () -> Unit,
     onMusicClick: (MusicTrack, List<MusicTrack>) -> Unit = { track, _ -> onVideoClick(track) },
     modifier: Modifier = Modifier,
-    viewModel: LikedVideosViewModel = hiltViewModel()
+    viewModel: LikedVideosViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsState()
     var selectedFilter by rememberSaveable { mutableStateOf(LikesFilter.Videos) }
 
-    val displayLikes = remember(uiState.likedVideos, selectedFilter) {
-        uiState.likedVideos.filter { selectedFilter.matches(it) }
-    }
-    val musicQueue = remember(uiState.likedVideos) {
-        uiState.likedVideos.filter { it.isMusic }.map { it.toMusicTrack() }
-    }
+    val displayLikes =
+        remember(uiState.likedVideos, selectedFilter) {
+            uiState.likedVideos.filter { selectedFilter.matches(it) }
+        }
+    val musicQueue =
+        remember(uiState.likedVideos) {
+            uiState.likedVideos.filter { it.isMusic }.map { it.toMusicTrack() }
+        }
 
     Scaffold(
         topBar = {
             Surface(
                 modifier = Modifier.fillMaxWidth(),
-                color = MaterialTheme.colorScheme.background
+                color = MaterialTheme.colorScheme.background,
             ) {
                 Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 4.dp, vertical = 8.dp),
-                    verticalAlignment = Alignment.CenterVertically
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 4.dp, vertical = 8.dp),
+                    verticalAlignment = Alignment.CenterVertically,
                 ) {
                     IconButton(onClick = onBackClick) {
                         Icon(
                             imageVector = Icons.Default.ArrowBack,
-                            contentDescription = stringResource(R.string.btn_back)
+                            contentDescription = stringResource(R.string.btn_back),
                         )
                     }
                     Text(
@@ -100,29 +103,30 @@ fun LikesScreen(
                         style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
                         maxLines = 1,
                         overflow = TextOverflow.Ellipsis,
-                        modifier = Modifier.weight(1f)
+                        modifier = Modifier.weight(1f),
                     )
                 }
             }
         },
-        containerColor = MaterialTheme.colorScheme.background
+        containerColor = MaterialTheme.colorScheme.background,
     ) { paddingValues ->
         Column(
-            modifier = modifier
-                .fillMaxSize()
-                .background(MaterialTheme.colorScheme.background)
-                .padding(paddingValues)
+            modifier =
+                modifier
+                    .fillMaxSize()
+                    .background(MaterialTheme.colorScheme.background)
+                    .padding(paddingValues),
         ) {
             LikesFilterRow(
                 selectedFilter = selectedFilter,
-                onFilterSelected = { selectedFilter = it }
+                onFilterSelected = { selectedFilter = it },
             )
 
             when {
                 uiState.isLoading -> {
                     Box(
                         modifier = Modifier.fillMaxSize(),
-                        contentAlignment = Alignment.Center
+                        contentAlignment = Alignment.Center,
                     ) {
                         CircularProgressIndicator()
                     }
@@ -136,7 +140,7 @@ fun LikesScreen(
                     EmptyLikesState(
                         modifier = Modifier.fillMaxSize(),
                         title = selectedFilter.emptyTitle(),
-                        body = selectedFilter.emptyBody()
+                        body = selectedFilter.emptyBody(),
                     )
                 }
 
@@ -144,11 +148,11 @@ fun LikesScreen(
                     LazyColumn(
                         modifier = Modifier.fillMaxSize(),
                         contentPadding = PaddingValues(bottom = 80.dp),
-                        verticalArrangement = Arrangement.spacedBy(0.dp)
+                        verticalArrangement = Arrangement.spacedBy(0.dp),
                     ) {
                         items(
                             items = displayLikes,
-                            key = { it.videoId }
+                            key = { it.videoId },
                         ) { like ->
                             if (like.isMusic) {
                                 val track = like.toMusicTrack()
@@ -160,16 +164,16 @@ fun LikesScreen(
                                             Icon(
                                                 imageVector = Icons.Default.Favorite,
                                                 contentDescription = stringResource(R.string.unlike),
-                                                tint = MaterialTheme.colorScheme.primary
+                                                tint = MaterialTheme.colorScheme.primary,
                                             )
                                         }
-                                    }
+                                    },
                                 )
                             } else {
                                 LikedVideoCard(
                                     video = like,
                                     onClick = { onVideoClick(like.toMusicTrack()) },
-                                    onUnlikeClick = { viewModel.removeLike(like.videoId) }
+                                    onUnlikeClick = { viewModel.removeLike(like.videoId) },
                                 )
                             }
                         }
@@ -183,18 +187,18 @@ fun LikesScreen(
 @Composable
 private fun LikesFilterRow(
     selectedFilter: LikesFilter,
-    onFilterSelected: (LikesFilter) -> Unit
+    onFilterSelected: (LikesFilter) -> Unit,
 ) {
     LazyRow(
         modifier = Modifier.fillMaxWidth(),
         contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp),
-        horizontalArrangement = Arrangement.spacedBy(8.dp)
+        horizontalArrangement = Arrangement.spacedBy(8.dp),
     ) {
         items(LikesFilter.values().toList()) { filter ->
             FilterChip(
                 selected = selectedFilter == filter,
                 onClick = { onFilterSelected(filter) },
-                label = { Text(filter.label()) }
+                label = { Text(filter.label()) },
             )
         }
     }
@@ -205,27 +209,29 @@ private fun LikedVideoCard(
     video: LikedVideoInfo,
     onClick: () -> Unit,
     onUnlikeClick: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     Row(
-        modifier = modifier
-            .fillMaxWidth()
-            .clickable(onClick = onClick)
-            .padding(vertical = 8.dp, horizontal = 16.dp),
-        horizontalArrangement = Arrangement.spacedBy(12.dp)
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .clickable(onClick = onClick)
+                .padding(vertical = 8.dp, horizontal = 16.dp),
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
     ) {
         Box(
-            modifier = Modifier
-                .width(156.dp)
-                .aspectRatio(16f / 9f)
-                .clip(RoundedCornerShape(8.dp))
-                .background(MaterialTheme.colorScheme.surfaceVariant)
+            modifier =
+                Modifier
+                    .width(156.dp)
+                    .aspectRatio(16f / 9f)
+                    .clip(RoundedCornerShape(8.dp))
+                    .background(MaterialTheme.colorScheme.surfaceVariant),
         ) {
             AsyncImage(
                 model = video.thumbnail,
                 contentDescription = null,
                 modifier = Modifier.fillMaxSize(),
-                contentScale = ContentScale.Crop
+                contentScale = ContentScale.Crop,
             )
         }
 
@@ -233,7 +239,7 @@ private fun LikedVideoCard(
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.Top
+                verticalAlignment = Alignment.Top,
             ) {
                 Text(
                     text = video.title,
@@ -241,20 +247,21 @@ private fun LikedVideoCard(
                     color = MaterialTheme.colorScheme.onSurface,
                     maxLines = 2,
                     overflow = TextOverflow.Ellipsis,
-                    modifier = Modifier
-                        .weight(1f)
-                        .padding(end = 4.dp)
+                    modifier =
+                        Modifier
+                            .weight(1f)
+                            .padding(end = 4.dp),
                 )
 
                 IconButton(
                     onClick = onUnlikeClick,
-                    modifier = Modifier.size(32.dp)
+                    modifier = Modifier.size(32.dp),
                 ) {
                     Icon(
                         imageVector = Icons.Filled.ThumbUp,
                         contentDescription = stringResource(R.string.unlike),
                         tint = MaterialTheme.colorScheme.primary,
-                        modifier = Modifier.size(20.dp)
+                        modifier = Modifier.size(20.dp),
                     )
                 }
             }
@@ -266,7 +273,7 @@ private fun LikedVideoCard(
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                     maxLines = 1,
-                    overflow = TextOverflow.Ellipsis
+                    overflow = TextOverflow.Ellipsis,
                 )
             }
         }
@@ -277,69 +284,75 @@ private fun LikedVideoCard(
 private fun EmptyLikesState(
     modifier: Modifier = Modifier,
     title: String = stringResource(R.string.empty_liked),
-    body: String = stringResource(R.string.empty_liked_body)
+    body: String = stringResource(R.string.empty_liked_body),
 ) {
     Column(
         modifier = modifier.padding(32.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.Center
+        verticalArrangement = Arrangement.Center,
     ) {
         Icon(
             imageVector = Icons.Outlined.ThumbUp,
             contentDescription = null,
             modifier = Modifier.size(80.dp),
-            tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f)
+            tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
         )
         Spacer(modifier = Modifier.height(16.dp))
         Text(
             text = title,
             style = MaterialTheme.typography.titleLarge,
             color = MaterialTheme.colorScheme.onBackground,
-            textAlign = TextAlign.Center
+            textAlign = TextAlign.Center,
         )
         Spacer(modifier = Modifier.height(8.dp))
         Text(
             text = body,
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
-            textAlign = TextAlign.Center
+            textAlign = TextAlign.Center,
         )
     }
 }
 
 private enum class LikesFilter {
     Videos,
-    Music;
+    Music,
+    ;
 
-    fun matches(like: LikedVideoInfo): Boolean = when (this) {
-        Videos -> !like.isMusic
-        Music -> like.isMusic
+    fun matches(like: LikedVideoInfo): Boolean =
+        when (this) {
+            Videos -> !like.isMusic
+            Music -> like.isMusic
+        }
+}
+
+@Composable
+private fun LikesFilter.label(): String =
+    when (this) {
+        LikesFilter.Videos -> stringResource(R.string.history_tab_videos)
+        LikesFilter.Music -> stringResource(R.string.nav_music)
     }
-}
 
 @Composable
-private fun LikesFilter.label(): String = when (this) {
-    LikesFilter.Videos -> stringResource(R.string.history_tab_videos)
-    LikesFilter.Music -> stringResource(R.string.nav_music)
-}
+private fun LikesFilter.emptyTitle(): String =
+    when (this) {
+        LikesFilter.Videos -> stringResource(R.string.empty_liked_videos)
+        LikesFilter.Music -> stringResource(R.string.empty_liked_music)
+    }
 
 @Composable
-private fun LikesFilter.emptyTitle(): String = when (this) {
-    LikesFilter.Videos -> stringResource(R.string.empty_liked_videos)
-    LikesFilter.Music -> stringResource(R.string.empty_liked_music)
-}
+private fun LikesFilter.emptyBody(): String =
+    when (this) {
+        LikesFilter.Videos -> stringResource(R.string.empty_liked_body)
+        LikesFilter.Music -> stringResource(R.string.empty_liked_music_body)
+    }
 
-@Composable
-private fun LikesFilter.emptyBody(): String = when (this) {
-    LikesFilter.Videos -> stringResource(R.string.empty_liked_body)
-    LikesFilter.Music -> stringResource(R.string.empty_liked_music_body)
-}
-
-private fun LikedVideoInfo.toMusicTrack(): MusicTrack = MusicTrack(
-    videoId = videoId,
-    title = title,
-    artist = channelName,
-    thumbnailUrl = thumbnail,
-    duration = 0,
-    channelId = ""
-)
+private fun LikedVideoInfo.toMusicTrack(): MusicTrack =
+    MusicTrack(
+        videoId = videoId,
+        title = title,
+        artist = channelName,
+        thumbnailUrl = thumbnail,
+        duration = 0,
+        channelId = "",
+    )

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/likedvideos/LikedVideosViewModel.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/likedvideos/LikedVideosViewModel.kt
@@ -3,43 +3,47 @@ package io.github.aedev.flow.ui.screens.likedvideos
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
-import io.github.aedev.flow.data.local.LikedVideosRepository
 import io.github.aedev.flow.data.local.LikedVideoInfo
-import kotlinx.coroutines.flow.*
+import io.github.aedev.flow.data.local.LikedVideosRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
-class LikedVideosViewModel @Inject constructor(
-    private val likedVideosRepository: LikedVideosRepository,
-) : ViewModel() {
+class LikedVideosViewModel
+    @Inject
+    constructor(
+        private val likedVideosRepository: LikedVideosRepository,
+    ) : ViewModel() {
+        private val _uiState = MutableStateFlow(LikedVideosUiState())
+        val uiState: StateFlow<LikedVideosUiState> = _uiState.asStateFlow()
 
-    private val _uiState = MutableStateFlow(LikedVideosUiState())
-    val uiState: StateFlow<LikedVideosUiState> = _uiState.asStateFlow()
-
-    init {
-        // Load all likes so the screen can switch between videos and music locally.
-        viewModelScope.launch {
-            _uiState.update { it.copy(isLoading = true) }
-            likedVideosRepository.getAllLikedVideos().collect { likedVideos ->
-                _uiState.update { 
-                    it.copy(
-                        likedVideos = likedVideos,
-                        isLoading = false
-                    )
+        init {
+            // Load all likes so the screen can switch between videos and music locally.
+            viewModelScope.launch {
+                _uiState.update { it.copy(isLoading = true) }
+                likedVideosRepository.getAllLikedVideos().collect { likedVideos ->
+                    _uiState.update {
+                        it.copy(
+                            likedVideos = likedVideos,
+                            isLoading = false,
+                        )
+                    }
                 }
+            }
+        }
+
+        fun removeLike(videoId: String) {
+            viewModelScope.launch {
+                likedVideosRepository.removeLikeState(videoId)
             }
         }
     }
 
-    fun removeLike(videoId: String) {
-        viewModelScope.launch {
-            likedVideosRepository.removeLikeState(videoId)
-        }
-    }
-}
-
 data class LikedVideosUiState(
     val likedVideos: List<LikedVideoInfo> = emptyList(),
-    val isLoading: Boolean = false
+    val isLoading: Boolean = false,
 )

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/likedvideos/LikedVideosViewModel.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/likedvideos/LikedVideosViewModel.kt
@@ -1,23 +1,23 @@
 package io.github.aedev.flow.ui.screens.likedvideos
 
-import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
 import io.github.aedev.flow.data.local.LikedVideosRepository
 import io.github.aedev.flow.data.local.LikedVideoInfo
 import kotlinx.coroutines.flow.*
 import kotlinx.coroutines.launch
+import javax.inject.Inject
 
-class LikedVideosViewModel : ViewModel() {
-    
-    private lateinit var likedVideosRepository: LikedVideosRepository
-    
+@HiltViewModel
+class LikedVideosViewModel @Inject constructor(
+    private val likedVideosRepository: LikedVideosRepository,
+) : ViewModel() {
+
     private val _uiState = MutableStateFlow(LikedVideosUiState())
     val uiState: StateFlow<LikedVideosUiState> = _uiState.asStateFlow()
-    
-    fun initialize(context: Context) {
-        likedVideosRepository = LikedVideosRepository.getInstance(context)
-        
+
+    init {
         // Load all likes so the screen can switch between videos and music locally.
         viewModelScope.launch {
             _uiState.update { it.copy(isLoading = true) }
@@ -31,7 +31,7 @@ class LikedVideosViewModel : ViewModel() {
             }
         }
     }
-    
+
     fun removeLike(videoId: String) {
         viewModelScope.launch {
             likedVideosRepository.removeLikeState(videoId)

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/search/SearchScreen.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/search/SearchScreen.kt
@@ -1,10 +1,14 @@
+@file:Suppress("ktlint:standard:no-wildcard-imports")
+
 package io.github.aedev.flow.ui.screens.search
 
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.*
 import androidx.compose.animation.core.*
 import androidx.compose.foundation.*
-import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.*
 import androidx.compose.foundation.lazy.grid.*
@@ -25,27 +29,25 @@ import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.input.pointer.*
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.stringResource
-import androidx.activity.compose.rememberLauncherForActivityResult
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.ui.text.*
+import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.TextFieldValue
-import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.*
-import androidx.compose.ui.platform.LocalSoftwareKeyboardController
-import androidx.compose.ui.platform.LocalFocusManager
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.paging.LoadState
 import androidx.paging.compose.collectAsLazyPagingItems
 import coil.compose.AsyncImage
 import io.github.aedev.flow.R
 import io.github.aedev.flow.data.local.*
+import io.github.aedev.flow.data.local.ContentType
 import io.github.aedev.flow.data.local.SearchFilter
 import io.github.aedev.flow.data.local.SearchHistoryItem
-import io.github.aedev.flow.data.local.ContentType
 import io.github.aedev.flow.data.model.*
 import io.github.aedev.flow.data.paging.SearchResultItem
 import io.github.aedev.flow.data.search.SearchSuggestionsService
@@ -56,7 +58,6 @@ import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
-
 @OptIn(FlowPreview::class, ExperimentalMaterial3Api::class)
 @Composable
 fun SearchScreen(
@@ -64,19 +65,23 @@ fun SearchScreen(
     onChannelClick: (Channel) -> Unit,
     onPlaylistClick: (Playlist) -> Unit,
     modifier: Modifier = Modifier,
-    viewModel: SearchViewModel = hiltViewModel()
+    viewModel: SearchViewModel = hiltViewModel(),
 ) {
     val context = LocalContext.current
     val searchHistoryRepo = remember { SearchHistoryRepository(context) }
-    val preferences = remember { io.github.aedev.flow.data.local.PlayerPreferences(context) }
+    val preferences =
+        remember {
+            io.github.aedev.flow.data.local
+                .PlayerPreferences(context)
+        }
     val uiState by viewModel.uiState.collectAsState()
 
     var searchQuery by rememberSaveable(stateSaver = TextFieldValue.Saver) {
         mutableStateOf(
             TextFieldValue(
                 text = viewModel.uiState.value.query,
-                selection = TextRange(viewModel.uiState.value.query.length)
-            )
+                selection = TextRange(viewModel.uiState.value.query.length),
+            ),
         )
     }
     var isSearchFocused by remember { mutableStateOf(false) }
@@ -85,9 +90,11 @@ fun SearchScreen(
     var hasPerformedSearch by rememberSaveable { mutableStateOf(false) }
     var isNavigatingAway by remember { mutableStateOf(false) }
 
-    val searchHistory by searchHistoryRepo.getSearchHistoryFlow()
+    val searchHistory by searchHistoryRepo
+        .getSearchHistoryFlow()
         .collectAsState(initial = emptyList())
-    val suggestionsEnabled by searchHistoryRepo.isSearchSuggestionsEnabledFlow()
+    val suggestionsEnabled by searchHistoryRepo
+        .isSearchSuggestionsEnabledFlow()
         .collectAsState(initial = true)
     val pagingItems = viewModel.searchResults.collectAsLazyPagingItems()
 
@@ -100,96 +107,108 @@ fun SearchScreen(
 
     var liveSuggestions by remember { mutableStateOf<List<String>>(emptyList()) }
     var isLoadingSuggestions by remember { mutableStateOf(false) }
-    val matchingHistorySuggestions = remember(searchHistory, searchQuery.text) {
-        val queryText = searchQuery.text.trim()
-        if (queryText.isBlank()) {
-            emptyList()
-        } else {
-            val normalizedQuery = queryText.lowercase()
-            val matchingQueries = searchHistory
-                .asSequence()
-                .map { it.query.trim() }
-                .filter { it.isNotBlank() && it.contains(queryText, ignoreCase = true) }
-                .distinctBy { it.lowercase() }
-                .toList()
-            val prefixMatches = matchingQueries.filter { it.lowercase().startsWith(normalizedQuery) }
-            val containsMatches = matchingQueries.filterNot { it.lowercase().startsWith(normalizedQuery) }
-            (prefixMatches + containsMatches).take(5)
-        }
-    }
-    val orderedSuggestions = remember(matchingHistorySuggestions, liveSuggestions) {
-        (matchingHistorySuggestions + liveSuggestions)
-            .distinctBy { it.trim().lowercase() }
-            .take(10)
-    }
-
-    val dismissKeyboard: () -> Unit = remember(focusManager, keyboardController) {
-        {
-            focusManager.clearFocus(force = true)
-            keyboardController?.hide()
-            isSearchFocused = false
-        }
-    }
-
-    val setSearchQueryToEnd: (String) -> Unit = remember {
-        { value ->
-            searchQuery = TextFieldValue(value, selection = TextRange(value.length))
-        }
-    }
-
-    val voiceSearchLauncher = rememberLauncherForActivityResult(
-        contract = ActivityResultContracts.StartActivityForResult()
-    ) { result ->
-        if (result.resultCode == android.app.Activity.RESULT_OK) {
-            val spokenText = result.data
-                ?.getStringArrayListExtra(android.speech.RecognizerIntent.EXTRA_RESULTS)
-                ?.firstOrNull()
-            if (!spokenText.isNullOrBlank()) {
-                setSearchQueryToEnd(spokenText)
-                dismissKeyboard()
-                viewModel.search(spokenText)
+    val matchingHistorySuggestions =
+        remember(searchHistory, searchQuery.text) {
+            val queryText = searchQuery.text.trim()
+            if (queryText.isBlank()) {
+                emptyList()
+            } else {
+                val normalizedQuery = queryText.lowercase()
+                val matchingQueries =
+                    searchHistory
+                        .asSequence()
+                        .map { it.query.trim() }
+                        .filter { it.isNotBlank() && it.contains(queryText, ignoreCase = true) }
+                        .distinctBy { it.lowercase() }
+                        .toList()
+                val prefixMatches = matchingQueries.filter { it.lowercase().startsWith(normalizedQuery) }
+                val containsMatches = matchingQueries.filterNot { it.lowercase().startsWith(normalizedQuery) }
+                (prefixMatches + containsMatches).take(5)
             }
         }
-    }
-    val launchVoiceSearch: () -> Unit = {
-        val intent = android.content.Intent(android.speech.RecognizerIntent.ACTION_RECOGNIZE_SPEECH).apply {
-            putExtra(
-                android.speech.RecognizerIntent.EXTRA_LANGUAGE_MODEL,
-                android.speech.RecognizerIntent.LANGUAGE_MODEL_FREE_FORM
-            )
-            putExtra(android.speech.RecognizerIntent.EXTRA_PROMPT, "Speak to search…")
+    val orderedSuggestions =
+        remember(matchingHistorySuggestions, liveSuggestions) {
+            (matchingHistorySuggestions + liveSuggestions)
+                .distinctBy { it.trim().lowercase() }
+                .take(10)
         }
+
+    val dismissKeyboard: () -> Unit =
+        remember(focusManager, keyboardController) {
+            {
+                focusManager.clearFocus(force = true)
+                keyboardController?.hide()
+                isSearchFocused = false
+            }
+        }
+
+    val setSearchQueryToEnd: (String) -> Unit =
+        remember {
+            { value ->
+                searchQuery = TextFieldValue(value, selection = TextRange(value.length))
+            }
+        }
+
+    val voiceSearchLauncher =
+        rememberLauncherForActivityResult(
+            contract = ActivityResultContracts.StartActivityForResult(),
+        ) { result ->
+            if (result.resultCode == android.app.Activity.RESULT_OK) {
+                val spokenText =
+                    result.data
+                        ?.getStringArrayListExtra(android.speech.RecognizerIntent.EXTRA_RESULTS)
+                        ?.firstOrNull()
+                if (!spokenText.isNullOrBlank()) {
+                    setSearchQueryToEnd(spokenText)
+                    dismissKeyboard()
+                    viewModel.search(spokenText)
+                }
+            }
+        }
+    val launchVoiceSearch: () -> Unit = {
+        val intent =
+            android.content.Intent(android.speech.RecognizerIntent.ACTION_RECOGNIZE_SPEECH).apply {
+                putExtra(
+                    android.speech.RecognizerIntent.EXTRA_LANGUAGE_MODEL,
+                    android.speech.RecognizerIntent.LANGUAGE_MODEL_FREE_FORM,
+                )
+                putExtra(android.speech.RecognizerIntent.EXTRA_PROMPT, "Speak to search…")
+            }
         try {
             voiceSearchLauncher.launch(intent)
-        } catch (_: android.content.ActivityNotFoundException) { }
-    }
-
-    val navigateToVideo: (Video) -> Unit = remember(dismissKeyboard, onVideoClick) {
-        { video ->
-            isNavigatingAway = true
-            hasPerformedSearch = true
-            dismissKeyboard()
-            onVideoClick(video)
+        } catch (_: android.content.ActivityNotFoundException) {
         }
     }
 
-    val navigateToChannel: (Channel) -> Unit = remember(dismissKeyboard, onChannelClick) {
-        { channel ->
-            isNavigatingAway = true
-            hasPerformedSearch = true
-            dismissKeyboard()
-            onChannelClick(channel)
+    val navigateToVideo: (Video) -> Unit =
+        remember(dismissKeyboard, onVideoClick) {
+            { video ->
+                isNavigatingAway = true
+                hasPerformedSearch = true
+                dismissKeyboard()
+                onVideoClick(video)
+            }
         }
-    }
 
-    val navigateToPlaylist: (Playlist) -> Unit = remember(dismissKeyboard, onPlaylistClick) {
-        { playlist ->
-            isNavigatingAway = true
-            hasPerformedSearch = true
-            dismissKeyboard()
-            onPlaylistClick(playlist)
+    val navigateToChannel: (Channel) -> Unit =
+        remember(dismissKeyboard, onChannelClick) {
+            { channel ->
+                isNavigatingAway = true
+                hasPerformedSearch = true
+                dismissKeyboard()
+                onChannelClick(channel)
+            }
         }
-    }
+
+    val navigateToPlaylist: (Playlist) -> Unit =
+        remember(dismissKeyboard, onPlaylistClick) {
+            { playlist ->
+                isNavigatingAway = true
+                hasPerformedSearch = true
+                dismissKeyboard()
+                onPlaylistClick(playlist)
+            }
+        }
 
     LaunchedEffect(Unit) {
         if (!hasPerformedSearch) {
@@ -197,7 +216,8 @@ fun SearchScreen(
             try {
                 focusRequester.requestFocus()
                 keyboardController?.show()
-            } catch (_: Exception) {}
+            } catch (_: Exception) {
+            }
         }
     }
 
@@ -245,15 +265,19 @@ fun SearchScreen(
         }
     }
 
-    val sortByTypes = listOf(
-        SortType.RELEVANCE, SortType.RATING, SortType.VIEWS
-    )
+    val sortByTypes =
+        listOf(
+            SortType.RELEVANCE,
+            SortType.RATING,
+            SortType.VIEWS,
+        )
     val selectedContentType = uiState.filters?.contentType ?: ContentType.ALL
 
     Column(
-        modifier = modifier
-            .fillMaxSize()
-            .background(MaterialTheme.colorScheme.background)
+        modifier =
+            modifier
+                .fillMaxSize()
+                .background(MaterialTheme.colorScheme.background),
     ) {
         SearchBarRow(
             query = searchQuery,
@@ -280,8 +304,8 @@ fun SearchScreen(
                                 duration = 0,
                                 viewCount = 0L,
                                 uploadDate = "",
-                                channelThumbnailUrl = ""
-                            )
+                                channelThumbnailUrl = "",
+                            ),
                         )
                         return@SearchBarRow
                     }
@@ -301,14 +325,15 @@ fun SearchScreen(
                 isSearchFocused = focused
             },
             focusRequester = focusRequester,
-            modifier = Modifier.padding(horizontal = 16.dp, vertical = 10.dp)
+            modifier = Modifier.padding(horizontal = 16.dp, vertical = 10.dp),
         )
 
         AnimatedVisibility(
-            visible = isSearchFocused && searchQuery.text.isNotEmpty() &&
+            visible =
+                isSearchFocused && searchQuery.text.isNotEmpty() &&
                     (orderedSuggestions.isNotEmpty() || isLoadingSuggestions),
             enter = expandVertically() + fadeIn(),
-            exit = shrinkVertically() + fadeOut()
+            exit = shrinkVertically() + fadeOut(),
         ) {
             SuggestionsCard(
                 query = searchQuery.text,
@@ -331,15 +356,15 @@ fun SearchScreen(
                                 duration = 0,
                                 viewCount = 0L,
                                 uploadDate = "",
-                                channelThumbnailUrl = ""
-                            )
+                                channelThumbnailUrl = "",
+                            ),
                         )
                     } else {
                         viewModel.search(s)
                     }
                 },
                 onFillClick = { setSearchQueryToEnd(it) },
-                modifier = Modifier.padding(horizontal = 16.dp)
+                modifier = Modifier.padding(horizontal = 16.dp),
             )
         }
 
@@ -358,7 +383,7 @@ fun SearchScreen(
                 },
                 onClearHistory = {
                     scope.launch { searchHistoryRepo.clearSearchHistory() }
-                }
+                },
             )
         } else {
             SearchFiltersBar(
@@ -383,7 +408,7 @@ fun SearchScreen(
                 onSelectedSortType = {
                     val base = uiState.filters ?: SearchFilter()
                     viewModel.updateFilters(base.copy(sortType = it))
-                }
+                },
             )
 
             val isInitialLoading =
@@ -392,50 +417,68 @@ fun SearchScreen(
                 pagingItems.loadState.refresh is LoadState.Error && pagingItems.itemCount == 0
 
             BoxWithConstraints(modifier = Modifier.weight(1f)) {
-                val responsiveColumns = when {
-                    maxWidth < 700.dp -> 1
-                    maxWidth < 900.dp -> 2
-                    maxWidth < 1200.dp -> 3
-                    else -> 4
-                }
+                val responsiveColumns =
+                    when {
+                        maxWidth < 700.dp -> 1
+                        maxWidth < 900.dp -> 2
+                        maxWidth < 1200.dp -> 3
+                        else -> 4
+                    }
 
-                val responsiveGridColumns = when {
-                    maxWidth < 600.dp -> 1
-                    maxWidth < 900.dp -> 2
-                    maxWidth < 1200.dp -> 3
-                    else -> 4
-                }
+                val responsiveGridColumns =
+                    when {
+                        maxWidth < 600.dp -> 1
+                        maxWidth < 900.dp -> 2
+                        maxWidth < 1200.dp -> 3
+                        else -> 4
+                    }
 
                 val columns = if (isGridMode) responsiveGridColumns else responsiveColumns
 
                 when {
-                    isInitialLoading -> ShimmerResultsScreen(isGridMode, columns)
+                    isInitialLoading -> {
+                        ShimmerResultsScreen(isGridMode, columns)
+                    }
+
                     isInitialError -> {
                         val err =
                             (pagingItems.loadState.refresh as LoadState.Error).error
                         SearchErrorState(
                             message = err.localizedMessage ?: "Search failed",
-                            onRetry = pagingItems::retry
+                            onRetry = pagingItems::retry,
                         )
                     }
+
                     selectedContentType == ContentType.SHORTS -> {
                         SearchShortsGrid(
-                            pagingItems, gridState, maxOf(columns, 2),
-                            navigateToVideo, dismissKeyboard
+                            pagingItems,
+                            gridState,
+                            maxOf(columns, 2),
+                            navigateToVideo,
+                            dismissKeyboard,
                         )
                     }
+
                     else -> {
                         if (isGridMode) {
                             SearchResultGrid(
-                                pagingItems, gridState, columns,
-                                navigateToVideo, navigateToChannel, navigateToPlaylist,
-                                dismissKeyboard
+                                pagingItems,
+                                gridState,
+                                columns,
+                                navigateToVideo,
+                                navigateToChannel,
+                                navigateToPlaylist,
+                                dismissKeyboard,
                             )
                         } else {
                             SearchResultList(
-                                pagingItems, gridState, columns,
-                                navigateToVideo, navigateToChannel, navigateToPlaylist,
-                                dismissKeyboard
+                                pagingItems,
+                                gridState,
+                                columns,
+                                navigateToVideo,
+                                navigateToChannel,
+                                navigateToPlaylist,
+                                dismissKeyboard,
                             )
                         }
                     }
@@ -447,13 +490,14 @@ fun SearchScreen(
 
 private fun extractVideoId(url: String): String? {
     if (!isSupportedVideoUrl(url)) return null
-    val patterns = listOf(
-        Regex("v=([^&]+)"),
-        Regex("shorts/([^/?]+)"),
-        Regex("youtu.be/([^/?]+)"),
-        Regex("embed/([^/?]+)"),
-        Regex("v/([^/?]+)")
-    )
+    val patterns =
+        listOf(
+            Regex("v=([^&]+)"),
+            Regex("shorts/([^/?]+)"),
+            Regex("youtu.be/([^/?]+)"),
+            Regex("embed/([^/?]+)"),
+            Regex("v/([^/?]+)"),
+        )
     for (pattern in patterns) {
         val match = pattern.find(url)
         if (match != null) return match.groupValues[1]
@@ -481,123 +525,138 @@ private fun SearchBarRow(
     isSearchFocused: Boolean,
     onFocusChange: (Boolean) -> Unit,
     focusRequester: FocusRequester,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     val focusAnim by animateFloatAsState(
         targetValue = if (isSearchFocused) 1f else 0f,
         animationSpec = tween(300),
-        label = "focus"
+        label = "focus",
     )
     val primary = MaterialTheme.colorScheme.primary
     val keyboardController = LocalSoftwareKeyboardController.current
 
     Box(
-        modifier = modifier
-            .fillMaxWidth()
-            .height(48.dp)
-            .clip(RoundedCornerShape(23.dp))
-            .drawBehind {
-                if (focusAnim > 0f) {
-                    drawRoundRect(
-                        brush = Brush.sweepGradient(
-                            listOf(
-                                primary.copy(alpha = focusAnim * 0.9f),
-                                primary.copy(alpha = focusAnim * 0.3f),
-                                primary.copy(alpha = focusAnim * 0.9f)
-                            )
-                        ),
-                        cornerRadius = androidx.compose.ui.geometry.CornerRadius(
-                            23.dp.toPx()
-                        ),
-                        style = Stroke(width = (2.5f * focusAnim).dp.toPx())
-                    )
-                }
-            }
-            .background(
-                color = if (isSearchFocused)
-                    MaterialTheme.colorScheme.surface
-                else
-                    MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.6f),
-                shape = RoundedCornerShape(23.dp)
-            )
-            .clickable(
-                indication = null,
-                interactionSource = remember { 
-                    androidx.compose.foundation.interaction.MutableInteractionSource() 
-                }
-            ) {
-                focusRequester.requestFocus()
-                keyboardController?.show()
-            }
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .height(48.dp)
+                .clip(RoundedCornerShape(23.dp))
+                .drawBehind {
+                    if (focusAnim > 0f) {
+                        drawRoundRect(
+                            brush =
+                                Brush.sweepGradient(
+                                    listOf(
+                                        primary.copy(alpha = focusAnim * 0.9f),
+                                        primary.copy(alpha = focusAnim * 0.3f),
+                                        primary.copy(alpha = focusAnim * 0.9f),
+                                    ),
+                                ),
+                            cornerRadius =
+                                androidx.compose.ui.geometry.CornerRadius(
+                                    23.dp.toPx(),
+                                ),
+                            style = Stroke(width = (2.5f * focusAnim).dp.toPx()),
+                        )
+                    }
+                }.background(
+                    color =
+                        if (isSearchFocused) {
+                            MaterialTheme.colorScheme.surface
+                        } else {
+                            MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.6f)
+                        },
+                    shape = RoundedCornerShape(23.dp),
+                ).clickable(
+                    indication = null,
+                    interactionSource =
+                        remember {
+                            androidx.compose.foundation.interaction
+                                .MutableInteractionSource()
+                        },
+                ) {
+                    focusRequester.requestFocus()
+                    keyboardController?.show()
+                },
     ) {
         Row(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(start = 16.dp),
-            verticalAlignment = Alignment.CenterVertically
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .padding(start = 16.dp),
+            verticalAlignment = Alignment.CenterVertically,
         ) {
             Icon(
                 Icons.Outlined.Search,
                 contentDescription = null,
-                tint = if (isSearchFocused) primary
-                else MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.size(20.dp)
+                tint =
+                    if (isSearchFocused) {
+                        primary
+                    } else {
+                        MaterialTheme.colorScheme.onSurfaceVariant
+                    },
+                modifier = Modifier.size(20.dp),
             )
             Spacer(modifier = Modifier.width(8.dp))
 
             BasicTextField(
                 value = query,
                 onValueChange = onQueryChange,
-                modifier = Modifier
-                    .weight(1f)
-                    .focusRequester(focusRequester)
-                    .onFocusChanged { state ->
-                        onFocusChange(state.isFocused)
-                    },
-                textStyle = MaterialTheme.typography.bodyMedium.copy(
-                    color = MaterialTheme.colorScheme.onSurface,
-                    fontSize = 16.sp
-                ),
+                modifier =
+                    Modifier
+                        .weight(1f)
+                        .focusRequester(focusRequester)
+                        .onFocusChanged { state ->
+                            onFocusChange(state.isFocused)
+                        },
+                textStyle =
+                    MaterialTheme.typography.bodyMedium.copy(
+                        color = MaterialTheme.colorScheme.onSurface,
+                        fontSize = 16.sp,
+                    ),
                 singleLine = true,
                 keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
-                keyboardActions = KeyboardActions(
-                    onSearch = { if (query.text.isNotBlank()) onSearch() }
-                ),
+                keyboardActions =
+                    KeyboardActions(
+                        onSearch = { if (query.text.isNotBlank()) onSearch() },
+                    ),
                 cursorBrush = SolidColor(primary),
                 decorationBox = { innerTextField ->
                     Box(
                         modifier = Modifier.fillMaxWidth(),
-                        contentAlignment = Alignment.CenterStart
+                        contentAlignment = Alignment.CenterStart,
                     ) {
                         if (query.text.isEmpty()) {
                             Text(
                                 stringResource(R.string.search_videos_channels_placeholder),
                                 style = MaterialTheme.typography.bodyMedium,
-                                color = MaterialTheme.colorScheme.onSurfaceVariant.copy(
-                                    alpha = 0.55f
-                                ),
-                                fontSize = 16.sp
+                                color =
+                                    MaterialTheme.colorScheme.onSurfaceVariant.copy(
+                                        alpha = 0.55f,
+                                    ),
+                                fontSize = 16.sp,
                             )
                         }
                         innerTextField()
                     }
-                }
+                },
             )
 
             if (query.text.isEmpty()) {
                 Box(
-                    modifier = Modifier
-                        .padding(end = 2.dp)
-                        .size(36.dp)
-                        .clip(CircleShape)
-                        .clickable(onClick = onVoiceSearch),
-                    contentAlignment = Alignment.Center
+                    modifier =
+                        Modifier
+                            .padding(end = 2.dp)
+                            .size(36.dp)
+                            .clip(CircleShape)
+                            .clickable(onClick = onVoiceSearch),
+                    contentAlignment = Alignment.Center,
                 ) {
                     Icon(
                         Icons.Outlined.Mic,
                         contentDescription = stringResource(R.string.voice_search_cd),
                         tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.size(20.dp)
+                        modifier = Modifier.size(20.dp),
                     )
                 }
             } else {
@@ -606,7 +665,7 @@ private fun SearchBarRow(
                         Icons.Filled.Close,
                         contentDescription = stringResource(R.string.clear),
                         tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.size(18.dp)
+                        modifier = Modifier.size(18.dp),
                     )
                 }
             }
@@ -627,47 +686,56 @@ private fun SearchFiltersBar(
     isGridMode: Boolean,
     onToggleGridMode: () -> Unit,
 ) {
-    val showVideoFilters = selectedContentType in listOf(
-        ContentType.ALL, ContentType.VIDEOS, ContentType.LIVE
-    )
-    val typeLabels = listOf(
-        ContentType.ALL to R.string.search_filter_all,
-        ContentType.VIDEOS to R.string.videos_header,
-        ContentType.SHORTS to R.string.tab_shorts,
-        ContentType.CHANNELS to R.string.channels_header,
-        ContentType.PLAYLISTS to R.string.tab_playlists,
-        ContentType.LIVE to R.string.tab_live
-    )
-    val durationLabels = listOf(
-        Duration.ANY to R.string.duration_any,
-        Duration.UNDER_4_MINUTES to R.string.duration_under_4,
-        Duration.FROM_4_TO_20_MINUTES to R.string.duration_4_20,
-        Duration.OVER_20_MINUTES to R.string.duration_over_20
-    )
-    val uploadDateLabels = listOf(
-        UploadDate.ANY to R.string.date_any,
-        UploadDate.TODAY to R.string.date_today,
-        UploadDate.THIS_WEEK to R.string.date_this_week,
-        UploadDate.THIS_MONTH to R.string.date_this_month,
-        UploadDate.THIS_YEAR to R.string.date_this_year
-    )
-    val sortTypeLabels = listOf(
-        SortType.RELEVANCE to R.string.sort_relevance,
-        SortType.RATING to R.string.sort_rating,
-        SortType.VIEWS to R.string.views
-    )
+    val showVideoFilters =
+        selectedContentType in
+            listOf(
+                ContentType.ALL,
+                ContentType.VIDEOS,
+                ContentType.LIVE,
+            )
+    val typeLabels =
+        listOf(
+            ContentType.ALL to R.string.search_filter_all,
+            ContentType.VIDEOS to R.string.videos_header,
+            ContentType.SHORTS to R.string.tab_shorts,
+            ContentType.CHANNELS to R.string.channels_header,
+            ContentType.PLAYLISTS to R.string.tab_playlists,
+            ContentType.LIVE to R.string.tab_live,
+        )
+    val durationLabels =
+        listOf(
+            Duration.ANY to R.string.duration_any,
+            Duration.UNDER_4_MINUTES to R.string.duration_under_4,
+            Duration.FROM_4_TO_20_MINUTES to R.string.duration_4_20,
+            Duration.OVER_20_MINUTES to R.string.duration_over_20,
+        )
+    val uploadDateLabels =
+        listOf(
+            UploadDate.ANY to R.string.date_any,
+            UploadDate.TODAY to R.string.date_today,
+            UploadDate.THIS_WEEK to R.string.date_this_week,
+            UploadDate.THIS_MONTH to R.string.date_this_month,
+            UploadDate.THIS_YEAR to R.string.date_this_year,
+        )
+    val sortTypeLabels =
+        listOf(
+            SortType.RELEVANCE to R.string.sort_relevance,
+            SortType.RATING to R.string.sort_rating,
+            SortType.VIEWS to R.string.views,
+        )
 
     Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(horizontal = 8.dp, vertical = 4.dp),
-        verticalAlignment = Alignment.CenterVertically
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 8.dp, vertical = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
     ) {
         LazyRow(
             modifier = Modifier.weight(1f),
             horizontalArrangement = Arrangement.spacedBy(8.dp),
             contentPadding = PaddingValues(horizontal = 8.dp),
-            verticalAlignment = Alignment.CenterVertically
+            verticalAlignment = Alignment.CenterVertically,
         ) {
             item {
                 var typeExpanded by remember { mutableStateOf(false) }
@@ -683,22 +751,25 @@ private fun SearchFiltersBar(
                         },
                         trailingIcon = {
                             Icon(Icons.Default.ArrowDropDown, null, Modifier.size(16.dp))
-                        }
+                        },
                     )
                     DropdownMenu(
                         expanded = typeExpanded,
-                        onDismissRequest = { typeExpanded = false }
+                        onDismissRequest = { typeExpanded = false },
                     ) {
                         typeLabels.forEach { (type, labelRes) ->
                             DropdownMenuItem(
                                 text = { Text(stringResource(labelRes)) },
-                                leadingIcon = if (type == selectedContentType) {
-                                    { Icon(Icons.Default.Check, null, Modifier.size(16.dp)) }
-                                } else null,
+                                leadingIcon =
+                                    if (type == selectedContentType) {
+                                        { Icon(Icons.Default.Check, null, Modifier.size(16.dp)) }
+                                    } else {
+                                        null
+                                    },
                                 onClick = {
                                     onContentTypeSelected(type)
                                     typeExpanded = false
-                                }
+                                },
                             )
                         }
                     }
@@ -717,22 +788,25 @@ private fun SearchFiltersBar(
                             },
                             trailingIcon = {
                                 Icon(Icons.Default.ArrowDropDown, null, Modifier.size(16.dp))
-                            }
+                            },
                         )
                         DropdownMenu(
                             expanded = durationExpanded,
-                            onDismissRequest = { durationExpanded = false }
+                            onDismissRequest = { durationExpanded = false },
                         ) {
                             durationLabels.forEach { (dur, labelRes) ->
                                 DropdownMenuItem(
                                     text = { Text(stringResource(labelRes)) },
-                                    leadingIcon = if (dur == selectedDuration) {
-                                        { Icon(Icons.Default.Check, null, Modifier.size(16.dp)) }
-                                    } else null,
+                                    leadingIcon =
+                                        if (dur == selectedDuration) {
+                                            { Icon(Icons.Default.Check, null, Modifier.size(16.dp)) }
+                                        } else {
+                                            null
+                                        },
                                     onClick = {
                                         onDurationSelected(dur)
                                         durationExpanded = false
-                                    }
+                                    },
                                 )
                             }
                         }
@@ -750,22 +824,25 @@ private fun SearchFiltersBar(
                             },
                             trailingIcon = {
                                 Icon(Icons.Default.ArrowDropDown, null, Modifier.size(16.dp))
-                            }
+                            },
                         )
                         DropdownMenu(
                             expanded = dateExpanded,
-                            onDismissRequest = { dateExpanded = false }
+                            onDismissRequest = { dateExpanded = false },
                         ) {
                             uploadDateLabels.forEach { (date, labelRes) ->
                                 DropdownMenuItem(
                                     text = { Text(stringResource(labelRes)) },
-                                    leadingIcon = if (date == selectedUploadDate) {
-                                        { Icon(Icons.Default.Check, null, Modifier.size(16.dp)) }
-                                    } else null,
+                                    leadingIcon =
+                                        if (date == selectedUploadDate) {
+                                            { Icon(Icons.Default.Check, null, Modifier.size(16.dp)) }
+                                        } else {
+                                            null
+                                        },
                                     onClick = {
                                         onUploadDateSelected(date)
                                         dateExpanded = false
-                                    }
+                                    },
                                 )
                             }
                         }
@@ -782,22 +859,25 @@ private fun SearchFiltersBar(
                             },
                             trailingIcon = {
                                 Icon(Icons.Default.ArrowDropDown, null, Modifier.size(16.dp))
-                            }
+                            },
                         )
                         DropdownMenu(
                             expanded = sortExpanded,
-                            onDismissRequest = { sortExpanded = false }
+                            onDismissRequest = { sortExpanded = false },
                         ) {
                             sortTypeLabels.forEach { (sort, labelRes) ->
                                 DropdownMenuItem(
                                     text = { Text(stringResource(labelRes)) },
-                                    leadingIcon = if (sort == selectedSortType) {
-                                        { Icon(Icons.Default.Check, null, Modifier.size(16.dp)) }
-                                    } else null,
+                                    leadingIcon =
+                                        if (sort == selectedSortType) {
+                                            { Icon(Icons.Default.Check, null, Modifier.size(16.dp)) }
+                                        } else {
+                                            null
+                                        },
                                     onClick = {
                                         onSelectedSortType(sort)
                                         sortExpanded = false
-                                    }
+                                    },
                                 )
                             }
                         }
@@ -807,44 +887,56 @@ private fun SearchFiltersBar(
         }
 
         Box(
-            modifier = Modifier
-                .padding(start = 2.dp, end = 6.dp)
-                .size(36.dp)
-                .clip(CircleShape)
-                .background(
-                    if (isGridMode) MaterialTheme.colorScheme.primary
-                    else Color.Transparent
-                )
-                .clickable(onClick = onToggleGridMode),
-            contentAlignment = Alignment.Center
+            modifier =
+                Modifier
+                    .padding(start = 2.dp, end = 6.dp)
+                    .size(36.dp)
+                    .clip(CircleShape)
+                    .background(
+                        if (isGridMode) {
+                            MaterialTheme.colorScheme.primary
+                        } else {
+                            Color.Transparent
+                        },
+                    ).clickable(onClick = onToggleGridMode),
+            contentAlignment = Alignment.Center,
         ) {
             Icon(
                 if (isGridMode) Icons.Outlined.ViewList else Icons.Outlined.GridView,
                 contentDescription = stringResource(R.string.search_toggle_view_mode),
-                tint = if (isGridMode) MaterialTheme.colorScheme.onPrimary
-                       else MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.size(20.dp)
+                tint =
+                    if (isGridMode) {
+                        MaterialTheme.colorScheme.onPrimary
+                    } else {
+                        MaterialTheme.colorScheme.onSurfaceVariant
+                    },
+                modifier = Modifier.size(20.dp),
             )
         }
     }
 }
 
-private fun searchItemKey(item: SearchResultItem?, index: Int): Any = when (item) {
-    is SearchResultItem.VideoResult -> "v_${item.video.id}"
-    is SearchResultItem.ChannelResult -> "c_${item.channel.id}"
-    is SearchResultItem.PlaylistResult -> "p_${item.playlist.id}"
-    is SearchResultItem.ShortsShelfResult -> SHORTS_SHELF_KEY
-    null -> "placeholder_$index"
-}
+private fun searchItemKey(
+    item: SearchResultItem?,
+    index: Int,
+): Any =
+    when (item) {
+        is SearchResultItem.VideoResult -> "v_${item.video.id}"
+        is SearchResultItem.ChannelResult -> "c_${item.channel.id}"
+        is SearchResultItem.PlaylistResult -> "p_${item.playlist.id}"
+        is SearchResultItem.ShortsShelfResult -> SHORTS_SHELF_KEY
+        null -> "placeholder_$index"
+    }
 
 /** Lets the grid reuse an item's composition when a slot is filled by another item of the same kind. */
-private fun searchItemContentType(item: SearchResultItem?): Any = when (item) {
-    is SearchResultItem.VideoResult -> "video"
-    is SearchResultItem.ChannelResult -> "channel"
-    is SearchResultItem.PlaylistResult -> "playlist"
-    is SearchResultItem.ShortsShelfResult -> SHORTS_SHELF_KEY
-    null -> "placeholder"
-}
+private fun searchItemContentType(item: SearchResultItem?): Any =
+    when (item) {
+        is SearchResultItem.VideoResult -> "video"
+        is SearchResultItem.ChannelResult -> "channel"
+        is SearchResultItem.PlaylistResult -> "playlist"
+        is SearchResultItem.ShortsShelfResult -> SHORTS_SHELF_KEY
+        null -> "placeholder"
+    }
 
 private const val SHORTS_SHELF_KEY = "shortsShelf"
 
@@ -856,49 +948,57 @@ private fun SearchResultList(
     onVideoClick: (Video) -> Unit,
     onChannelClick: (Channel) -> Unit,
     onPlaylistClick: (Playlist) -> Unit,
-    dismissKeyboard: () -> Unit
+    dismissKeyboard: () -> Unit,
 ) {
     LazyVerticalGrid(
         state = gridState,
         columns = GridCells.Fixed(columns),
-        modifier = Modifier
-            .fillMaxSize()
-            .pointerInput(Unit) {
-                awaitPointerEventScope {
-                    while (true) {
-                        val event = awaitPointerEvent(
-                            pass = androidx.compose.ui.input.pointer.PointerEventPass.Initial
-                        )
-                        if (event.changes.any { it.pressed }) {
-                            dismissKeyboard()
+        modifier =
+            Modifier
+                .fillMaxSize()
+                .pointerInput(Unit) {
+                    awaitPointerEventScope {
+                        while (true) {
+                            val event =
+                                awaitPointerEvent(
+                                    pass = androidx.compose.ui.input.pointer.PointerEventPass.Initial,
+                                )
+                            if (event.changes.any { it.pressed }) {
+                                dismissKeyboard()
+                            }
                         }
                     }
-                }
-            },
-        contentPadding = PaddingValues(
-            start = if (columns == 1) 0.dp else 16.dp,
-            end = if (columns == 1) 0.dp else 16.dp,
-            top = 8.dp,
-            bottom = 90.dp
-        ),
-        horizontalArrangement = Arrangement.spacedBy(
-            if (columns == 1) 0.dp else 12.dp
-        ),
-        verticalArrangement = Arrangement.spacedBy(
-            if (columns == 1) 0.dp else 12.dp
-        )
+                },
+        contentPadding =
+            PaddingValues(
+                start = if (columns == 1) 0.dp else 16.dp,
+                end = if (columns == 1) 0.dp else 16.dp,
+                top = 8.dp,
+                bottom = 90.dp,
+            ),
+        horizontalArrangement =
+            Arrangement.spacedBy(
+                if (columns == 1) 0.dp else 12.dp,
+            ),
+        verticalArrangement =
+            Arrangement.spacedBy(
+                if (columns == 1) 0.dp else 12.dp,
+            ),
     ) {
         items(
             count = pagingItems.itemCount,
             key = { i -> searchItemKey(pagingItems.peek(i), i) },
             contentType = { i -> searchItemContentType(pagingItems.peek(i)) },
             span = { i ->
-                if (pagingItems.peek(i) is SearchResultItem.ShortsShelfResult)
-                    GridItemSpan(maxLineSpan) else GridItemSpan(1)
-            }
+                if (pagingItems.peek(i) is SearchResultItem.ShortsShelfResult) {
+                    GridItemSpan(maxLineSpan)
+                } else {
+                    GridItemSpan(1)
+                }
+            },
         ) { i ->
             when (val item = pagingItems[i]) {
-                is SearchResultItem.VideoResult ->
+                is SearchResultItem.VideoResult -> {
                     VideoCardFullWidth(
                         video = item.video,
                         modifier = Modifier.padding(vertical = 4.dp),
@@ -908,31 +1008,42 @@ private fun SearchResultList(
                                 Channel(
                                     id = channelId,
                                     name = item.video.channelName,
-                                    thumbnailUrl = item.video.channelThumbnailUrl
-                                        ?: "",
+                                    thumbnailUrl =
+                                        item.video.channelThumbnailUrl
+                                            ?: "",
                                     subscriberCount = 0,
-                                    url = "https://www.youtube.com/channel/$channelId"
-                                )
+                                    url = "https://www.youtube.com/channel/$channelId",
+                                ),
                             )
-                        }
+                        },
                     )
-                is SearchResultItem.ChannelResult ->
+                }
+
+                is SearchResultItem.ChannelResult -> {
                     SearchChannelCard(
                         item.channel,
                         onClick = {
                             onChannelClick(item.channel)
-                        }
+                        },
                     )
-                is SearchResultItem.PlaylistResult ->
+                }
+
+                is SearchResultItem.PlaylistResult -> {
                     PlaylistCard(
                         item.playlist,
                         onClick = {
                             onPlaylistClick(item.playlist)
-                        }
+                        },
                     )
-                is SearchResultItem.ShortsShelfResult ->
+                }
+
+                is SearchResultItem.ShortsShelfResult -> {
                     ShortsShelf(shorts = item.shorts, onShortClick = onVideoClick)
-                null -> Unit
+                }
+
+                null -> {
+                    Unit
+                }
             }
         }
 
@@ -940,7 +1051,7 @@ private fun SearchResultList(
             PagingFooter(
                 pagingItems.loadState.append,
                 pagingItems::retry,
-                pagingItems.itemCount
+                pagingItems.itemCount,
             )
         }
     }
@@ -954,41 +1065,46 @@ private fun SearchResultGrid(
     onVideoClick: (Video) -> Unit,
     onChannelClick: (Channel) -> Unit,
     onPlaylistClick: (Playlist) -> Unit,
-    dismissKeyboard: () -> Unit
+    dismissKeyboard: () -> Unit,
 ) {
     LazyVerticalGrid(
         columns = GridCells.Fixed(columns),
         state = gridState,
-        modifier = Modifier
-            .fillMaxSize()
-            .pointerInput(Unit) {
-                awaitPointerEventScope {
-                    while (true) {
-                        val event = awaitPointerEvent(
-                            pass = androidx.compose.ui.input.pointer.PointerEventPass.Initial
-                        )
-                        if (event.changes.any { it.pressed }) {
-                            dismissKeyboard()
+        modifier =
+            Modifier
+                .fillMaxSize()
+                .pointerInput(Unit) {
+                    awaitPointerEventScope {
+                        while (true) {
+                            val event =
+                                awaitPointerEvent(
+                                    pass = androidx.compose.ui.input.pointer.PointerEventPass.Initial,
+                                )
+                            if (event.changes.any { it.pressed }) {
+                                dismissKeyboard()
+                            }
                         }
                     }
-                }
-            },
+                },
         contentPadding = PaddingValues(12.dp),
         horizontalArrangement = Arrangement.spacedBy(12.dp),
-        verticalArrangement = Arrangement.spacedBy(14.dp)
+        verticalArrangement = Arrangement.spacedBy(14.dp),
     ) {
         items(
             count = pagingItems.itemCount,
             key = { i -> searchItemKey(pagingItems.peek(i), i) },
             contentType = { i -> searchItemContentType(pagingItems.peek(i)) },
             span = { i ->
-                if (pagingItems.peek(i) is SearchResultItem.ShortsShelfResult)
-                    GridItemSpan(maxLineSpan) else GridItemSpan(1)
-            }
+                if (pagingItems.peek(i) is SearchResultItem.ShortsShelfResult) {
+                    GridItemSpan(maxLineSpan)
+                } else {
+                    GridItemSpan(1)
+                }
+            },
         ) { i ->
             val item = pagingItems[i] ?: return@items
             when (item) {
-                is SearchResultItem.VideoResult ->
+                is SearchResultItem.VideoResult -> {
                     CompactVideoCard(
                         video = item.video,
                         onClick = {
@@ -999,30 +1115,38 @@ private fun SearchResultGrid(
                                 Channel(
                                     id = channelId,
                                     name = item.video.channelName,
-                                    thumbnailUrl = item.video.channelThumbnailUrl
-                                        ?: "",
+                                    thumbnailUrl =
+                                        item.video.channelThumbnailUrl
+                                            ?: "",
                                     subscriberCount = 0,
-                                    url = "https://www.youtube.com/channel/$channelId"
-                                )
+                                    url = "https://www.youtube.com/channel/$channelId",
+                                ),
                             )
-                        }
+                        },
                     )
-                is SearchResultItem.ChannelResult ->
+                }
+
+                is SearchResultItem.ChannelResult -> {
                     SearchChannelCardCompact(
                         item.channel,
                         onClick = {
                             onChannelClick(item.channel)
-                        }
+                        },
                     )
-                is SearchResultItem.PlaylistResult ->
+                }
+
+                is SearchResultItem.PlaylistResult -> {
                     SearchPlaylistCardCompact(
                         item.playlist,
                         onClick = {
                             onPlaylistClick(item.playlist)
-                        }
+                        },
                     )
-                is SearchResultItem.ShortsShelfResult ->
+                }
+
+                is SearchResultItem.ShortsShelfResult -> {
                     ShortsShelf(shorts = item.shorts, onShortClick = onVideoClick)
+                }
             }
         }
 
@@ -1030,7 +1154,7 @@ private fun SearchResultGrid(
             PagingFooter(
                 pagingItems.loadState.append,
                 pagingItems::retry,
-                pagingItems.itemCount
+                pagingItems.itemCount,
             )
         }
     }
@@ -1043,39 +1167,41 @@ private fun SearchShortsGrid(
     gridState: LazyGridState,
     columns: Int,
     onVideoClick: (Video) -> Unit,
-    dismissKeyboard: () -> Unit
+    dismissKeyboard: () -> Unit,
 ) {
     LazyVerticalGrid(
         columns = GridCells.Fixed(columns),
         state = gridState,
-        modifier = Modifier
-            .fillMaxSize()
-            .pointerInput(Unit) {
-                awaitPointerEventScope {
-                    while (true) {
-                        val event = awaitPointerEvent(
-                            pass = androidx.compose.ui.input.pointer.PointerEventPass.Initial
-                        )
-                        if (event.changes.any { it.pressed }) {
-                            dismissKeyboard()
+        modifier =
+            Modifier
+                .fillMaxSize()
+                .pointerInput(Unit) {
+                    awaitPointerEventScope {
+                        while (true) {
+                            val event =
+                                awaitPointerEvent(
+                                    pass = androidx.compose.ui.input.pointer.PointerEventPass.Initial,
+                                )
+                            if (event.changes.any { it.pressed }) {
+                                dismissKeyboard()
+                            }
                         }
                     }
-                }
-            },
+                },
         contentPadding = PaddingValues(start = 12.dp, end = 12.dp, top = 8.dp, bottom = 90.dp),
         horizontalArrangement = Arrangement.spacedBy(12.dp),
-        verticalArrangement = Arrangement.spacedBy(14.dp)
+        verticalArrangement = Arrangement.spacedBy(14.dp),
     ) {
         items(
             count = pagingItems.itemCount,
             key = { i -> searchItemKey(pagingItems.peek(i), i) },
-            contentType = { i -> searchItemContentType(pagingItems.peek(i)) }
+            contentType = { i -> searchItemContentType(pagingItems.peek(i)) },
         ) { i ->
             (pagingItems[i] as? SearchResultItem.VideoResult)?.let {
                 ShortsCard(
                     video = it.video,
                     onClick = { onVideoClick(it.video) },
-                    modifier = Modifier.fillMaxWidth()
+                    modifier = Modifier.fillMaxWidth(),
                 )
             }
         }
@@ -1084,7 +1210,7 @@ private fun SearchShortsGrid(
             PagingFooter(
                 pagingItems.loadState.append,
                 pagingItems::retry,
-                pagingItems.itemCount
+                pagingItems.itemCount,
             )
         }
     }
@@ -1094,39 +1220,40 @@ private fun SearchShortsGrid(
 private fun PagingFooter(
     appendState: LoadState,
     onRetry: () -> Unit,
-    itemCount: Int
+    itemCount: Int,
 ) {
     when {
         appendState is LoadState.Loading -> {
             Box(Modifier.fillMaxWidth().padding(20.dp), Alignment.Center) {
                 Row(
                     verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(10.dp)
+                    horizontalArrangement = Arrangement.spacedBy(10.dp),
                 ) {
                     CircularProgressIndicator(
                         modifier = Modifier.size(18.dp),
                         strokeWidth = 2.dp,
-                        color = MaterialTheme.colorScheme.primary
+                        color = MaterialTheme.colorScheme.primary,
                     )
                     Text(
                         "Loading more\u2026",
                         style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
                 }
             }
         }
+
         appendState is LoadState.Error -> {
             Column(
                 modifier = Modifier.fillMaxWidth().padding(16.dp),
                 horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.spacedBy(8.dp)
+                verticalArrangement = Arrangement.spacedBy(8.dp),
             ) {
                 Text(
                     appendState.error.localizedMessage ?: "Load failed",
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.error,
-                    maxLines = 2
+                    maxLines = 2,
                 )
                 OutlinedButton(onClick = onRetry) {
                     Icon(Icons.Default.Refresh, null, modifier = Modifier.size(16.dp))
@@ -1135,19 +1262,21 @@ private fun PagingFooter(
                 }
             }
         }
+
         appendState.endOfPaginationReached && itemCount > 0 -> {
             Box(Modifier.fillMaxWidth().padding(20.dp), Alignment.Center) {
                 Row(
                     verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
                 ) {
                     HorizontalDivider(Modifier.weight(1f))
                     Text(
                         "End of results",
                         style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(
-                            alpha = 0.5f
-                        )
+                        color =
+                            MaterialTheme.colorScheme.onSurfaceVariant.copy(
+                                alpha = 0.5f,
+                            ),
                     )
                     HorizontalDivider(Modifier.weight(1f))
                 }
@@ -1157,14 +1286,17 @@ private fun PagingFooter(
 }
 
 @Composable
-private fun ShimmerResultsScreen(isGrid: Boolean, columns: Int) {
+private fun ShimmerResultsScreen(
+    isGrid: Boolean,
+    columns: Int,
+) {
     if (isGrid) {
         LazyVerticalGrid(
             columns = GridCells.Fixed(columns),
             contentPadding = PaddingValues(12.dp),
             horizontalArrangement = Arrangement.spacedBy(10.dp),
             verticalArrangement = Arrangement.spacedBy(10.dp),
-            modifier = Modifier.fillMaxSize()
+            modifier = Modifier.fillMaxSize(),
         ) {
             items(8, key = { "shimmer_$it" }, contentType = { "shimmer" }) { ShimmerGridVideoCard() }
         }
@@ -1172,22 +1304,28 @@ private fun ShimmerResultsScreen(isGrid: Boolean, columns: Int) {
         LazyVerticalGrid(
             columns = GridCells.Fixed(columns),
             modifier = Modifier.fillMaxSize(),
-            contentPadding = PaddingValues(
-                start = if (columns == 1) 0.dp else 16.dp,
-                end = if (columns == 1) 0.dp else 16.dp,
-                top = 8.dp,
-                bottom = 80.dp
-            ),
-            horizontalArrangement = Arrangement.spacedBy(
-                if (columns == 1) 0.dp else 12.dp
-            ),
-            verticalArrangement = Arrangement.spacedBy(
-                if (columns == 1) 0.dp else 12.dp
-            )
+            contentPadding =
+                PaddingValues(
+                    start = if (columns == 1) 0.dp else 16.dp,
+                    end = if (columns == 1) 0.dp else 16.dp,
+                    top = 8.dp,
+                    bottom = 80.dp,
+                ),
+            horizontalArrangement =
+                Arrangement.spacedBy(
+                    if (columns == 1) 0.dp else 12.dp,
+                ),
+            verticalArrangement =
+                Arrangement.spacedBy(
+                    if (columns == 1) 0.dp else 12.dp,
+                ),
         ) {
             items(8, key = { "shimmer_$it" }, contentType = { "shimmer" }) {
-                if (columns == 1) ShimmerVideoCardFullWidth()
-                else ShimmerGridVideoCard()
+                if (columns == 1) {
+                    ShimmerVideoCardFullWidth()
+                } else {
+                    ShimmerGridVideoCard()
+                }
             }
         }
     }
@@ -1198,31 +1336,32 @@ private fun DiscoverScreen(
     searchHistory: List<SearchHistoryItem>,
     onHistoryClick: (String) -> Unit,
     onHistoryDelete: (SearchHistoryItem) -> Unit,
-    onClearHistory: () -> Unit
+    onClearHistory: () -> Unit,
 ) {
     LazyColumn(
         modifier = Modifier.fillMaxSize(),
-        contentPadding = PaddingValues(bottom = 90.dp)
+        contentPadding = PaddingValues(bottom = 90.dp),
     ) {
         if (searchHistory.isNotEmpty()) {
             item {
                 Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 16.dp, vertical = 12.dp),
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .padding(horizontal = 16.dp, vertical = 12.dp),
                     horizontalArrangement = Arrangement.SpaceBetween,
-                    verticalAlignment = Alignment.CenterVertically
+                    verticalAlignment = Alignment.CenterVertically,
                 ) {
                     Text(
                         stringResource(R.string.recent_searches),
                         style = MaterialTheme.typography.titleMedium,
                         fontWeight = FontWeight.Bold,
-                        color = MaterialTheme.colorScheme.onBackground
+                        color = MaterialTheme.colorScheme.onBackground,
                     )
                     TextButton(onClick = onClearHistory) {
                         Text(
                             stringResource(R.string.clear_search_history),
-                            style = MaterialTheme.typography.labelMedium
+                            style = MaterialTheme.typography.labelMedium,
                         )
                     }
                 }
@@ -1231,12 +1370,12 @@ private fun DiscoverScreen(
                 HistoryRow(
                     item = item,
                     onClick = { onHistoryClick(item.query) },
-                    onDelete = { onHistoryDelete(item) }
+                    onDelete = { onHistoryDelete(item) },
                 )
             }
             item {
                 HorizontalDivider(
-                    Modifier.padding(horizontal = 16.dp, vertical = 10.dp)
+                    Modifier.padding(horizontal = 16.dp, vertical = 10.dp),
                 )
             }
         }
@@ -1244,27 +1383,30 @@ private fun DiscoverScreen(
         if (searchHistory.isEmpty()) {
             item {
                 Box(
-                    modifier = Modifier
-                        .fillParentMaxSize()
-                        .padding(bottom = 100.dp),
-                    contentAlignment = Alignment.Center
+                    modifier =
+                        Modifier
+                            .fillParentMaxSize()
+                            .padding(bottom = 100.dp),
+                    contentAlignment = Alignment.Center,
                 ) {
                     Column(horizontalAlignment = Alignment.CenterHorizontally) {
                         Icon(
                             Icons.Outlined.Search,
                             contentDescription = null,
                             modifier = Modifier.size(64.dp),
-                            tint = MaterialTheme.colorScheme.onSurfaceVariant.copy(
-                                alpha = 0.2f
-                            )
+                            tint =
+                                MaterialTheme.colorScheme.onSurfaceVariant.copy(
+                                    alpha = 0.2f,
+                                ),
                         )
                         Spacer(Modifier.height(16.dp))
                         Text(
                             stringResource(R.string.search_empty_prompt),
                             style = MaterialTheme.typography.bodyLarge,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant.copy(
-                                alpha = 0.6f
-                            )
+                            color =
+                                MaterialTheme.colorScheme.onSurfaceVariant.copy(
+                                    alpha = 0.6f,
+                                ),
                         )
                     }
                 }
@@ -1273,28 +1415,31 @@ private fun DiscoverScreen(
     }
 }
 
-
 @Composable
 private fun HistoryRow(
     item: SearchHistoryItem,
     onClick: () -> Unit,
     onDelete: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     Row(
-        modifier = modifier
-            .fillMaxWidth()
-            .clickable(onClick = onClick)
-            .padding(horizontal = 16.dp, vertical = 12.dp),
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .clickable(onClick = onClick)
+                .padding(horizontal = 16.dp, vertical = 12.dp),
         horizontalArrangement = Arrangement.spacedBy(12.dp),
-        verticalAlignment = Alignment.CenterVertically
+        verticalAlignment = Alignment.CenterVertically,
     ) {
         Icon(
-            if (item.type == SearchType.VOICE) Icons.Filled.Mic
-            else Icons.Filled.History,
+            if (item.type == SearchType.VOICE) {
+                Icons.Filled.Mic
+            } else {
+                Icons.Filled.History
+            },
             contentDescription = null,
             tint = MaterialTheme.colorScheme.onSurfaceVariant,
-            modifier = Modifier.size(20.dp)
+            modifier = Modifier.size(20.dp),
         )
         Text(
             item.query,
@@ -1302,13 +1447,14 @@ private fun HistoryRow(
             color = MaterialTheme.colorScheme.onBackground,
             modifier = Modifier.weight(1f),
             maxLines = 1,
-            overflow = TextOverflow.Ellipsis
+            overflow = TextOverflow.Ellipsis,
         )
         IconButton(onClick = onDelete, modifier = Modifier.size(32.dp)) {
             Icon(
-                Icons.Filled.Close, "Remove",
+                Icons.Filled.Close,
+                "Remove",
                 tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.size(16.dp)
+                modifier = Modifier.size(16.dp),
             )
         }
     }
@@ -1321,33 +1467,34 @@ private fun SuggestionsCard(
     isLoading: Boolean,
     onSuggestionClick: (String) -> Unit,
     onFillClick: (String) -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     Card(
         modifier = modifier.fillMaxWidth(),
         elevation = CardDefaults.cardElevation(10.dp),
         colors = CardDefaults.cardColors(MaterialTheme.colorScheme.surface),
-        shape = RoundedCornerShape(18.dp)
+        shape = RoundedCornerShape(18.dp),
     ) {
         LazyColumn(Modifier.heightIn(max = 300.dp)) {
             if (isLoading && suggestions.isEmpty()) {
                 item {
                     Box(
                         Modifier.fillMaxWidth().padding(16.dp),
-                        Alignment.Center
+                        Alignment.Center,
                     ) {
                         CircularProgressIndicator(
                             Modifier.size(20.dp),
-                            strokeWidth = 2.dp
+                            strokeWidth = 2.dp,
                         )
                     }
                 }
             }
             items(suggestions, key = { it }) { s ->
                 SuggestionRow(
-                    s, query,
+                    s,
+                    query,
                     { onSuggestionClick(s) },
-                    { onFillClick(s) }
+                    { onFillClick(s) },
                 )
             }
         }
@@ -1360,20 +1507,22 @@ private fun SuggestionRow(
     query: String,
     onClick: () -> Unit,
     onFill: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     Row(
-        modifier = modifier
-            .fillMaxWidth()
-            .clickable(onClick = onClick)
-            .padding(horizontal = 16.dp, vertical = 13.dp),
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .clickable(onClick = onClick)
+                .padding(horizontal = 16.dp, vertical = 13.dp),
         horizontalArrangement = Arrangement.spacedBy(12.dp),
-        verticalAlignment = Alignment.CenterVertically
+        verticalAlignment = Alignment.CenterVertically,
     ) {
         Icon(
-            Icons.Outlined.Search, null,
+            Icons.Outlined.Search,
+            null,
             tint = MaterialTheme.colorScheme.onSurfaceVariant,
-            modifier = Modifier.size(20.dp)
+            modifier = Modifier.size(20.dp),
         )
         Text(
             buildAnnotatedString {
@@ -1385,67 +1534,74 @@ private fun SuggestionRow(
                     withStyle(
                         SpanStyle(
                             fontWeight = FontWeight.Bold,
-                            color = MaterialTheme.colorScheme.onSurface
-                        )
+                            color = MaterialTheme.colorScheme.onSurface,
+                        ),
                     ) {
                         append(
-                            suggestion.substring(idx, idx + query.length)
+                            suggestion.substring(idx, idx + query.length),
                         )
                     }
                     append(suggestion.substring(idx + query.length))
-                } else append(suggestion)
+                } else {
+                    append(suggestion)
+                }
             },
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             modifier = Modifier.weight(1f),
             maxLines = 1,
-            overflow = TextOverflow.Ellipsis
+            overflow = TextOverflow.Ellipsis,
         )
         IconButton(onClick = onFill, modifier = Modifier.size(32.dp)) {
             Icon(
-                Icons.Outlined.NorthWest, "Fill",
+                Icons.Outlined.NorthWest,
+                "Fill",
                 tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.size(16.dp)
+                modifier = Modifier.size(16.dp),
             )
         }
     }
 }
 
-
 @Composable
 private fun SearchVideoCard(
     video: Video,
     onClick: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     val interactionSource =
-        remember { androidx.compose.foundation.interaction.MutableInteractionSource() }
+        remember {
+            androidx.compose.foundation.interaction
+                .MutableInteractionSource()
+        }
     val isPressed by interactionSource.collectIsPressedAsState()
     val scale by animateFloatAsState(
         if (isPressed) 0.98f else 1f,
         spring(Spring.DampingRatioMediumBouncy, Spring.StiffnessHigh),
-        label = "sc"
+        label = "sc",
     )
 
     Column(
-        modifier = modifier
-            .fillMaxWidth()
-            .scale(scale)
-            .clickable(interactionSource, null, onClick = onClick)
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .scale(scale)
+                .clickable(interactionSource, null, onClick = onClick),
     ) {
         Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .aspectRatio(16f / 9f)
-                .clip(RoundedCornerShape(14.dp))
-                .background(MaterialTheme.colorScheme.surfaceVariant)
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .aspectRatio(16f / 9f)
+                    .clip(RoundedCornerShape(14.dp))
+                    .background(MaterialTheme.colorScheme.surfaceVariant),
         ) {
             VideoThumbnailImage(
                 videoId = video.id,
                 model = video.thumbnailUrl,
                 contentDescription = video.title,
                 modifier = Modifier.fillMaxSize(),
-                contentScale = ContentScale.Crop
+                contentScale = ContentScale.Crop,
             )
 
             Box(
@@ -1457,119 +1613,132 @@ private fun SearchVideoCard(
                         Brush.verticalGradient(
                             listOf(
                                 Color.Transparent,
-                                Color.Black.copy(0.55f)
-                            )
-                        )
-                    )
+                                Color.Black.copy(0.55f),
+                            ),
+                        ),
+                    ),
             )
 
             Surface(
-                modifier = Modifier
-                    .align(Alignment.BottomEnd)
-                    .padding(8.dp),
+                modifier =
+                    Modifier
+                        .align(Alignment.BottomEnd)
+                        .padding(8.dp),
                 shape = RoundedCornerShape(6.dp),
-                color = Color.Black.copy(0.78f)
+                color = Color.Black.copy(0.78f),
             ) {
                 Text(
                     formatDuration(video.duration),
                     style = MaterialTheme.typography.labelSmall,
-                    color = Color.White, fontWeight = FontWeight.Bold,
-                    modifier = Modifier.padding(
-                        horizontal = 6.dp,
-                        vertical = 3.dp
-                    )
+                    color = Color.White,
+                    fontWeight = FontWeight.Bold,
+                    modifier =
+                        Modifier.padding(
+                            horizontal = 6.dp,
+                            vertical = 3.dp,
+                        ),
                 )
             }
 
             if (video.isShort) {
                 Surface(
-                    modifier = Modifier
-                        .align(Alignment.TopStart)
-                        .padding(8.dp),
+                    modifier =
+                        Modifier
+                            .align(Alignment.TopStart)
+                            .padding(8.dp),
                     shape = RoundedCornerShape(6.dp),
-                    color = Color(0xFF1565C0)
+                    color = Color(0xFF1565C0),
                 ) {
                     Text(
                         "SHORT",
                         style = MaterialTheme.typography.labelSmall,
                         color = Color.White,
                         fontWeight = FontWeight.ExtraBold,
-                        modifier = Modifier.padding(
-                            horizontal = 6.dp,
-                            vertical = 3.dp
-                        )
+                        modifier =
+                            Modifier.padding(
+                                horizontal = 6.dp,
+                                vertical = 3.dp,
+                            ),
                     )
                 }
             }
             if (video.isLive) {
                 Surface(
-                    modifier = Modifier
-                        .align(Alignment.TopStart)
-                        .padding(8.dp),
+                    modifier =
+                        Modifier
+                            .align(Alignment.TopStart)
+                            .padding(8.dp),
                     shape = RoundedCornerShape(6.dp),
-                    color = Color(0xFFD32F2F)
+                    color = Color(0xFFD32F2F),
                 ) {
                     Text(
                         "\u25CF LIVE",
                         style = MaterialTheme.typography.labelSmall,
                         color = Color.White,
                         fontWeight = FontWeight.ExtraBold,
-                        modifier = Modifier.padding(
-                            horizontal = 6.dp,
-                            vertical = 3.dp
-                        )
+                        modifier =
+                            Modifier.padding(
+                                horizontal = 6.dp,
+                                vertical = 3.dp,
+                            ),
                     )
                 }
             }
         }
 
         Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(
-                    start = 4.dp,
-                    end = 4.dp,
-                    top = 10.dp,
-                    bottom = 6.dp
-                ),
-            horizontalArrangement = Arrangement.spacedBy(10.dp)
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(
+                        start = 4.dp,
+                        end = 4.dp,
+                        top = 10.dp,
+                        bottom = 6.dp,
+                    ),
+            horizontalArrangement = Arrangement.spacedBy(10.dp),
         ) {
             AsyncImage(
-                model = video.channelThumbnailUrl.takeIf { it.isNotEmpty() }
-                    ?: Icons.Default.AccountCircle,
+                model =
+                    video.channelThumbnailUrl.takeIf { it.isNotEmpty() }
+                        ?: Icons.Default.AccountCircle,
                 contentDescription = video.channelName,
-                modifier = Modifier
-                    .size(34.dp)
-                    .clip(CircleShape)
-                    .background(MaterialTheme.colorScheme.surfaceVariant),
-                contentScale = ContentScale.Crop
+                modifier =
+                    Modifier
+                        .size(34.dp)
+                        .clip(CircleShape)
+                        .background(MaterialTheme.colorScheme.surfaceVariant),
+                contentScale = ContentScale.Crop,
             )
             Column(Modifier.weight(1f)) {
                 Text(
                     video.title,
                     style = MaterialTheme.typography.bodyMedium,
-                    fontWeight = FontWeight.SemiBold, maxLines = 2,
-                    overflow = TextOverflow.Ellipsis, lineHeight = 18.sp,
-                    color = MaterialTheme.colorScheme.onSurface
+                    fontWeight = FontWeight.SemiBold,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                    lineHeight = 18.sp,
+                    color = MaterialTheme.colorScheme.onSurface,
                 )
                 Spacer(Modifier.height(3.dp))
                 Row(
                     verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(4.dp)
+                    horizontalArrangement = Arrangement.spacedBy(4.dp),
                 ) {
                     Text(
                         video.channelName,
                         style = MaterialTheme.typography.labelSmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        maxLines = 1, overflow = TextOverflow.Ellipsis,
-                        modifier = Modifier.weight(1f, fill = false)
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.weight(1f, fill = false),
                     )
                     Dot()
                     Text(
                         formatViewCount(video.viewCount),
                         style = MaterialTheme.typography.labelSmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        maxLines = 1
+                        maxLines = 1,
                     )
                     if (video.uploadDate.isNotBlank()) {
                         Dot()
@@ -1578,7 +1747,7 @@ private fun SearchVideoCard(
                             style = MaterialTheme.typography.labelSmall,
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
                             maxLines = 1,
-                            overflow = TextOverflow.Ellipsis
+                            overflow = TextOverflow.Ellipsis,
                         )
                     }
                 }
@@ -1591,42 +1760,46 @@ private fun SearchVideoCard(
 private fun SearchVideoCardCompact(
     video: Video,
     onClick: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     Column(
-        modifier = modifier
-            .clip(RoundedCornerShape(12.dp))
-            .clickable(onClick = onClick)
+        modifier =
+            modifier
+                .clip(RoundedCornerShape(12.dp))
+                .clickable(onClick = onClick),
     ) {
         Box(
             Modifier
                 .fillMaxWidth()
                 .aspectRatio(16f / 9f)
                 .clip(RoundedCornerShape(12.dp))
-                .background(MaterialTheme.colorScheme.surfaceVariant)
+                .background(MaterialTheme.colorScheme.surfaceVariant),
         ) {
             VideoThumbnailImage(
                 videoId = video.id,
                 model = video.thumbnailUrl,
                 contentDescription = video.title,
                 modifier = Modifier.fillMaxSize(),
-                contentScale = ContentScale.Crop
+                contentScale = ContentScale.Crop,
             )
             Surface(
-                modifier = Modifier
-                    .align(Alignment.BottomEnd)
-                    .padding(6.dp),
+                modifier =
+                    Modifier
+                        .align(Alignment.BottomEnd)
+                        .padding(6.dp),
                 shape = RoundedCornerShape(5.dp),
-                color = Color.Black.copy(0.78f)
+                color = Color.Black.copy(0.78f),
             ) {
                 Text(
                     formatDuration(video.duration),
                     style = MaterialTheme.typography.labelSmall,
-                    color = Color.White, fontWeight = FontWeight.Bold,
-                    modifier = Modifier.padding(
-                        horizontal = 5.dp,
-                        vertical = 2.dp
-                    )
+                    color = Color.White,
+                    fontWeight = FontWeight.Bold,
+                    modifier =
+                        Modifier.padding(
+                            horizontal = 5.dp,
+                            vertical = 2.dp,
+                        ),
                 )
             }
         }
@@ -1637,14 +1810,14 @@ private fun SearchVideoCardCompact(
             fontWeight = FontWeight.SemiBold,
             maxLines = 2,
             overflow = TextOverflow.Ellipsis,
-            color = MaterialTheme.colorScheme.onSurface
+            color = MaterialTheme.colorScheme.onSurface,
         )
         Text(
             video.channelName,
             style = MaterialTheme.typography.labelSmall,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
             maxLines = 1,
-            overflow = TextOverflow.Ellipsis
+            overflow = TextOverflow.Ellipsis,
         )
     }
 }
@@ -1653,23 +1826,25 @@ private fun SearchVideoCardCompact(
 private fun SearchChannelCard(
     channel: Channel,
     onClick: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     val primary = MaterialTheme.colorScheme.primary
     Surface(
-        modifier = modifier
-            .fillMaxWidth()
-            .padding(horizontal = 12.dp, vertical = 5.dp)
-            .clickable(onClick = onClick),
+        modifier =
+            modifier
+                .fillMaxWidth()
+                .padding(horizontal = 12.dp, vertical = 5.dp)
+                .clickable(onClick = onClick),
         shape = RoundedCornerShape(18.dp),
         color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.35f),
-        tonalElevation = 1.dp
+        tonalElevation = 1.dp,
     ) {
         Row(
             Modifier
                 .fillMaxWidth()
                 .padding(14.dp),
-            Arrangement.spacedBy(14.dp), Alignment.CenterVertically
+            Arrangement.spacedBy(14.dp),
+            Alignment.CenterVertically,
         ) {
             Box(contentAlignment = Alignment.Center) {
                 Box(
@@ -1680,18 +1855,20 @@ private fun SearchChannelCard(
                                 listOf(
                                     primary,
                                     primary.copy(0.3f),
-                                    primary
-                                )
-                            ), CircleShape
-                        )
+                                    primary,
+                                ),
+                            ),
+                            CircleShape,
+                        ),
                 )
                 AsyncImage(
-                    channel.thumbnailUrl, channel.name,
+                    channel.thumbnailUrl,
+                    channel.name,
                     Modifier
                         .size(66.dp)
                         .clip(CircleShape)
                         .background(MaterialTheme.colorScheme.surfaceVariant),
-                    contentScale = ContentScale.Crop
+                    contentScale = ContentScale.Crop,
                 )
             }
             Column(Modifier.weight(1f)) {
@@ -1701,14 +1878,14 @@ private fun SearchChannelCard(
                     fontWeight = FontWeight.Bold,
                     color = MaterialTheme.colorScheme.onSurface,
                     maxLines = 1,
-                    overflow = TextOverflow.Ellipsis
+                    overflow = TextOverflow.Ellipsis,
                 )
                 if (channel.subscriberCount > 0) {
                     Spacer(Modifier.height(3.dp))
                     Text(
                         formatSubs(channel.subscriberCount),
                         style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
                 }
                 if (channel.description.isNotBlank()) {
@@ -1717,14 +1894,16 @@ private fun SearchChannelCard(
                         channel.description,
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        maxLines = 2, overflow = TextOverflow.Ellipsis
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis,
                     )
                 }
             }
             Icon(
-                Icons.Default.ChevronRight, null,
+                Icons.Default.ChevronRight,
+                null,
                 tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.size(22.dp)
+                modifier = Modifier.size(22.dp),
             )
         }
     }
@@ -1734,33 +1913,35 @@ private fun SearchChannelCard(
 private fun SearchChannelCardCompact(
     channel: Channel,
     onClick: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     Column(
-        modifier = modifier
-            .clip(RoundedCornerShape(14.dp))
-            .background(
-                MaterialTheme.colorScheme.surfaceVariant.copy(0.35f)
-            )
-            .clickable(onClick = onClick)
-            .padding(12.dp),
+        modifier =
+            modifier
+                .clip(RoundedCornerShape(14.dp))
+                .background(
+                    MaterialTheme.colorScheme.surfaceVariant.copy(0.35f),
+                ).clickable(onClick = onClick)
+                .padding(12.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.spacedBy(8.dp)
+        verticalArrangement = Arrangement.spacedBy(8.dp),
     ) {
         AsyncImage(
-            channel.thumbnailUrl, channel.name,
+            channel.thumbnailUrl,
+            channel.name,
             Modifier
                 .size(60.dp)
                 .clip(CircleShape)
                 .background(MaterialTheme.colorScheme.surfaceVariant),
-            contentScale = ContentScale.Crop
+            contentScale = ContentScale.Crop,
         )
         Text(
             channel.name,
             style = MaterialTheme.typography.bodySmall,
             fontWeight = FontWeight.SemiBold,
             color = MaterialTheme.colorScheme.onSurface,
-            maxLines = 1, overflow = TextOverflow.Ellipsis
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
         )
     }
 }
@@ -1769,24 +1950,26 @@ private fun SearchChannelCardCompact(
 private fun SearchPlaylistCardCompact(
     playlist: Playlist,
     onClick: () -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     Column(
-        modifier = modifier
-            .clip(RoundedCornerShape(12.dp))
-            .clickable(onClick = onClick)
+        modifier =
+            modifier
+                .clip(RoundedCornerShape(12.dp))
+                .clickable(onClick = onClick),
     ) {
         Box(
             Modifier
                 .fillMaxWidth()
                 .aspectRatio(16f / 9f)
                 .clip(RoundedCornerShape(12.dp))
-                .background(MaterialTheme.colorScheme.surfaceVariant)
+                .background(MaterialTheme.colorScheme.surfaceVariant),
         ) {
             AsyncImage(
-                playlist.thumbnailUrl, playlist.name,
+                playlist.thumbnailUrl,
+                playlist.name,
                 Modifier.fillMaxSize(),
-                contentScale = ContentScale.Crop
+                contentScale = ContentScale.Crop,
             )
         }
         Spacer(Modifier.height(6.dp))
@@ -1794,41 +1977,46 @@ private fun SearchPlaylistCardCompact(
             playlist.name,
             style = MaterialTheme.typography.bodySmall,
             fontWeight = FontWeight.SemiBold,
-            maxLines = 1, overflow = TextOverflow.Ellipsis,
-            color = MaterialTheme.colorScheme.onSurface
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            color = MaterialTheme.colorScheme.onSurface,
         )
         Text(
             "${playlist.videoCount} videos",
             style = MaterialTheme.typography.labelSmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
     }
 }
 
 @Composable
-private fun SearchErrorState(message: String, onRetry: () -> Unit) {
+private fun SearchErrorState(
+    message: String,
+    onRetry: () -> Unit,
+) {
     Box(Modifier.fillMaxSize(), Alignment.Center) {
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.spacedBy(12.dp)
+            verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {
             Icon(
-                Icons.Outlined.WifiOff, null,
+                Icons.Outlined.WifiOff,
+                null,
                 tint = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.size(48.dp)
+                modifier = Modifier.size(48.dp),
             )
             Text(
                 "Search Failed",
                 style = MaterialTheme.typography.titleMedium,
                 fontWeight = FontWeight.SemiBold,
-                color = MaterialTheme.colorScheme.onBackground
+                color = MaterialTheme.colorScheme.onBackground,
             )
             Text(
                 message,
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 maxLines = 3,
-                overflow = TextOverflow.Ellipsis
+                overflow = TextOverflow.Ellipsis,
             )
             Button(onClick = onRetry) {
                 Icon(Icons.Default.Refresh, null, modifier = Modifier.size(18.dp))
@@ -1844,13 +2032,14 @@ private fun Dot() {
     Text(
         "\u00B7",
         style = MaterialTheme.typography.labelSmall,
-        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f)
+        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.5f),
     )
 }
 
-private fun formatSubs(count: Long): String = when {
-    count >= 1_000_000 -> "${"%.1f".format(count / 1_000_000.0)}M subscribers"
-    count >= 1_000 -> "${"%.1f".format(count / 1_000.0)}K subscribers"
-    count > 0 -> "$count subscribers"
-    else -> ""
-}
+private fun formatSubs(count: Long): String =
+    when {
+        count >= 1_000_000 -> "${"%.1f".format(count / 1_000_000.0)}M subscribers"
+        count >= 1_000 -> "${"%.1f".format(count / 1_000.0)}K subscribers"
+        count > 0 -> "$count subscribers"
+        else -> ""
+    }

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/search/SearchScreen.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/search/SearchScreen.kt
@@ -37,7 +37,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.*
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.platform.LocalFocusManager
-import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.paging.LoadState
 import androidx.paging.compose.collectAsLazyPagingItems
 import coil.compose.AsyncImage
@@ -64,7 +64,7 @@ fun SearchScreen(
     onChannelClick: (Channel) -> Unit,
     onPlaylistClick: (Playlist) -> Unit,
     modifier: Modifier = Modifier,
-    viewModel: SearchViewModel = viewModel()
+    viewModel: SearchViewModel = hiltViewModel()
 ) {
     val context = LocalContext.current
     val searchHistoryRepo = remember { SearchHistoryRepository(context) }

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/search/SearchViewModel.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/search/SearchViewModel.kt
@@ -11,8 +11,10 @@ import io.github.aedev.flow.data.local.SearchFilter
 import io.github.aedev.flow.data.paging.SearchPagingSource
 import io.github.aedev.flow.data.paging.SearchResultItem
 import io.github.aedev.flow.data.repository.YouTubeRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.*
+import javax.inject.Inject
 
 // ── UI state ─────────────────────────────────────────────────────────────────
 
@@ -23,9 +25,10 @@ data class SearchUiState(
 
 // ── ViewModel ─────────────────────────────────────────────────────────────────
 
+@HiltViewModel
 @OptIn(ExperimentalCoroutinesApi::class)
-class SearchViewModel(
-    private val repository: YouTubeRepository = YouTubeRepository.getInstance()
+class SearchViewModel @Inject constructor(
+    private val repository: YouTubeRepository,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(SearchUiState())

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/search/SearchViewModel.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/search/SearchViewModel.kt
@@ -1,3 +1,5 @@
+@file:Suppress("ktlint:standard:backing-property-naming")
+
 package io.github.aedev.flow.ui.screens.search
 
 import androidx.lifecycle.ViewModel
@@ -6,118 +8,145 @@ import androidx.paging.Pager
 import androidx.paging.PagingConfig
 import androidx.paging.PagingData
 import androidx.paging.cachedIn
+import dagger.hilt.android.lifecycle.HiltViewModel
 import io.github.aedev.flow.data.local.ContentType
 import io.github.aedev.flow.data.local.SearchFilter
 import io.github.aedev.flow.data.paging.SearchPagingSource
 import io.github.aedev.flow.data.paging.SearchResultItem
 import io.github.aedev.flow.data.repository.YouTubeRepository
-import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.filterNotNull
+import kotlinx.coroutines.flow.flatMapLatest
 import javax.inject.Inject
 
 // ── UI state ─────────────────────────────────────────────────────────────────
 
 data class SearchUiState(
     val query: String = "",
-    val filters: SearchFilter? = null
+    val filters: SearchFilter? = null,
 )
 
 // ── ViewModel ─────────────────────────────────────────────────────────────────
 
 @HiltViewModel
 @OptIn(ExperimentalCoroutinesApi::class)
-class SearchViewModel @Inject constructor(
-    private val repository: YouTubeRepository,
-) : ViewModel() {
+class SearchViewModel
+    @Inject
+    constructor(
+        private val repository: YouTubeRepository,
+    ) : ViewModel() {
+        private val _uiState = MutableStateFlow(SearchUiState())
+        val uiState: StateFlow<SearchUiState> = _uiState.asStateFlow()
 
-    private val _uiState = MutableStateFlow(SearchUiState())
-    val uiState: StateFlow<SearchUiState> = _uiState.asStateFlow()
+        /**
+         * Internal trigger: emitting a new value here restarts the pager from page 0.
+         * Holds (query, contentFilters) so the PagingSource gets fresh arguments.
+         */
+        private data class SearchKey(
+            val query: String,
+            val contentFilters: List<String>,
+            val searchFilter: SearchFilter?,
+        )
 
-    /**
-     * Internal trigger: emitting a new value here restarts the pager from page 0.
-     * Holds (query, contentFilters) so the PagingSource gets fresh arguments.
-     */
-    private data class SearchKey(val query: String, val contentFilters: List<String>, val searchFilter: SearchFilter?)
-    private val _searchKey = MutableStateFlow<SearchKey?>(null)
+        private val _searchKey = MutableStateFlow<SearchKey?>(null)
 
-    /**
-     * flatMapLatest restarts the pager whenever [_searchKey] changes (new search
-     * or filter change), and cachedIn survives configuration changes.
-     */
-    val searchResults: Flow<PagingData<SearchResultItem>> = _searchKey
-        .filterNotNull()
-        .filter { it.query.isNotBlank() }
-        .flatMapLatest { key ->
-            Pager(
-                config = PagingConfig(
-                    pageSize = 20,
-                    prefetchDistance = 6,
-                    enablePlaceholders = false,
-                    initialLoadSize = 20
-                ),
-                pagingSourceFactory = { SearchPagingSource(key.query, key.contentFilters, key.searchFilter) }
-            ).flow
+        /**
+         * flatMapLatest restarts the pager whenever [_searchKey] changes (new search
+         * or filter change), and cachedIn survives configuration changes.
+         */
+        val searchResults: Flow<PagingData<SearchResultItem>> =
+            _searchKey
+                .filterNotNull()
+                .filter { it.query.isNotBlank() }
+                .flatMapLatest { key ->
+                    Pager(
+                        config =
+                            PagingConfig(
+                                pageSize = 20,
+                                prefetchDistance = 6,
+                                enablePlaceholders = false,
+                                initialLoadSize = 20,
+                            ),
+                        pagingSourceFactory = { SearchPagingSource(key.query, key.contentFilters, key.searchFilter) },
+                    ).flow
+                }.cachedIn(viewModelScope)
+
+        // ── public API ────────────────────────────────────────────────────────────
+
+        fun search(
+            query: String,
+            filters: SearchFilter? = null,
+        ) {
+            if (query.isBlank()) {
+                _uiState.value = SearchUiState()
+                _searchKey.value = null
+                return
+            }
+            _uiState.value = SearchUiState(query = query, filters = filters)
+            _searchKey.value = SearchKey(query, buildContentFilters(filters), filters)
         }
-        .cachedIn(viewModelScope)
 
-    // ── public API ────────────────────────────────────────────────────────────
+        fun updateFilters(filters: SearchFilter) {
+            val currentQuery = _uiState.value.query
+            _uiState.value = _uiState.value.copy(filters = filters)
+            if (currentQuery.isNotBlank()) {
+                _searchKey.value = SearchKey(currentQuery, buildContentFilters(filters), filters)
+            }
+        }
 
-    fun search(query: String, filters: SearchFilter? = null) {
-        if (query.isBlank()) {
+        fun clearSearch() {
             _uiState.value = SearchUiState()
             _searchKey.value = null
-            return
         }
-        _uiState.value = SearchUiState(query = query, filters = filters)
-        _searchKey.value = SearchKey(query, buildContentFilters(filters), filters)
-    }
 
-    fun updateFilters(filters: SearchFilter) {
-        val currentQuery = _uiState.value.query
-        _uiState.value = _uiState.value.copy(filters = filters)
-        if (currentQuery.isNotBlank()) {
-            _searchKey.value = SearchKey(currentQuery, buildContentFilters(filters), filters)
+        fun hasActiveFilters(filters: SearchFilter?): Boolean {
+            if (filters == null) return false
+            return filters.contentType != ContentType.ALL ||
+                filters.duration != io.github.aedev.flow.data.local.Duration.ANY ||
+                filters.uploadDate != io.github.aedev.flow.data.local.UploadDate.ANY ||
+                filters.sortType != io.github.aedev.flow.data.local.SortType.RELEVANCE
+        }
+
+        suspend fun getSearchSuggestions(query: String): List<String> {
+            if (query.length < 2) return emptyList()
+            return try {
+                repository.getSearchSuggestions(query)
+            } catch (_: Exception) {
+                emptyList()
+            }
+        }
+
+        // ── helpers ───────────────────────────────────────────────────────────────
+
+        private fun buildContentFilters(filters: SearchFilter?): List<String> {
+            val list = mutableListOf<String>()
+            if (filters == null) return list
+
+            when (filters.contentType) {
+                ContentType.VIDEOS -> {
+                    list.add("videos")
+                }
+
+                ContentType.CHANNELS -> {
+                    list.add("channels")
+                }
+
+                ContentType.PLAYLISTS -> {
+                    list.add("playlists")
+                }
+
+                ContentType.LIVE -> {
+                    list.add("videos")
+                }
+
+                else -> {}
+            }
+
+            return list
         }
     }
-
-    fun clearSearch() {
-        _uiState.value = SearchUiState()
-        _searchKey.value = null
-    }
-
-    fun hasActiveFilters(filters: SearchFilter?): Boolean {
-        if (filters == null) return false
-        return filters.contentType != ContentType.ALL
-                || filters.duration != io.github.aedev.flow.data.local.Duration.ANY
-                || filters.uploadDate != io.github.aedev.flow.data.local.UploadDate.ANY
-                || filters.sortType != io.github.aedev.flow.data.local.SortType.RELEVANCE
-    }
-
-    suspend fun getSearchSuggestions(query: String): List<String> {
-        if (query.length < 2) return emptyList()
-        return try {
-            repository.getSearchSuggestions(query)
-        } catch (_: Exception) {
-            emptyList()
-        }
-    }
-
-    // ── helpers ───────────────────────────────────────────────────────────────
-
-    private fun buildContentFilters(filters: SearchFilter?): List<String> {
-        val list = mutableListOf<String>()
-        if (filters == null) return list
-        
-        when (filters.contentType) {
-            ContentType.VIDEOS -> list.add("videos")
-            ContentType.CHANNELS -> list.add("channels")
-            ContentType.PLAYLISTS -> list.add("playlists")
-            ContentType.LIVE -> list.add("videos")
-            else -> {} 
-        }
-        
-        return list
-    }
-}
-

--- a/app/src/main/java/io/github/aedev/flow/ui/tv/FlowTvApp.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/tv/FlowTvApp.kt
@@ -14,7 +14,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.media3.common.util.UnstableApi
 import androidx.navigation.compose.rememberNavController
 import io.github.aedev.flow.data.model.Video
@@ -41,8 +40,8 @@ fun FlowTvApp(
     val activity = context as ComponentActivity
     val homeViewModel: HomeViewModel = hiltViewModel(activity)
     val playerViewModel: VideoPlayerViewModel = hiltViewModel(activity)
-    val subscriptionsViewModel: SubscriptionsViewModel = viewModel(viewModelStoreOwner = activity)
-    val searchViewModel: SearchViewModel = viewModel(viewModelStoreOwner = activity)
+    val subscriptionsViewModel: SubscriptionsViewModel = hiltViewModel(activity)
+    val searchViewModel: SearchViewModel = hiltViewModel(activity)
     val musicViewModel: MusicViewModel = hiltViewModel(activity)
     val musicPlayerViewModel: MusicPlayerViewModel = hiltViewModel(activity)
     val navController = rememberNavController()

--- a/app/src/main/java/io/github/aedev/flow/ui/tv/FlowTvApp.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/tv/FlowTvApp.kt
@@ -63,7 +63,10 @@ fun FlowTvApp(
         playerViewModel.playVideo(video)
     }
 
-    fun playPlaylist(videos: List<Video>, title: String) {
+    fun playPlaylist(
+        videos: List<Video>,
+        title: String,
+    ) {
         val first = videos.firstOrNull() ?: return
         EnhancedMusicPlayerManager.pause()
         GlobalPlayerState.setCurrentVideo(first)
@@ -84,7 +87,7 @@ fun FlowTvApp(
                 viewCount = 0L,
                 uploadDate = "",
                 isShort = isShort,
-            )
+            ),
         )
         onDeeplinkConsumed()
     }

--- a/app/src/test/java/io/github/aedev/flow/ui/screens/history/HistoryViewModelTest.kt
+++ b/app/src/test/java/io/github/aedev/flow/ui/screens/history/HistoryViewModelTest.kt
@@ -1,8 +1,8 @@
 package io.github.aedev.flow.ui.screens.history
 
 import com.google.common.truth.Truth.assertThat
-import io.github.aedev.flow.data.local.ViewHistory
 import io.github.aedev.flow.data.local.VideoHistoryEntry
+import io.github.aedev.flow.data.local.ViewHistory
 import io.github.aedev.flow.data.local.dao.VideoDao
 import io.github.aedev.flow.data.local.dao.WatchHistoryDao
 import io.github.aedev.flow.data.repository.YouTubeRepository
@@ -23,7 +23,6 @@ import org.junit.Test
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class HistoryViewModelTest {
-
     private val testDispatcher = StandardTestDispatcher()
     private val viewHistory: ViewHistory = mockk(relaxed = true)
     private val youTubeRepository: YouTubeRepository = mockk(relaxed = true)
@@ -42,50 +41,54 @@ class HistoryViewModelTest {
     }
 
     @Test
-    fun `initial state loads history entries`() = runTest {
-        val historyList = listOf(
-            VideoHistoryEntry(
-                videoId = "vid_1",
-                title = "Video Title",
-                channelName = "Channel Name",
-                channelId = "ch_1",
-                thumbnailUrl = "https://example.com/thumb.jpg",
-                duration = 60000,
-                position = 30000,
-                timestamp = 1000L
-            )
-        )
-        coEvery { viewHistory.getAllHistory() } returns flowOf(historyList)
-        coEvery { videoDao.getVideo("vid_1") } returns null
+    fun `initial state loads history entries`() =
+        runTest {
+            val historyList =
+                listOf(
+                    VideoHistoryEntry(
+                        videoId = "vid_1",
+                        title = "Video Title",
+                        channelName = "Channel Name",
+                        channelId = "ch_1",
+                        thumbnailUrl = "https://example.com/thumb.jpg",
+                        duration = 60000,
+                        position = 30000,
+                        timestamp = 1000L,
+                    ),
+                )
+            coEvery { viewHistory.getAllHistory() } returns flowOf(historyList)
+            coEvery { videoDao.getVideo("vid_1") } returns null
 
-        val viewModel = HistoryViewModel(viewHistory, youTubeRepository, videoDao, watchHistoryDao)
-        testDispatcher.scheduler.advanceUntilIdle()
+            val viewModel = HistoryViewModel(viewHistory, youTubeRepository, videoDao, watchHistoryDao)
+            testDispatcher.scheduler.advanceUntilIdle()
 
-        val uiState = viewModel.uiState.value
-        assertThat(uiState.isLoading).isFalse()
-        assertThat(uiState.historyEntries.size).isEqualTo(1)
-        assertThat(uiState.historyEntries.first().videoId).isEqualTo("vid_1")
-    }
-
-    @Test
-    fun `clearHistory delegates to viewHistory clearAllHistory`() = runTest {
-        coEvery { viewHistory.getAllHistory() } returns flowOf(emptyList())
-
-        val viewModel = HistoryViewModel(viewHistory, youTubeRepository, videoDao, watchHistoryDao)
-        viewModel.clearHistory()
-        testDispatcher.scheduler.advanceUntilIdle()
-
-        coVerify(exactly = 1) { viewHistory.clearAllHistory() }
-    }
+            val uiState = viewModel.uiState.value
+            assertThat(uiState.isLoading).isFalse()
+            assertThat(uiState.historyEntries.size).isEqualTo(1)
+            assertThat(uiState.historyEntries.first().videoId).isEqualTo("vid_1")
+        }
 
     @Test
-    fun `removeFromHistory delegates to viewHistory clearVideoHistory`() = runTest {
-        coEvery { viewHistory.getAllHistory() } returns flowOf(emptyList())
+    fun `clearHistory delegates to viewHistory clearAllHistory`() =
+        runTest {
+            coEvery { viewHistory.getAllHistory() } returns flowOf(emptyList())
 
-        val viewModel = HistoryViewModel(viewHistory, youTubeRepository, videoDao, watchHistoryDao)
-        viewModel.removeFromHistory("vid_123")
-        testDispatcher.scheduler.advanceUntilIdle()
+            val viewModel = HistoryViewModel(viewHistory, youTubeRepository, videoDao, watchHistoryDao)
+            viewModel.clearHistory()
+            testDispatcher.scheduler.advanceUntilIdle()
 
-        coVerify(exactly = 1) { viewHistory.clearVideoHistory("vid_123") }
-    }
+            coVerify(exactly = 1) { viewHistory.clearAllHistory() }
+        }
+
+    @Test
+    fun `removeFromHistory delegates to viewHistory clearVideoHistory`() =
+        runTest {
+            coEvery { viewHistory.getAllHistory() } returns flowOf(emptyList())
+
+            val viewModel = HistoryViewModel(viewHistory, youTubeRepository, videoDao, watchHistoryDao)
+            viewModel.removeFromHistory("vid_123")
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            coVerify(exactly = 1) { viewHistory.clearVideoHistory("vid_123") }
+        }
 }

--- a/app/src/test/java/io/github/aedev/flow/ui/screens/history/HistoryViewModelTest.kt
+++ b/app/src/test/java/io/github/aedev/flow/ui/screens/history/HistoryViewModelTest.kt
@@ -1,0 +1,91 @@
+package io.github.aedev.flow.ui.screens.history
+
+import com.google.common.truth.Truth.assertThat
+import io.github.aedev.flow.data.local.ViewHistory
+import io.github.aedev.flow.data.local.VideoHistoryEntry
+import io.github.aedev.flow.data.local.dao.VideoDao
+import io.github.aedev.flow.data.local.dao.WatchHistoryDao
+import io.github.aedev.flow.data.repository.YouTubeRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import io.mockk.unmockkAll
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class HistoryViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+    private val viewHistory: ViewHistory = mockk(relaxed = true)
+    private val youTubeRepository: YouTubeRepository = mockk(relaxed = true)
+    private val videoDao: VideoDao = mockk(relaxed = true)
+    private val watchHistoryDao: WatchHistoryDao = mockk(relaxed = true)
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+        unmockkAll()
+    }
+
+    @Test
+    fun `initial state loads history entries`() = runTest {
+        val historyList = listOf(
+            VideoHistoryEntry(
+                videoId = "vid_1",
+                title = "Video Title",
+                channelName = "Channel Name",
+                channelId = "ch_1",
+                thumbnailUrl = "https://example.com/thumb.jpg",
+                duration = 60000,
+                position = 30000,
+                timestamp = 1000L
+            )
+        )
+        coEvery { viewHistory.getAllHistory() } returns flowOf(historyList)
+        coEvery { videoDao.getVideo("vid_1") } returns null
+
+        val viewModel = HistoryViewModel(viewHistory, youTubeRepository, videoDao, watchHistoryDao)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        val uiState = viewModel.uiState.value
+        assertThat(uiState.isLoading).isFalse()
+        assertThat(uiState.historyEntries.size).isEqualTo(1)
+        assertThat(uiState.historyEntries.first().videoId).isEqualTo("vid_1")
+    }
+
+    @Test
+    fun `clearHistory delegates to viewHistory clearAllHistory`() = runTest {
+        coEvery { viewHistory.getAllHistory() } returns flowOf(emptyList())
+
+        val viewModel = HistoryViewModel(viewHistory, youTubeRepository, videoDao, watchHistoryDao)
+        viewModel.clearHistory()
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        coVerify(exactly = 1) { viewHistory.clearAllHistory() }
+    }
+
+    @Test
+    fun `removeFromHistory delegates to viewHistory clearVideoHistory`() = runTest {
+        coEvery { viewHistory.getAllHistory() } returns flowOf(emptyList())
+
+        val viewModel = HistoryViewModel(viewHistory, youTubeRepository, videoDao, watchHistoryDao)
+        viewModel.removeFromHistory("vid_123")
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        coVerify(exactly = 1) { viewHistory.clearVideoHistory("vid_123") }
+    }
+}

--- a/app/src/test/java/io/github/aedev/flow/ui/screens/likedvideos/LikedVideosViewModelTest.kt
+++ b/app/src/test/java/io/github/aedev/flow/ui/screens/likedvideos/LikedVideosViewModelTest.kt
@@ -1,0 +1,71 @@
+package io.github.aedev.flow.ui.screens.likedvideos
+
+import com.google.common.truth.Truth.assertThat
+import io.github.aedev.flow.data.local.LikedVideoInfo
+import io.github.aedev.flow.data.local.LikedVideosRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import io.mockk.unmockkAll
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class LikedVideosViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+    private val repository: LikedVideosRepository = mockk(relaxed = true)
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+        unmockkAll()
+    }
+
+    @Test
+    fun `initial state loads liked videos from repository`() = runTest {
+        val sampleLikes = listOf(
+            LikedVideoInfo(
+                videoId = "vid_1",
+                title = "Sample Video",
+                thumbnail = "https://example.com/thumb.jpg",
+                channelName = "Sample Channel",
+                likedAt = 1000L,
+                isMusic = false
+            )
+        )
+        coEvery { repository.getAllLikedVideos() } returns flowOf(sampleLikes)
+
+        val viewModel = LikedVideosViewModel(repository)
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        val uiState = viewModel.uiState.value
+        assertThat(uiState.isLoading).isFalse()
+        assertThat(uiState.likedVideos).isEqualTo(sampleLikes)
+    }
+
+    @Test
+    fun `removeLike delegates to repository to remove video`() = runTest {
+        coEvery { repository.getAllLikedVideos() } returns flowOf(emptyList())
+        coEvery { repository.removeLikeState("vid_1") } returns Unit
+
+        val viewModel = LikedVideosViewModel(repository)
+        viewModel.removeLike("vid_1")
+        testDispatcher.scheduler.advanceUntilIdle()
+
+        coVerify(exactly = 1) { repository.removeLikeState("vid_1") }
+    }
+}

--- a/app/src/test/java/io/github/aedev/flow/ui/screens/likedvideos/LikedVideosViewModelTest.kt
+++ b/app/src/test/java/io/github/aedev/flow/ui/screens/likedvideos/LikedVideosViewModelTest.kt
@@ -20,7 +20,6 @@ import org.junit.Test
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class LikedVideosViewModelTest {
-
     private val testDispatcher = StandardTestDispatcher()
     private val repository: LikedVideosRepository = mockk(relaxed = true)
 
@@ -36,36 +35,39 @@ class LikedVideosViewModelTest {
     }
 
     @Test
-    fun `initial state loads liked videos from repository`() = runTest {
-        val sampleLikes = listOf(
-            LikedVideoInfo(
-                videoId = "vid_1",
-                title = "Sample Video",
-                thumbnail = "https://example.com/thumb.jpg",
-                channelName = "Sample Channel",
-                likedAt = 1000L,
-                isMusic = false
-            )
-        )
-        coEvery { repository.getAllLikedVideos() } returns flowOf(sampleLikes)
+    fun `initial state loads liked videos from repository`() =
+        runTest {
+            val sampleLikes =
+                listOf(
+                    LikedVideoInfo(
+                        videoId = "vid_1",
+                        title = "Sample Video",
+                        thumbnail = "https://example.com/thumb.jpg",
+                        channelName = "Sample Channel",
+                        likedAt = 1000L,
+                        isMusic = false,
+                    ),
+                )
+            coEvery { repository.getAllLikedVideos() } returns flowOf(sampleLikes)
 
-        val viewModel = LikedVideosViewModel(repository)
-        testDispatcher.scheduler.advanceUntilIdle()
+            val viewModel = LikedVideosViewModel(repository)
+            testDispatcher.scheduler.advanceUntilIdle()
 
-        val uiState = viewModel.uiState.value
-        assertThat(uiState.isLoading).isFalse()
-        assertThat(uiState.likedVideos).isEqualTo(sampleLikes)
-    }
+            val uiState = viewModel.uiState.value
+            assertThat(uiState.isLoading).isFalse()
+            assertThat(uiState.likedVideos).isEqualTo(sampleLikes)
+        }
 
     @Test
-    fun `removeLike delegates to repository to remove video`() = runTest {
-        coEvery { repository.getAllLikedVideos() } returns flowOf(emptyList())
-        coEvery { repository.removeLikeState("vid_1") } returns Unit
+    fun `removeLike delegates to repository to remove video`() =
+        runTest {
+            coEvery { repository.getAllLikedVideos() } returns flowOf(emptyList())
+            coEvery { repository.removeLikeState("vid_1") } returns Unit
 
-        val viewModel = LikedVideosViewModel(repository)
-        viewModel.removeLike("vid_1")
-        testDispatcher.scheduler.advanceUntilIdle()
+            val viewModel = LikedVideosViewModel(repository)
+            viewModel.removeLike("vid_1")
+            testDispatcher.scheduler.advanceUntilIdle()
 
-        coVerify(exactly = 1) { repository.removeLikeState("vid_1") }
-    }
+            coVerify(exactly = 1) { repository.removeLikeState("vid_1") }
+        }
 }

--- a/app/src/test/java/io/github/aedev/flow/ui/screens/search/SearchViewModelTest.kt
+++ b/app/src/test/java/io/github/aedev/flow/ui/screens/search/SearchViewModelTest.kt
@@ -20,7 +20,6 @@ import org.junit.Test
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class SearchViewModelTest {
-
     private val testDispatcher = StandardTestDispatcher()
     private val repository: YouTubeRepository = mockk(relaxed = true)
 
@@ -85,14 +84,15 @@ class SearchViewModelTest {
     }
 
     @Test
-    fun `getSearchSuggestions calls YouTubeRepository for valid query`() = runTest {
-        val suggestions = listOf("kotlin tutorial", "kotlin android")
-        coEvery { repository.getSearchSuggestions("kotlin") } returns suggestions
+    fun `getSearchSuggestions calls YouTubeRepository for valid query`() =
+        runTest {
+            val suggestions = listOf("kotlin tutorial", "kotlin android")
+            coEvery { repository.getSearchSuggestions("kotlin") } returns suggestions
 
-        val viewModel = SearchViewModel(repository)
-        val result = viewModel.getSearchSuggestions("kotlin")
+            val viewModel = SearchViewModel(repository)
+            val result = viewModel.getSearchSuggestions("kotlin")
 
-        assertThat(result).isEqualTo(suggestions)
-        coVerify(exactly = 1) { repository.getSearchSuggestions("kotlin") }
-    }
+            assertThat(result).isEqualTo(suggestions)
+            coVerify(exactly = 1) { repository.getSearchSuggestions("kotlin") }
+        }
 }

--- a/app/src/test/java/io/github/aedev/flow/ui/screens/search/SearchViewModelTest.kt
+++ b/app/src/test/java/io/github/aedev/flow/ui/screens/search/SearchViewModelTest.kt
@@ -1,0 +1,98 @@
+package io.github.aedev.flow.ui.screens.search
+
+import com.google.common.truth.Truth.assertThat
+import io.github.aedev.flow.data.local.ContentType
+import io.github.aedev.flow.data.local.SearchFilter
+import io.github.aedev.flow.data.repository.YouTubeRepository
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import io.mockk.unmockkAll
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class SearchViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+    private val repository: YouTubeRepository = mockk(relaxed = true)
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+        unmockkAll()
+    }
+
+    @Test
+    fun `initial ui state has empty query and null filters`() {
+        val viewModel = SearchViewModel(repository)
+        assertThat(viewModel.uiState.value.query).isEmpty()
+        assertThat(viewModel.uiState.value.filters).isNull()
+    }
+
+    @Test
+    fun `search with valid query updates uiState`() {
+        val viewModel = SearchViewModel(repository)
+        viewModel.search("Kotlin Compose")
+
+        val uiState = viewModel.uiState.value
+        assertThat(uiState.query).isEqualTo("Kotlin Compose")
+    }
+
+    @Test
+    fun `search with empty query resets uiState`() {
+        val viewModel = SearchViewModel(repository)
+        viewModel.search("Kotlin")
+        viewModel.search("")
+
+        val uiState = viewModel.uiState.value
+        assertThat(uiState.query).isEmpty()
+        assertThat(uiState.filters).isNull()
+    }
+
+    @Test
+    fun `updateFilters updates filters in uiState when query is active`() {
+        val viewModel = SearchViewModel(repository)
+        viewModel.search("Music")
+
+        val filter = SearchFilter(contentType = ContentType.VIDEOS)
+        viewModel.updateFilters(filter)
+
+        assertThat(viewModel.uiState.value.filters).isEqualTo(filter)
+    }
+
+    @Test
+    fun `clearSearch resets search query and filters`() {
+        val viewModel = SearchViewModel(repository)
+        viewModel.search("Android", SearchFilter(contentType = ContentType.PLAYLISTS))
+
+        viewModel.clearSearch()
+
+        assertThat(viewModel.uiState.value.query).isEmpty()
+        assertThat(viewModel.uiState.value.filters).isNull()
+    }
+
+    @Test
+    fun `getSearchSuggestions calls YouTubeRepository for valid query`() = runTest {
+        val suggestions = listOf("kotlin tutorial", "kotlin android")
+        coEvery { repository.getSearchSuggestions("kotlin") } returns suggestions
+
+        val viewModel = SearchViewModel(repository)
+        val result = viewModel.getSearchSuggestions("kotlin")
+
+        assertThat(result).isEqualTo(suggestions)
+        coVerify(exactly = 1) { repository.getSearchSuggestions("kotlin") }
+    }
+}


### PR DESCRIPTION
## Summary

> [!NOTE]
> **Stacked PR**: This PR is stacked on top of **PR #859** (`refactor/di-improvements`). Please merge this branch. #859 is only meant to help reviewer stay focused on the DI improvment. This PR has extra lint commit, which makes this PR difficult to review.

This PR applies Spotless formatting rules and Ktlint suppressions on top of the DI improvements in PR #859.

### Changes:
- Applied `./gradlew spotlessApply` formatting across updated ViewModel and Screen files.
- Added `@file:Suppress(ktlint:standard:no-wildcard-imports)` and `@file:Suppress(ktlint:standard:backing-property-naming)` to resolve Ktlint rule violations.
- Ensures `./gradlew spotlessCheck` passes cleanly with 0 violations.

### Validation:
- [x] `./gradlew spotlessCheck` (Passed 100% cleanly)
- [x] `./gradlew :app:testGithubDebugUnitTest` (Passed 100% cleanly)
