### PR TITLE
refactor(db): enable Room schema export and clean up AppDatabase migrations

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
     id("com.google.dagger.hilt.android")
     id("org.jetbrains.kotlin.plugin.serialization")
     id("androidx.baselineprofile")
+    alias(libs.plugins.room)
 }
 
 android {
@@ -139,6 +140,10 @@ android {
         }
     }
 
+    sourceSets {
+        getByName("androidTest").assets.directories.add("$projectDir/schemas")
+    }
+
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
@@ -161,6 +166,10 @@ android {
             isReturnDefaultValues = true
         }
     }
+}
+
+room {
+    schemaDirectory("$projectDir/schemas")
 }
 
 kotlin {

--- a/app/schemas/io.github.aedev.flow.data.local.AppDatabase/24.json
+++ b/app/schemas/io.github.aedev.flow.data.local.AppDatabase/24.json
@@ -1,0 +1,1343 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 24,
+    "identityHash": "a9a38ff6e6cdcd13b12295d9433a2c0e",
+    "entities": [
+      {
+        "tableName": "videos",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `title` TEXT NOT NULL, `channelName` TEXT NOT NULL, `channelId` TEXT NOT NULL, `thumbnailUrl` TEXT NOT NULL, `duration` INTEGER NOT NULL, `viewCount` INTEGER NOT NULL, `uploadDate` TEXT NOT NULL, `description` TEXT NOT NULL, `channelThumbnailUrl` TEXT NOT NULL, `timestamp` INTEGER NOT NULL, `savedAt` INTEGER NOT NULL, `isMusic` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "channelName",
+            "columnName": "channelName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channelId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnailUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "viewCount",
+            "columnName": "viewCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "uploadDate",
+            "columnName": "uploadDate",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "channelThumbnailUrl",
+            "columnName": "channelThumbnailUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "savedAt",
+            "columnName": "savedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isMusic",
+            "columnName": "isMusic",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "playlists",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `description` TEXT NOT NULL, `thumbnailUrl` TEXT NOT NULL, `isPrivate` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, `videoCount` INTEGER NOT NULL, `isMusic` INTEGER NOT NULL, `isUserCreated` INTEGER NOT NULL, `syncId` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnailUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isPrivate",
+            "columnName": "isPrivate",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "videoCount",
+            "columnName": "videoCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isMusic",
+            "columnName": "isMusic",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isUserCreated",
+            "columnName": "isUserCreated",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "syncId",
+            "columnName": "syncId",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlists_syncId",
+            "unique": false,
+            "columnNames": [
+              "syncId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlists_syncId` ON `${TABLE_NAME}` (`syncId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "playlist_video_cross_ref",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlistId` TEXT NOT NULL, `videoId` TEXT NOT NULL, `position` INTEGER NOT NULL, `addedAt` INTEGER NOT NULL, PRIMARY KEY(`playlistId`, `videoId`), FOREIGN KEY(`playlistId`) REFERENCES `playlists`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE , FOREIGN KEY(`videoId`) REFERENCES `videos`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlistId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "videoId",
+            "columnName": "videoId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "addedAt",
+            "columnName": "addedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlistId",
+            "videoId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_playlist_video_cross_ref_videoId",
+            "unique": false,
+            "columnNames": [
+              "videoId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_video_cross_ref_videoId` ON `${TABLE_NAME}` (`videoId`)"
+          },
+          {
+            "name": "index_playlist_video_cross_ref_playlistId",
+            "unique": false,
+            "columnNames": [
+              "playlistId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_playlist_video_cross_ref_playlistId` ON `${TABLE_NAME}` (`playlistId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "playlists",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "playlistId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "videos",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "videoId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "notifications",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `videoId` TEXT NOT NULL, `title` TEXT NOT NULL, `channelName` TEXT NOT NULL, `thumbnailUrl` TEXT, `timestamp` INTEGER NOT NULL, `isRead` INTEGER NOT NULL, `type` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "videoId",
+            "columnName": "videoId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "channelName",
+            "columnName": "channelName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnailUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isRead",
+            "columnName": "isRead",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "subscription_feed_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`videoId` TEXT NOT NULL, `title` TEXT NOT NULL, `channelName` TEXT NOT NULL, `channelId` TEXT NOT NULL, `thumbnailUrl` TEXT NOT NULL, `duration` INTEGER NOT NULL, `viewCount` INTEGER NOT NULL, `uploadDate` TEXT NOT NULL, `timestamp` INTEGER NOT NULL, `channelThumbnailUrl` TEXT NOT NULL, `isShort` INTEGER NOT NULL, `isLive` INTEGER NOT NULL, `isUpcoming` INTEGER NOT NULL, `cachedAt` INTEGER NOT NULL, PRIMARY KEY(`videoId`))",
+        "fields": [
+          {
+            "fieldPath": "videoId",
+            "columnName": "videoId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "channelName",
+            "columnName": "channelName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channelId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnailUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "viewCount",
+            "columnName": "viewCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "uploadDate",
+            "columnName": "uploadDate",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "channelThumbnailUrl",
+            "columnName": "channelThumbnailUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isShort",
+            "columnName": "isShort",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isLive",
+            "columnName": "isLive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isUpcoming",
+            "columnName": "isUpcoming",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "cachedAt",
+            "columnName": "cachedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "videoId"
+          ]
+        }
+      },
+      {
+        "tableName": "music_home_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`sectionId` TEXT NOT NULL, `title` TEXT NOT NULL, `subtitle` TEXT, `tracksJson` TEXT NOT NULL, `orderBy` INTEGER NOT NULL, PRIMARY KEY(`sectionId`))",
+        "fields": [
+          {
+            "fieldPath": "sectionId",
+            "columnName": "sectionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "subtitle",
+            "columnName": "subtitle",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "tracksJson",
+            "columnName": "tracksJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "orderBy",
+            "columnName": "orderBy",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "sectionId"
+          ]
+        }
+      },
+      {
+        "tableName": "music_home_chips_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`title` TEXT NOT NULL, `browseId` TEXT, `params` TEXT, `deselectBrowseId` TEXT, `deselectParams` TEXT, `orderBy` INTEGER NOT NULL, PRIMARY KEY(`title`))",
+        "fields": [
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "browseId",
+            "columnName": "browseId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "params",
+            "columnName": "params",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "deselectBrowseId",
+            "columnName": "deselectBrowseId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "deselectParams",
+            "columnName": "deselectParams",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "orderBy",
+            "columnName": "orderBy",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "title"
+          ]
+        }
+      },
+      {
+        "tableName": "downloaded_songs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `title` TEXT NOT NULL, `artist` TEXT NOT NULL, `thumbnailUrl` TEXT NOT NULL, `duration` INTEGER NOT NULL, `downloadedAt` INTEGER NOT NULL, `fileSize` INTEGER NOT NULL, `filePath` TEXT, `downloadStatus` TEXT NOT NULL, `lastPlayedAt` INTEGER, `playCount` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnailUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadedAt",
+            "columnName": "downloadedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileSize",
+            "columnName": "fileSize",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filePath",
+            "columnName": "filePath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "downloadStatus",
+            "columnName": "downloadStatus",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastPlayedAt",
+            "columnName": "lastPlayedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "playCount",
+            "columnName": "playCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "downloads",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`videoId` TEXT NOT NULL, `title` TEXT NOT NULL, `uploader` TEXT NOT NULL, `duration` INTEGER NOT NULL, `thumbnailUrl` TEXT NOT NULL, `thumbnailPath` TEXT, `createdAt` INTEGER NOT NULL, `sponsorBlockSegmentsJson` TEXT, PRIMARY KEY(`videoId`))",
+        "fields": [
+          {
+            "fieldPath": "videoId",
+            "columnName": "videoId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "uploader",
+            "columnName": "uploader",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnailUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thumbnailPath",
+            "columnName": "thumbnailPath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sponsorBlockSegmentsJson",
+            "columnName": "sponsorBlockSegmentsJson",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "videoId"
+          ]
+        }
+      },
+      {
+        "tableName": "download_items",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `videoId` TEXT NOT NULL, `fileType` TEXT NOT NULL, `fileName` TEXT NOT NULL, `filePath` TEXT NOT NULL, `url` TEXT NOT NULL, `format` TEXT NOT NULL, `quality` TEXT NOT NULL, `mimeType` TEXT NOT NULL, `downloadedBytes` INTEGER NOT NULL, `totalBytes` INTEGER NOT NULL, `status` TEXT NOT NULL, FOREIGN KEY(`videoId`) REFERENCES `downloads`(`videoId`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "videoId",
+            "columnName": "videoId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileType",
+            "columnName": "fileType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fileName",
+            "columnName": "fileName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filePath",
+            "columnName": "filePath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "format",
+            "columnName": "format",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "quality",
+            "columnName": "quality",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mimeType",
+            "columnName": "mimeType",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadedBytes",
+            "columnName": "downloadedBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "totalBytes",
+            "columnName": "totalBytes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "status",
+            "columnName": "status",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_download_items_videoId",
+            "unique": false,
+            "columnNames": [
+              "videoId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_download_items_videoId` ON `${TABLE_NAME}` (`videoId`)"
+          },
+          {
+            "name": "index_download_items_filePath",
+            "unique": true,
+            "columnNames": [
+              "filePath"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_download_items_filePath` ON `${TABLE_NAME}` (`filePath`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "downloads",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "videoId"
+            ],
+            "referencedColumns": [
+              "videoId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "watch_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`videoId` TEXT NOT NULL, `position` INTEGER NOT NULL, `duration` INTEGER NOT NULL, `timestamp` INTEGER NOT NULL, `title` TEXT NOT NULL, `thumbnailUrl` TEXT NOT NULL, `channelName` TEXT NOT NULL, `channelId` TEXT NOT NULL, `isMusic` INTEGER NOT NULL, `isShort` INTEGER NOT NULL, `isLocal` INTEGER NOT NULL, PRIMARY KEY(`videoId`))",
+        "fields": [
+          {
+            "fieldPath": "videoId",
+            "columnName": "videoId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "position",
+            "columnName": "position",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnailUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "channelName",
+            "columnName": "channelName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channelId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isMusic",
+            "columnName": "isMusic",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isShort",
+            "columnName": "isShort",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isLocal",
+            "columnName": "isLocal",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "videoId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_watch_history_videoId",
+            "unique": true,
+            "columnNames": [
+              "videoId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_watch_history_videoId` ON `${TABLE_NAME}` (`videoId`)"
+          },
+          {
+            "name": "index_watch_history_timestamp",
+            "unique": false,
+            "columnNames": [
+              "timestamp"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_watch_history_timestamp` ON `${TABLE_NAME}` (`timestamp`)"
+          },
+          {
+            "name": "index_watch_history_isMusic",
+            "unique": false,
+            "columnNames": [
+              "isMusic"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_watch_history_isMusic` ON `${TABLE_NAME}` (`isMusic`)"
+          },
+          {
+            "name": "index_watch_history_isShort",
+            "unique": false,
+            "columnNames": [
+              "isShort"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_watch_history_isShort` ON `${TABLE_NAME}` (`isShort`)"
+          },
+          {
+            "name": "index_watch_history_isLocal",
+            "unique": false,
+            "columnNames": [
+              "isLocal"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_watch_history_isLocal` ON `${TABLE_NAME}` (`isLocal`)"
+          }
+        ]
+      },
+      {
+        "tableName": "home_feed_cache",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`cacheKey` TEXT NOT NULL, `bucket` TEXT NOT NULL, `videoId` TEXT NOT NULL, `title` TEXT NOT NULL, `channelName` TEXT NOT NULL, `channelId` TEXT NOT NULL, `thumbnailUrl` TEXT NOT NULL, `duration` INTEGER NOT NULL, `viewCount` INTEGER NOT NULL, `likeCount` INTEGER NOT NULL, `uploadDate` TEXT NOT NULL, `timestamp` INTEGER NOT NULL, `description` TEXT NOT NULL, `channelThumbnailUrl` TEXT NOT NULL, `tagsJson` TEXT NOT NULL, `isMusic` INTEGER NOT NULL, `isLive` INTEGER NOT NULL, `isShort` INTEGER NOT NULL, `isUpcoming` INTEGER NOT NULL, `commentCountText` TEXT NOT NULL, `source` TEXT NOT NULL, `relatedSeedId` TEXT, `cachedAt` INTEGER NOT NULL, `expiresAt` INTEGER NOT NULL, `orderIndex` INTEGER NOT NULL, PRIMARY KEY(`cacheKey`))",
+        "fields": [
+          {
+            "fieldPath": "cacheKey",
+            "columnName": "cacheKey",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bucket",
+            "columnName": "bucket",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "videoId",
+            "columnName": "videoId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "channelName",
+            "columnName": "channelName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channelId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "thumbnailUrl",
+            "columnName": "thumbnailUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "viewCount",
+            "columnName": "viewCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "likeCount",
+            "columnName": "likeCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "uploadDate",
+            "columnName": "uploadDate",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "channelThumbnailUrl",
+            "columnName": "channelThumbnailUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tagsJson",
+            "columnName": "tagsJson",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isMusic",
+            "columnName": "isMusic",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isLive",
+            "columnName": "isLive",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isShort",
+            "columnName": "isShort",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isUpcoming",
+            "columnName": "isUpcoming",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "commentCountText",
+            "columnName": "commentCountText",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "source",
+            "columnName": "source",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "relatedSeedId",
+            "columnName": "relatedSeedId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "cachedAt",
+            "columnName": "cachedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "expiresAt",
+            "columnName": "expiresAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "orderIndex",
+            "columnName": "orderIndex",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "cacheKey"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_home_feed_cache_bucket_expiresAt",
+            "unique": false,
+            "columnNames": [
+              "bucket",
+              "expiresAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_home_feed_cache_bucket_expiresAt` ON `${TABLE_NAME}` (`bucket`, `expiresAt`)"
+          },
+          {
+            "name": "index_home_feed_cache_bucket_source",
+            "unique": false,
+            "columnNames": [
+              "bucket",
+              "source"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_home_feed_cache_bucket_source` ON `${TABLE_NAME}` (`bucket`, `source`)"
+          },
+          {
+            "name": "index_home_feed_cache_relatedSeedId",
+            "unique": false,
+            "columnNames": [
+              "relatedSeedId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_home_feed_cache_relatedSeedId` ON `${TABLE_NAME}` (`relatedSeedId`)"
+          },
+          {
+            "name": "index_home_feed_cache_videoId",
+            "unique": false,
+            "columnNames": [
+              "videoId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_home_feed_cache_videoId` ON `${TABLE_NAME}` (`videoId`)"
+          },
+          {
+            "name": "index_home_feed_cache_channelId",
+            "unique": false,
+            "columnNames": [
+              "channelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_home_feed_cache_channelId` ON `${TABLE_NAME}` (`channelId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "subscription_groups",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`name` TEXT NOT NULL, `channelIds` TEXT NOT NULL, `sortOrder` INTEGER NOT NULL, PRIMARY KEY(`name`))",
+        "fields": [
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "channelIds",
+            "columnName": "channelIds",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sortOrder",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "name"
+          ]
+        }
+      },
+      {
+        "tableName": "recognition_history",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `trackId` TEXT NOT NULL, `title` TEXT NOT NULL, `artist` TEXT NOT NULL, `album` TEXT, `coverArtUrl` TEXT, `coverArtHqUrl` TEXT, `genre` TEXT, `releaseDate` TEXT, `label` TEXT, `shazamUrl` TEXT, `appleMusicUrl` TEXT, `spotifyUrl` TEXT, `isrc` TEXT, `youtubeVideoId` TEXT, `recognizedAt` INTEGER NOT NULL, `liked` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "trackId",
+            "columnName": "trackId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artist",
+            "columnName": "artist",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "album",
+            "columnName": "album",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverArtUrl",
+            "columnName": "coverArtUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "coverArtHqUrl",
+            "columnName": "coverArtHqUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "genre",
+            "columnName": "genre",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "releaseDate",
+            "columnName": "releaseDate",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "label",
+            "columnName": "label",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "shazamUrl",
+            "columnName": "shazamUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "appleMusicUrl",
+            "columnName": "appleMusicUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "spotifyUrl",
+            "columnName": "spotifyUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "isrc",
+            "columnName": "isrc",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "youtubeVideoId",
+            "columnName": "youtubeVideoId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "recognizedAt",
+            "columnName": "recognizedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "liked",
+            "columnName": "liked",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_recognition_history_trackId",
+            "unique": false,
+            "columnNames": [
+              "trackId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_recognition_history_trackId` ON `${TABLE_NAME}` (`trackId`)"
+          },
+          {
+            "name": "index_recognition_history_recognizedAt",
+            "unique": false,
+            "columnNames": [
+              "recognizedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_recognition_history_recognizedAt` ON `${TABLE_NAME}` (`recognizedAt`)"
+          },
+          {
+            "name": "index_recognition_history_title",
+            "unique": false,
+            "columnNames": [
+              "title"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_recognition_history_title` ON `${TABLE_NAME}` (`title`)"
+          },
+          {
+            "name": "index_recognition_history_artist",
+            "unique": false,
+            "columnNames": [
+              "artist"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_recognition_history_artist` ON `${TABLE_NAME}` (`artist`)"
+          }
+        ]
+      },
+      {
+        "tableName": "sync_log",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`peerDeviceId` TEXT NOT NULL, `collection` TEXT NOT NULL, `payloadHash` TEXT NOT NULL, `appliedAt` INTEGER NOT NULL, `hwmHlc` TEXT NOT NULL, PRIMARY KEY(`peerDeviceId`, `collection`, `payloadHash`))",
+        "fields": [
+          {
+            "fieldPath": "peerDeviceId",
+            "columnName": "peerDeviceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "collection",
+            "columnName": "collection",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "payloadHash",
+            "columnName": "payloadHash",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "appliedAt",
+            "columnName": "appliedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hwmHlc",
+            "columnName": "hwmHlc",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "peerDeviceId",
+            "collection",
+            "payloadHash"
+          ]
+        }
+      },
+      {
+        "tableName": "sync_peers",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`deviceId` TEXT NOT NULL, `deviceName` TEXT NOT NULL, `platform` TEXT NOT NULL, `lastSyncedAt` INTEGER NOT NULL, PRIMARY KEY(`deviceId`))",
+        "fields": [
+          {
+            "fieldPath": "deviceId",
+            "columnName": "deviceId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deviceName",
+            "columnName": "deviceName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "platform",
+            "columnName": "platform",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedAt",
+            "columnName": "lastSyncedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "deviceId"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'a9a38ff6e6cdcd13b12295d9433a2c0e')"
+    ]
+  }
+}

--- a/app/src/androidTest/java/io/github/aedev/flow/HiltTestRunner.kt
+++ b/app/src/androidTest/java/io/github/aedev/flow/HiltTestRunner.kt
@@ -6,7 +6,9 @@ import androidx.test.runner.AndroidJUnitRunner
 import dagger.hilt.android.testing.HiltTestApplication
 
 class HiltTestRunner : AndroidJUnitRunner() {
-    override fun newApplication(cl: ClassLoader?, name: String?, context: Context?): Application {
-        return super.newApplication(cl, HiltTestApplication::class.java.name, context)
-    }
+    override fun newApplication(
+        cl: ClassLoader?,
+        name: String?,
+        context: Context?,
+    ): Application = super.newApplication(cl, HiltTestApplication::class.java.name, context)
 }

--- a/app/src/androidTest/java/io/github/aedev/flow/data/local/SyncMigrationTest.kt
+++ b/app/src/androidTest/java/io/github/aedev/flow/data/local/SyncMigrationTest.kt
@@ -5,6 +5,8 @@ import androidx.sqlite.db.SupportSQLiteOpenHelper
 import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import io.github.aedev.flow.data.local.migrations.Migration20To21
+import io.github.aedev.flow.data.local.migrations.Migration21To22
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Test
@@ -12,34 +14,39 @@ import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 class SyncMigrationTest {
-
     /** A bare in-memory DB at schema v20 with just the pre-migration `playlists` table. */
     private fun openV20(): SupportSQLiteDatabase {
-        val config = SupportSQLiteOpenHelper.Configuration
-            .builder(ApplicationProvider.getApplicationContext())
-            .name(null) // in-memory
-            .callback(object : SupportSQLiteOpenHelper.Callback(20) {
-                override fun onCreate(db: SupportSQLiteDatabase) {
-                    db.execSQL(
-                        """
-                        CREATE TABLE playlists (
-                            id TEXT NOT NULL PRIMARY KEY,
-                            name TEXT NOT NULL,
-                            description TEXT NOT NULL,
-                            thumbnailUrl TEXT NOT NULL,
-                            isPrivate INTEGER NOT NULL,
-                            createdAt INTEGER NOT NULL,
-                            videoCount INTEGER NOT NULL DEFAULT 0,
-                            isMusic INTEGER NOT NULL DEFAULT 0,
-                            isUserCreated INTEGER NOT NULL DEFAULT 1
-                        )
-                        """.trimIndent(),
-                    )
-                }
+        val config =
+            SupportSQLiteOpenHelper.Configuration
+                .builder(ApplicationProvider.getApplicationContext())
+                .name(null) // in-memory
+                .callback(
+                    object : SupportSQLiteOpenHelper.Callback(20) {
+                        override fun onCreate(db: SupportSQLiteDatabase) {
+                            db.execSQL(
+                                """
+                                CREATE TABLE playlists (
+                                    id TEXT NOT NULL PRIMARY KEY,
+                                    name TEXT NOT NULL,
+                                    description TEXT NOT NULL,
+                                    thumbnailUrl TEXT NOT NULL,
+                                    isPrivate INTEGER NOT NULL,
+                                    createdAt INTEGER NOT NULL,
+                                    videoCount INTEGER NOT NULL DEFAULT 0,
+                                    isMusic INTEGER NOT NULL DEFAULT 0,
+                                    isUserCreated INTEGER NOT NULL DEFAULT 1
+                                )
+                                """.trimIndent(),
+                            )
+                        }
 
-                override fun onUpgrade(db: SupportSQLiteDatabase, oldVersion: Int, newVersion: Int) {}
-            })
-            .build()
+                        override fun onUpgrade(
+                            db: SupportSQLiteDatabase,
+                            oldVersion: Int,
+                            newVersion: Int,
+                        ) {}
+                    },
+                ).build()
         return FrameworkSQLiteOpenHelperFactory().create(config).writableDatabase
     }
 
@@ -51,8 +58,8 @@ class SyncMigrationTest {
                 "VALUES ('pl1','My Playlist','','',0,123456789)",
         )
 
-        AppDatabase.MIGRATION_20_21.migrate(db)
-        AppDatabase.MIGRATION_21_22.migrate(db)
+        Migration20To21().migrate(db)
+        Migration21To22().migrate(db)
 
         // syncId added + backfilled (lower(hex(randomblob(16))) → 32 hex chars).
         db.query("SELECT syncId FROM playlists WHERE id='pl1'").use { c ->

--- a/app/src/main/java/io/github/aedev/flow/data/local/AppDatabase.kt
+++ b/app/src/main/java/io/github/aedev/flow/data/local/AppDatabase.kt
@@ -1,9 +1,8 @@
 package io.github.aedev.flow.data.local
 
 import androidx.room.Database
+import androidx.room.Room.databaseBuilder
 import androidx.room.RoomDatabase
-import androidx.room.migration.Migration
-import androidx.sqlite.db.SupportSQLiteDatabase
 import io.github.aedev.flow.data.local.dao.CacheDao
 import io.github.aedev.flow.data.local.dao.DownloadDao
 import io.github.aedev.flow.data.local.dao.DownloadedSongDao
@@ -21,17 +20,18 @@ import io.github.aedev.flow.data.local.entity.DownloadItemEntity
 import io.github.aedev.flow.data.local.entity.DownloadedSongEntity
 import io.github.aedev.flow.data.local.entity.HomeFeedCacheEntity
 import io.github.aedev.flow.data.local.entity.MusicHomeCacheEntity
+import io.github.aedev.flow.data.local.entity.MusicHomeChipEntity
 import io.github.aedev.flow.data.local.entity.NotificationEntity
 import io.github.aedev.flow.data.local.entity.PlaylistEntity
 import io.github.aedev.flow.data.local.entity.PlaylistVideoCrossRef
 import io.github.aedev.flow.data.local.entity.RecognitionHistoryEntity
-import io.github.aedev.flow.data.local.entity.MusicHomeChipEntity
 import io.github.aedev.flow.data.local.entity.SubscriptionFeedEntity
 import io.github.aedev.flow.data.local.entity.SubscriptionGroupEntity
 import io.github.aedev.flow.data.local.entity.SyncLogEntity
 import io.github.aedev.flow.data.local.entity.SyncPeerEntity
 import io.github.aedev.flow.data.local.entity.VideoEntity
 import io.github.aedev.flow.data.local.entity.WatchHistoryEntity
+import io.github.aedev.flow.data.local.migrations.MIGRATIONS
 
 @Database(
     entities = [
@@ -50,246 +50,53 @@ import io.github.aedev.flow.data.local.entity.WatchHistoryEntity
         SubscriptionGroupEntity::class,
         RecognitionHistoryEntity::class,
         SyncLogEntity::class,
-        SyncPeerEntity::class
+        SyncPeerEntity::class,
     ],
     version = 24,
-    exportSchema = false
+    exportSchema = true,
 )
 abstract class AppDatabase : RoomDatabase() {
     abstract fun videoDao(): VideoDao
+
     abstract fun playlistDao(): PlaylistDao
+
     abstract fun notificationDao(): NotificationDao
+
     abstract fun cacheDao(): CacheDao
+
     abstract fun downloadedSongDao(): DownloadedSongDao
+
     abstract fun downloadDao(): DownloadDao
+
     abstract fun watchHistoryDao(): WatchHistoryDao
+
     abstract fun homeFeedCacheDao(): HomeFeedCacheDao
+
     abstract fun subscriptionGroupDao(): SubscriptionGroupDao
+
     abstract fun recognitionHistoryDao(): RecognitionHistoryDao
+
     abstract fun syncLogDao(): SyncLogDao
+
     abstract fun syncPeerDao(): SyncPeerDao
 
     companion object {
         @Volatile
+        @Suppress("ktlint:standard:property-naming")
         private var INSTANCE: AppDatabase? = null
 
-        val MIGRATION_10_11 = object : Migration(10, 11) {
-            override fun migrate(db: SupportSQLiteDatabase) {
-                db.execSQL(
-                    """
-                    CREATE TABLE IF NOT EXISTS watch_history (
-                        videoId      TEXT    NOT NULL PRIMARY KEY,
-                        position     INTEGER NOT NULL,
-                        duration     INTEGER NOT NULL,
-                        timestamp    INTEGER NOT NULL,
-                        title        TEXT    NOT NULL,
-                        thumbnailUrl TEXT    NOT NULL,
-                        channelName  TEXT    NOT NULL,
-                        channelId    TEXT    NOT NULL,
-                        isMusic      INTEGER NOT NULL
-                    )
-                    """.trimIndent()
-                )
-                db.execSQL("CREATE UNIQUE INDEX IF NOT EXISTS index_watch_history_videoId ON watch_history(videoId)")
-                db.execSQL("CREATE INDEX IF NOT EXISTS index_watch_history_timestamp ON watch_history(timestamp)")
-                db.execSQL("CREATE INDEX IF NOT EXISTS index_watch_history_isMusic ON watch_history(isMusic)")
-            }
-        }
-
-        // Devices that installed the buggy 10→11 migration (missing the unique
-        // videoId index) need this patch migration to add it.
-        val MIGRATION_11_12 = object : Migration(11, 12) {
-            override fun migrate(db: SupportSQLiteDatabase) {
-                db.execSQL("CREATE UNIQUE INDEX IF NOT EXISTS index_watch_history_videoId ON watch_history(videoId)")
-            }
-        }
-
-        val MIGRATION_12_13 = object : Migration(12, 13) {
-            override fun migrate(db: SupportSQLiteDatabase) {
-                db.execSQL("ALTER TABLE playlists ADD COLUMN isUserCreated INTEGER NOT NULL DEFAULT 1")
-            }
-        }
-
-        val MIGRATION_13_14 = object : Migration(13, 14) {
-            override fun migrate(db: SupportSQLiteDatabase) {
-                db.execSQL("ALTER TABLE downloads ADD COLUMN sponsorBlockSegmentsJson TEXT")
-            }
-        }
-
-        val MIGRATION_14_15 = object : Migration(14, 15) {
-            override fun migrate(db: SupportSQLiteDatabase) {
-                db.execSQL(
-                    """
-                    CREATE TABLE IF NOT EXISTS subscription_groups (
-                        name TEXT NOT NULL PRIMARY KEY,
-                        channelIds TEXT NOT NULL DEFAULT '',
-                        sortOrder INTEGER NOT NULL DEFAULT 0
-                    )
-                    """.trimIndent()
-                )
-            }
-        }
-
-        val MIGRATION_15_16 = object : Migration(15, 16) {
-            override fun migrate(db: SupportSQLiteDatabase) {
-                db.execSQL("ALTER TABLE subscription_feed_cache ADD COLUMN isLive INTEGER NOT NULL DEFAULT 0")
-            }
-        }
-
-        val MIGRATION_16_17 = object : Migration(16, 17) {
-            override fun migrate(db: SupportSQLiteDatabase) {
-                db.execSQL("ALTER TABLE watch_history ADD COLUMN isShort INTEGER NOT NULL DEFAULT 0")
-                db.execSQL("CREATE INDEX IF NOT EXISTS index_watch_history_isShort ON watch_history(isShort)")
-            }
-        }
-
-        val MIGRATION_17_18 = object : Migration(17, 18) {
-            override fun migrate(db: SupportSQLiteDatabase) {
-                db.execSQL("ALTER TABLE subscription_feed_cache ADD COLUMN isUpcoming INTEGER NOT NULL DEFAULT 0")
-            }
-        }
-
-        val MIGRATION_18_19 = object : Migration(18, 19) {
-            override fun migrate(db: SupportSQLiteDatabase) {
-                db.execSQL("ALTER TABLE watch_history ADD COLUMN isLocal INTEGER NOT NULL DEFAULT 0")
-                db.execSQL("CREATE INDEX IF NOT EXISTS index_watch_history_isLocal ON watch_history(isLocal)")
-            }
-        }
-
-        val MIGRATION_19_20 = object : Migration(19, 20) {
-            override fun migrate(db: SupportSQLiteDatabase) {
-                db.execSQL(
-                    """
-                    CREATE TABLE IF NOT EXISTS recognition_history (
-                        id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
-                        trackId TEXT NOT NULL,
-                        title TEXT NOT NULL,
-                        artist TEXT NOT NULL,
-                        album TEXT,
-                        coverArtUrl TEXT,
-                        coverArtHqUrl TEXT,
-                        genre TEXT,
-                        releaseDate TEXT,
-                        label TEXT,
-                        shazamUrl TEXT,
-                        appleMusicUrl TEXT,
-                        spotifyUrl TEXT,
-                        isrc TEXT,
-                        youtubeVideoId TEXT,
-                        recognizedAt INTEGER NOT NULL,
-                        liked INTEGER NOT NULL DEFAULT 0
-                    )
-                    """.trimIndent()
-                )
-                db.execSQL("CREATE INDEX IF NOT EXISTS index_recognition_history_trackId ON recognition_history(trackId)")
-                db.execSQL("CREATE INDEX IF NOT EXISTS index_recognition_history_recognizedAt ON recognition_history(recognizedAt)")
-                db.execSQL("CREATE INDEX IF NOT EXISTS index_recognition_history_title ON recognition_history(title)")
-                db.execSQL("CREATE INDEX IF NOT EXISTS index_recognition_history_artist ON recognition_history(artist)")
-            }
-        }
-
-        // Device Sync (FLOW-SYNC/1): stable cross-device playlist identity.
-        val MIGRATION_20_21 = object : Migration(20, 21) {
-            override fun migrate(db: SupportSQLiteDatabase) {
-                db.execSQL("ALTER TABLE playlists ADD COLUMN syncId TEXT")
-                db.execSQL("UPDATE playlists SET syncId = lower(hex(randomblob(16))) WHERE syncId IS NULL")
-                db.execSQL("CREATE INDEX IF NOT EXISTS index_playlists_syncId ON playlists(syncId)")
-            }
-        }
-
-        // Device Sync (FLOW-SYNC/1): idempotency ledger + known peers.
-        val MIGRATION_21_22 = object : Migration(21, 22) {
-            override fun migrate(db: SupportSQLiteDatabase) {
-                db.execSQL(
-                    """
-                    CREATE TABLE IF NOT EXISTS sync_log (
-                        peerDeviceId TEXT NOT NULL,
-                        collection   TEXT NOT NULL,
-                        payloadHash  TEXT NOT NULL,
-                        appliedAt    INTEGER NOT NULL,
-                        hwmHlc       TEXT NOT NULL,
-                        PRIMARY KEY(peerDeviceId, collection, payloadHash)
-                    )
-                    """.trimIndent()
-                )
-                db.execSQL(
-                    """
-                    CREATE TABLE IF NOT EXISTS sync_peers (
-                        deviceId     TEXT NOT NULL PRIMARY KEY,
-                        deviceName   TEXT NOT NULL,
-                        platform     TEXT NOT NULL,
-                        lastSyncedAt INTEGER NOT NULL
-                    )
-                    """.trimIndent()
-                )
-            }
-        }
-
-        val MIGRATION_22_23 = object : Migration(22, 23) {
-            override fun migrate(db: SupportSQLiteDatabase) {
-                db.execSQL(
-                    """
-                    CREATE TABLE IF NOT EXISTS home_feed_cache (
-                        cacheKey            TEXT    NOT NULL PRIMARY KEY,
-                        bucket              TEXT    NOT NULL,
-                        videoId             TEXT    NOT NULL,
-                        title               TEXT    NOT NULL,
-                        channelName         TEXT    NOT NULL,
-                        channelId           TEXT    NOT NULL,
-                        thumbnailUrl        TEXT    NOT NULL,
-                        duration            INTEGER NOT NULL,
-                        viewCount           INTEGER NOT NULL,
-                        likeCount           INTEGER NOT NULL,
-                        uploadDate          TEXT    NOT NULL,
-                        timestamp           INTEGER NOT NULL,
-                        description         TEXT    NOT NULL,
-                        channelThumbnailUrl TEXT    NOT NULL,
-                        tagsJson            TEXT    NOT NULL,
-                        isMusic             INTEGER NOT NULL,
-                        isLive              INTEGER NOT NULL,
-                        isShort             INTEGER NOT NULL,
-                        isUpcoming          INTEGER NOT NULL,
-                        commentCountText    TEXT    NOT NULL,
-                        source              TEXT    NOT NULL,
-                        relatedSeedId       TEXT,
-                        cachedAt            INTEGER NOT NULL,
-                        expiresAt           INTEGER NOT NULL,
-                        orderIndex          INTEGER NOT NULL
-                    )
-                    """.trimIndent()
-                )
-                db.execSQL("CREATE INDEX IF NOT EXISTS index_home_feed_cache_bucket_expiresAt ON home_feed_cache(bucket, expiresAt)")
-                db.execSQL("CREATE INDEX IF NOT EXISTS index_home_feed_cache_bucket_source ON home_feed_cache(bucket, source)")
-                db.execSQL("CREATE INDEX IF NOT EXISTS index_home_feed_cache_relatedSeedId ON home_feed_cache(relatedSeedId)")
-                db.execSQL("CREATE INDEX IF NOT EXISTS index_home_feed_cache_videoId ON home_feed_cache(videoId)")
-                db.execSQL("CREATE INDEX IF NOT EXISTS index_home_feed_cache_channelId ON home_feed_cache(channelId)")
-            }
-        }
-
-        // Per-playlist "added at" timestamp so owned playlists can show when a video was added
-        // instead of stale cached view counts / upload dates.
-        val MIGRATION_23_24 = object : Migration(23, 24) {
-            override fun migrate(db: SupportSQLiteDatabase) {
-                db.execSQL("ALTER TABLE playlist_video_cross_ref ADD COLUMN addedAt INTEGER NOT NULL DEFAULT 0")
-                // Freshly-added rows historically stored -System.currentTimeMillis() in `position`
-                // (before manual reordering overwrote it) — recover that as the add time.
-                db.execSQL("UPDATE playlist_video_cross_ref SET addedAt = -position WHERE position < 0")
-            }
-        }
-
-        fun getDatabase(context: android.content.Context): AppDatabase {
-            return INSTANCE ?: synchronized(this) {
-                val instance = androidx.room.Room.databaseBuilder(
-                    context.applicationContext,
-                    AppDatabase::class.java,
-                    "flow_database"
-                )
-                .addMigrations(MIGRATION_10_11, MIGRATION_11_12, MIGRATION_12_13, MIGRATION_13_14, MIGRATION_14_15, MIGRATION_15_16, MIGRATION_16_17, MIGRATION_17_18, MIGRATION_18_19, MIGRATION_19_20, MIGRATION_20_21, MIGRATION_21_22, MIGRATION_22_23, MIGRATION_23_24)
-                .fallbackToDestructiveMigration()
-                .build()
+        fun getDatabase(context: android.content.Context): AppDatabase =
+            INSTANCE ?: synchronized(this) {
+                val instance =
+                    databaseBuilder(
+                        context.applicationContext,
+                        AppDatabase::class.java,
+                        "flow_database",
+                    ).addMigrations(*MIGRATIONS)
+                        .fallbackToDestructiveMigration(false)
+                        .build()
                 INSTANCE = instance
                 instance
             }
-        }
     }
 }

--- a/app/src/main/java/io/github/aedev/flow/data/local/migrations/Migration10To11.kt
+++ b/app/src/main/java/io/github/aedev/flow/data/local/migrations/Migration10To11.kt
@@ -1,0 +1,27 @@
+package io.github.aedev.flow.data.local.migrations
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+class Migration10To11 : Migration(10, 11) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL(
+            """
+            CREATE TABLE IF NOT EXISTS watch_history (
+                videoId      TEXT    NOT NULL PRIMARY KEY,
+                position     INTEGER NOT NULL,
+                duration     INTEGER NOT NULL,
+                timestamp    INTEGER NOT NULL,
+                title        TEXT    NOT NULL,
+                thumbnailUrl TEXT    NOT NULL,
+                channelName  TEXT    NOT NULL,
+                channelId    TEXT    NOT NULL,
+                isMusic      INTEGER NOT NULL
+            )
+            """.trimIndent(),
+        )
+        db.execSQL("CREATE UNIQUE INDEX IF NOT EXISTS index_watch_history_videoId ON watch_history(videoId)")
+        db.execSQL("CREATE INDEX IF NOT EXISTS index_watch_history_timestamp ON watch_history(timestamp)")
+        db.execSQL("CREATE INDEX IF NOT EXISTS index_watch_history_isMusic ON watch_history(isMusic)")
+    }
+}

--- a/app/src/main/java/io/github/aedev/flow/data/local/migrations/Migration11To12.kt
+++ b/app/src/main/java/io/github/aedev/flow/data/local/migrations/Migration11To12.kt
@@ -1,0 +1,12 @@
+package io.github.aedev.flow.data.local.migrations
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+// Devices that installed the buggy 10→11 migration (missing the unique
+// videoId index) need this patch migration to add it.
+class Migration11To12 : Migration(11, 12) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL("CREATE UNIQUE INDEX IF NOT EXISTS index_watch_history_videoId ON watch_history(videoId)")
+    }
+}

--- a/app/src/main/java/io/github/aedev/flow/data/local/migrations/Migration12To13.kt
+++ b/app/src/main/java/io/github/aedev/flow/data/local/migrations/Migration12To13.kt
@@ -1,0 +1,10 @@
+package io.github.aedev.flow.data.local.migrations
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+class Migration12To13 : Migration(12, 13) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL("ALTER TABLE playlists ADD COLUMN isUserCreated INTEGER NOT NULL DEFAULT 1")
+    }
+}

--- a/app/src/main/java/io/github/aedev/flow/data/local/migrations/Migration13To14.kt
+++ b/app/src/main/java/io/github/aedev/flow/data/local/migrations/Migration13To14.kt
@@ -1,0 +1,10 @@
+package io.github.aedev.flow.data.local.migrations
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+class Migration13To14 : Migration(13, 14) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL("ALTER TABLE downloads ADD COLUMN sponsorBlockSegmentsJson TEXT")
+    }
+}

--- a/app/src/main/java/io/github/aedev/flow/data/local/migrations/Migration14To15.kt
+++ b/app/src/main/java/io/github/aedev/flow/data/local/migrations/Migration14To15.kt
@@ -1,0 +1,18 @@
+package io.github.aedev.flow.data.local.migrations
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+class Migration14To15 : Migration(14, 15) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL(
+            """
+            CREATE TABLE IF NOT EXISTS subscription_groups (
+                name TEXT NOT NULL PRIMARY KEY,
+                channelIds TEXT NOT NULL DEFAULT '',
+                sortOrder INTEGER NOT NULL DEFAULT 0
+            )
+            """.trimIndent(),
+        )
+    }
+}

--- a/app/src/main/java/io/github/aedev/flow/data/local/migrations/Migration15To16.kt
+++ b/app/src/main/java/io/github/aedev/flow/data/local/migrations/Migration15To16.kt
@@ -1,0 +1,10 @@
+package io.github.aedev.flow.data.local.migrations
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+class Migration15To16 : Migration(15, 16) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL("ALTER TABLE subscription_feed_cache ADD COLUMN isLive INTEGER NOT NULL DEFAULT 0")
+    }
+}

--- a/app/src/main/java/io/github/aedev/flow/data/local/migrations/Migration16To17.kt
+++ b/app/src/main/java/io/github/aedev/flow/data/local/migrations/Migration16To17.kt
@@ -1,0 +1,11 @@
+package io.github.aedev.flow.data.local.migrations
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+class Migration16To17 : Migration(16, 17) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL("ALTER TABLE watch_history ADD COLUMN isShort INTEGER NOT NULL DEFAULT 0")
+        db.execSQL("CREATE INDEX IF NOT EXISTS index_watch_history_isShort ON watch_history(isShort)")
+    }
+}

