### PR TITLE
Fix the broken Star History chart in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,11 +271,11 @@ It is distributed under the **GNU General Public License v3 (GPLv3)**.
 
 ## Star History
 
-<a href="https://www.star-history.com/?repos=A-EDev%2FFlow&type=date&legend=top-left">
+<a href="https://star-history.dera.page/#A-EDev/Flow&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=A-EDev/Flow&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=A-EDev/Flow&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=A-EDev/Flow&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=A-EDev/Flow&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=A-EDev/Flow&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=A-EDev/Flow&type=date&legend=top-left" />
  </picture>
 </a>
 


### PR DESCRIPTION
The Star History chart at the bottom of the README has been broken and no longer renders. This PR replaces it with a working alternative so contributors and visitors can still see Flow's growth at a glance.

Only the chart is affected; the rest of the README is unchanged.