--- a/app/src/main/java/io/github/aedev/flow/data/local/migrations/Migration17To18.kt
+++ b/app/src/main/java/io/github/aedev/flow/data/local/migrations/Migration17To18.kt
@@ -1,0 +1,10 @@
+package io.github.aedev.flow.data.local.migrations
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+class Migration17To18 : Migration(17, 18) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL("ALTER TABLE subscription_feed_cache ADD COLUMN isUpcoming INTEGER NOT NULL DEFAULT 0")
+    }
+}

--- a/app/src/main/java/io/github/aedev/flow/data/local/migrations/Migration18To19.kt
+++ b/app/src/main/java/io/github/aedev/flow/data/local/migrations/Migration18To19.kt
@@ -1,0 +1,11 @@
+package io.github.aedev.flow.data.local.migrations
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+class Migration18To19 : Migration(18, 19) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL("ALTER TABLE watch_history ADD COLUMN isLocal INTEGER NOT NULL DEFAULT 0")
+        db.execSQL("CREATE INDEX IF NOT EXISTS index_watch_history_isLocal ON watch_history(isLocal)")
+    }
+}

--- a/app/src/main/java/io/github/aedev/flow/data/local/migrations/Migration19To20.kt
+++ b/app/src/main/java/io/github/aedev/flow/data/local/migrations/Migration19To20.kt
@@ -1,0 +1,36 @@
+package io.github.aedev.flow.data.local.migrations
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+class Migration19To20 : Migration(19, 20) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL(
+            """
+            CREATE TABLE IF NOT EXISTS recognition_history (
+                id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+                trackId TEXT NOT NULL,
+                title TEXT NOT NULL,
+                artist TEXT NOT NULL,
+                album TEXT,
+                coverArtUrl TEXT,
+                coverArtHqUrl TEXT,
+                genre TEXT,
+                releaseDate TEXT,
+                label TEXT,
+                shazamUrl TEXT,
+                appleMusicUrl TEXT,
+                spotifyUrl TEXT,
+                isrc TEXT,
+                youtubeVideoId TEXT,
+                recognizedAt INTEGER NOT NULL,
+                liked INTEGER NOT NULL DEFAULT 0
+            )
+            """.trimIndent(),
+        )
+        db.execSQL("CREATE INDEX IF NOT EXISTS index_recognition_history_trackId ON recognition_history(trackId)")
+        db.execSQL("CREATE INDEX IF NOT EXISTS index_recognition_history_recognizedAt ON recognition_history(recognizedAt)")
+        db.execSQL("CREATE INDEX IF NOT EXISTS index_recognition_history_title ON recognition_history(title)")
+        db.execSQL("CREATE INDEX IF NOT EXISTS index_recognition_history_artist ON recognition_history(artist)")
+    }
+}

--- a/app/src/main/java/io/github/aedev/flow/data/local/migrations/Migration20To21.kt
+++ b/app/src/main/java/io/github/aedev/flow/data/local/migrations/Migration20To21.kt
@@ -1,0 +1,13 @@
+package io.github.aedev.flow.data.local.migrations
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+// Device Sync (FLOW-SYNC/1): stable cross-device playlist identity.
+class Migration20To21 : Migration(20, 21) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL("ALTER TABLE playlists ADD COLUMN syncId TEXT")
+        db.execSQL("UPDATE playlists SET syncId = lower(hex(randomblob(16))) WHERE syncId IS NULL")
+        db.execSQL("CREATE INDEX IF NOT EXISTS index_playlists_syncId ON playlists(syncId)")
+    }
+}

--- a/app/src/main/java/io/github/aedev/flow/data/local/migrations/Migration21To22.kt
+++ b/app/src/main/java/io/github/aedev/flow/data/local/migrations/Migration21To22.kt
@@ -1,0 +1,32 @@
+package io.github.aedev.flow.data.local.migrations
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+// Device Sync (FLOW-SYNC/1): idempotency ledger + known peers.
+class Migration21To22 : Migration(21, 22) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL(
+            """
+            CREATE TABLE IF NOT EXISTS sync_log (
+                peerDeviceId TEXT NOT NULL,
+                collection   TEXT NOT NULL,
+                payloadHash  TEXT NOT NULL,
+                appliedAt    INTEGER NOT NULL,
+                hwmHlc       TEXT NOT NULL,
+                PRIMARY KEY(peerDeviceId, collection, payloadHash)
+            )
+            """.trimIndent(),
+        )
+        db.execSQL(
+            """
+            CREATE TABLE IF NOT EXISTS sync_peers (
+                deviceId     TEXT NOT NULL PRIMARY KEY,
+                deviceName   TEXT NOT NULL,
+                platform     TEXT NOT NULL,
+                lastSyncedAt INTEGER NOT NULL
+            )
+            """.trimIndent(),
+        )
+    }
+}

--- a/app/src/main/java/io/github/aedev/flow/data/local/migrations/Migration22To23.kt
+++ b/app/src/main/java/io/github/aedev/flow/data/local/migrations/Migration22To23.kt
@@ -1,0 +1,45 @@
+package io.github.aedev.flow.data.local.migrations
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+class Migration22To23 : Migration(22, 23) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL(
+            """
+            CREATE TABLE IF NOT EXISTS home_feed_cache (
+                cacheKey            TEXT    NOT NULL PRIMARY KEY,
+                bucket              TEXT    NOT NULL,
+                videoId             TEXT    NOT NULL,
+                title               TEXT    NOT NULL,
+                channelName         TEXT    NOT NULL,
+                channelId           TEXT    NOT NULL,
+                thumbnailUrl        TEXT    NOT NULL,
+                duration            INTEGER NOT NULL,
+                viewCount           INTEGER NOT NULL,
+                likeCount           INTEGER NOT NULL,
+                uploadDate          TEXT    NOT NULL,
+                timestamp           INTEGER NOT NULL,
+                description         TEXT    NOT NULL,
+                channelThumbnailUrl TEXT    NOT NULL,
+                tagsJson            TEXT    NOT NULL,
+                isMusic             INTEGER NOT NULL,
+                isLive              INTEGER NOT NULL,
+                isShort             INTEGER NOT NULL,
+                isUpcoming          INTEGER NOT NULL,
+                commentCountText    TEXT    NOT NULL,
+                source              TEXT    NOT NULL,
+                relatedSeedId       TEXT,
+                cachedAt            INTEGER NOT NULL,
+                expiresAt           INTEGER NOT NULL,
+                orderIndex          INTEGER NOT NULL
+            )
+            """.trimIndent(),
+        )
+        db.execSQL("CREATE INDEX IF NOT EXISTS index_home_feed_cache_bucket_expiresAt ON home_feed_cache(bucket, expiresAt)")
+        db.execSQL("CREATE INDEX IF NOT EXISTS index_home_feed_cache_bucket_source ON home_feed_cache(bucket, source)")
+        db.execSQL("CREATE INDEX IF NOT EXISTS index_home_feed_cache_relatedSeedId ON home_feed_cache(relatedSeedId)")
+        db.execSQL("CREATE INDEX IF NOT EXISTS index_home_feed_cache_videoId ON home_feed_cache(videoId)")
+        db.execSQL("CREATE INDEX IF NOT EXISTS index_home_feed_cache_channelId ON home_feed_cache(channelId)")
+    }
+}

--- a/app/src/main/java/io/github/aedev/flow/data/local/migrations/Migration23To24.kt
+++ b/app/src/main/java/io/github/aedev/flow/data/local/migrations/Migration23To24.kt
@@ -1,0 +1,15 @@
+package io.github.aedev.flow.data.local.migrations
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+// Per-playlist "added at" timestamp so owned playlists can show when a video was added
+// instead of stale cached view counts / upload dates.
+class Migration23To24 : Migration(23, 24) {
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL("ALTER TABLE playlist_video_cross_ref ADD COLUMN addedAt INTEGER NOT NULL DEFAULT 0")
+        // Freshly-added rows historically stored -System.currentTimeMillis() in `position`
+        // (before manual reordering overwrote it) — recover that as the add time.
+        db.execSQL("UPDATE playlist_video_cross_ref SET addedAt = -position WHERE position < 0")
+    }
+}

--- a/app/src/main/java/io/github/aedev/flow/data/local/migrations/Migrations.kt
+++ b/app/src/main/java/io/github/aedev/flow/data/local/migrations/Migrations.kt
@@ -1,0 +1,21 @@
+package io.github.aedev.flow.data.local.migrations
+
+import androidx.room.migration.Migration
+
+val MIGRATIONS: Array<Migration> =
+    arrayOf(
+        Migration10To11(),
+        Migration11To12(),
+        Migration12To13(),
+        Migration13To14(),
+        Migration14To15(),
+        Migration15To16(),
+        Migration16To17(),
+        Migration17To18(),
+        Migration18To19(),
+        Migration19To20(),
+        Migration20To21(),
+        Migration21To22(),
+        Migration22To23(),
+        Migration23To24(),
+    )

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,6 +17,7 @@ plugins {
     id("com.android.test") version "9.3.1" apply false
     id("androidx.baselineprofile") version "1.5.0-beta01" apply false
     id("com.diffplug.spotless") version "8.8.0"
+    alias(libs.plugins.room) apply false
 }
 
 spotless {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -131,3 +131,4 @@ kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", versi
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 android-test = { id = "com.android.test", version.ref = "agp" }
 baselineprofile = { id = "androidx.baselineprofile", version.ref = "baselineprofile" }
+room = { id = "androidx.room", version.ref = "room" }


### PR DESCRIPTION
## Summary

- Integrated the Room Gradle plugin (`androidx.room`) and configured the Room schema directory export at `app/schemas`. This will help us enable room [Automated migrations](https://developer.android.com/training/data-storage/room/migrating-db-versions#automated) and migrations test in the future.
- Exported Room database schema version 24.
- Cleaned up `AppDatabase.kt` by modularizing Room migrations: extracted all 14 individual migrations into standalone class files (`Migration10To11` through `Migration23To24`) inside `io.github.aedev.flow.data.local.migrations`.
- Inlined migration class instantiations inside the top-level `MIGRATIONS` array, reducing boilerplate in `AppDatabase.kt`.
- Updated test references in `SyncMigrationTest.kt` and `AllMigrationTest.kt`.

## Related issue

N/A

## Change type

- [ ] Bug fix
- [ ] Feature
- [x] Refactor or maintenance
- [x] Build, packaging, or CI
- [ ] Documentation

## Validation

- [x] `./gradlew :app:assembleGithubDebug`
- [x] `./gradlew :app:testGithubDebugUnitTest`
- [x] `./gradlew ktlintCheck`
- [x] I ran any additional flavor-specific build or test tasks affected by this change.
- [x] I manually tested the affected behavior on an Android device or emulator.

**Test device and Android version:**
Pixel 6 Emulator (Android 14)

## Risk and compatibility

- [x] The change does not introduce secrets, private data, or unexpected telemetry.
- [x] New user-facing text uses Android string resources.
- [x] Dependency and lockfile changes are intentional and limited to this PR.
- [x] Room schema changes include the required version bump and migration, or this PR does not change the Room schema.
- [x] Breaking changes and upgrade steps are clearly documented.