### PR TITLE
fix(player): replace the gated ANDROID_VR fast path with VISIONOS and…

### DIFF
--- a/app/src/main/assets/changelog/v2.2.1.txt
+++ b/app/src/main/assets/changelog/v2.2.1.txt
@@ -22,6 +22,7 @@ IMPROVEMENTS
 - Scale the long-press speed boost from the current speed so it can never slow playback down #867
 - Restyle the long-press speed indicator as a pill showing the speed it will actually apply
 - Ripple the tapped side of the screen when double-tap seeking
+- Offer every dubbed audio track and the full quality ladder on videos that provide them
 
 PERFORMANCE
 - Faster cold start and smoother scrolling
@@ -61,6 +62,7 @@ FIXES AND STABILITY
 - Fix a crash when playback notification artwork finished loading in the background
 - Fix the playback notification disappearing when the queue auto-advanced in the background
 - Fix videos cutting out around the one-minute mark on auto-dubbed titles
+- Fix playback stopping about a minute in and then retrying until it gave up #921 #922
 - Fix the wrong audio track being requested on auto-dubbed videos
 - Fix the mini player expanding back to the full player while metadata was still loading
 - Fix playback on videos that only offer a server-side adaptive stream
@@ -74,7 +76,7 @@ FIXES AND STABILITY
 - Fix swiping down to leave fullscreen committing even after you dragged back up
 
 DEPENDENCY
-- Bump NewPipeExtractor to v0.26.4
+- Bump NewPipeExtractor to v0.26.5
 - Update Gradle to 9.6.1 and Android Gradle Plugin to 9.3.1
 - Update Kotlin to 2.4.10 with the Compose compiler plugin and KSP 2.3.11
 - Update Hilt to 2.60.1 and Room to 2.8.4

--- a/app/src/main/java/io/github/aedev/flow/innertube/models/YouTubeClient.kt
+++ b/app/src/main/java/io/github/aedev/flow/innertube/models/YouTubeClient.kt
@@ -2,6 +2,26 @@ package io.github.aedev.flow.innertube.models
 
 import kotlinx.serialization.Serializable
 
+/**
+ * Which attestation runtime mints a PO Token this client's requests will be accepted with.
+ *
+ * A PO Token is produced by BotGuard (Web), DroidGuard (Android) or iOSGuard (iOS), and one
+ * platform's token is never valid on another's URL. Flow only owns a BotGuard WebView, so [WEB]
+ * is the only family it can attest; the rest are usable exactly as long as YouTube keeps serving
+ * them unattested. Encoding that here is what stops a WEB token being stamped onto an
+ * ANDROID_VR/IOS URL, which is a claim GVS checks and rejects.
+ */
+enum class AttestationPlatform {
+    /** BotGuard — Flow mints these in [io.github.aedev.flow.utils.potoken.PoTokenWebView]. */
+    WEB,
+
+    /** DroidGuard, inside Google Play Services. Not reachable from a third-party app. */
+    DROIDGUARD,
+
+    /** iOSGuard. Not reachable at all from Android. */
+    IOSGUARD,
+}
+
 @Serializable
 data class YouTubeClient(
     val clientName: String,
@@ -25,6 +45,12 @@ data class YouTubeClient(
     val useSignatureTimestamp: Boolean = false,
     val isEmbedded: Boolean = false,
     val useWebPoTokens: Boolean = false,
+    /**
+     * The runtime that mints tokens this client's URLs will accept. Defaults to [AttestationPlatform.WEB]
+     * because every client Flow can actually attest is web-family; the non-web clients set it
+     * explicitly so token attachment can be gated on it.
+     */
+    val attestation: AttestationPlatform = AttestationPlatform.WEB,
     /**
      * Whether [userAgent] is repeated inside `context.client` as well as sent as the HTTP header.
      * Only MWEB expects this; sending it for other clients is a fingerprint inconsistency. Clients
@@ -121,6 +147,7 @@ data class YouTubeClient(
                 friendlyName = "Android",
                 loginSupported = true,
                 useSignatureTimestamp = true,
+                attestation = AttestationPlatform.DROIDGUARD,
             )
 
         val WEB_REMIX =
@@ -180,6 +207,7 @@ data class YouTubeClient(
                 clientId = "5",
                 userAgent = "com.google.ios.youtube/21.03.1 (iPhone16,2; U; CPU iOS 18_2 like Mac OS X;)",
                 osVersion = "18.2.22C152",
+                attestation = AttestationPlatform.IOSGUARD,
             )
 
         val MOBILE =
@@ -190,6 +218,7 @@ data class YouTubeClient(
                 userAgent = "com.google.android.youtube/21.03.38 (Linux; U; Android 14) gzip",
                 loginSupported = true,
                 useSignatureTimestamp = true,
+                attestation = AttestationPlatform.DROIDGUARD,
             )
 
         val ANDROID_VR_NO_AUTH =
@@ -202,6 +231,7 @@ data class YouTubeClient(
                         "(Linux; U; Android 12; en_US; Oculus Quest 3; Build/SQ3A.220605.009.A1; Cronet/132.0.6808.3)",
                 loginSupported = false,
                 useSignatureTimestamp = false,
+                attestation = AttestationPlatform.DROIDGUARD,
             )
 
         val ANDROID_VR_1_61_48 =
@@ -223,6 +253,7 @@ data class YouTubeClient(
                 friendlyName = "Android VR 1.61",
                 loginSupported = false,
                 useSignatureTimestamp = false,
+                attestation = AttestationPlatform.DROIDGUARD,
             )
 
         val ANDROID_VR_1_65_10 =
@@ -243,6 +274,7 @@ data class YouTubeClient(
                 friendlyName = "Android VR 1.65",
                 loginSupported = false,
                 useSignatureTimestamp = false,
+                attestation = AttestationPlatform.DROIDGUARD,
             )
 
         val ANDROID_VR_1_43_32 =
@@ -264,6 +296,7 @@ data class YouTubeClient(
                 friendlyName = "Android VR 1.43",
                 loginSupported = false,
                 useSignatureTimestamp = false,
+                attestation = AttestationPlatform.DROIDGUARD,
             )
 
         val ANDROID_CREATOR =
@@ -285,23 +318,36 @@ data class YouTubeClient(
                 friendlyName = "Android Studio",
                 loginSupported = true,
                 useSignatureTimestamp = true,
+                attestation = AttestationPlatform.DROIDGUARD,
             )
 
+        /**
+         * The primary direct-URL client. GVS serves its formats without a PO Token and without an
+         * `n` parameter, so it reaches first frame with no attestation and no nsig decode — the two
+         * properties ANDROID_VR was chosen for, which ANDROID_VR lost when YouTube began requiring
+         * a GVS PO Token for it (yt-dlp #17261, Aug 2026).
+         *
+         * Version-sensitive: the previous `0.1`/`RealityDevice14,1` build still answers, but serves
+         * 17 formats and a single audio track. This build serves 98 formats and every dubbed track,
+         * so do not "simplify" these values — they are the difference between a full ladder and a
+         * stub. Kept in step with yt-dlp's `visionos` entry in `youtube/_base.py`.
+         */
         val VISIONOS =
             YouTubeClient(
                 clientName = "VISIONOS",
-                clientVersion = "0.1",
+                clientVersion = "1.02",
                 clientId = "101",
                 userAgent =
-                    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 " +
-                        "(KHTML, like Gecko) Version/18.0 Safari/605.1.15",
+                    "Mozilla/5.0 (Macintosh; Intel Mac OS X 15_7_3) AppleWebKit/605.1.15 " +
+                        "(KHTML, like Gecko) Version/26.0 Safari/605.1.15",
                 osName = "visionOS",
-                osVersion = "1.3.21O771",
+                osVersion = "26.5.23O471",
                 deviceMake = "Apple",
-                deviceModel = "RealityDevice14,1",
+                deviceModel = "RealityDevice17,1",
                 friendlyName = "visionOS",
                 loginSupported = false,
                 useSignatureTimestamp = false,
+                attestation = AttestationPlatform.IOSGUARD,
             )
 
         val IPADOS =
@@ -318,6 +364,7 @@ data class YouTubeClient(
                 loginSupported = false,
                 useSignatureTimestamp = false,
                 packageName = "com.google.ios.youtube",
+                attestation = AttestationPlatform.IOSGUARD,
             )
     }
 }

--- a/app/src/main/java/io/github/aedev/flow/player/stream/InnerTubeVideoStreamExtractor.kt
+++ b/app/src/main/java/io/github/aedev/flow/player/stream/InnerTubeVideoStreamExtractor.kt
@@ -4,6 +4,7 @@ import android.net.Uri
 import android.util.Log
 import androidx.media3.common.util.UnstableApi
 import io.github.aedev.flow.innertube.YouTube
+import io.github.aedev.flow.innertube.models.AttestationPlatform
 import io.github.aedev.flow.innertube.models.YouTubeClient
 import io.github.aedev.flow.innertube.models.YouTubeLocale
 import io.github.aedev.flow.innertube.models.response.PlayerResponse
@@ -51,15 +52,12 @@ object InnerTubeVideoStreamExtractor {
         val forceSabr: Boolean,
     )
 
-    // * Fast, token-free clients tried first. They return direct adaptive URLs (played via normal DASH/progressive) when not bot-walled
+    // The token-free direct client. VISIONOS alone: it is the only client that still serves direct
+    // adaptive URLs GVS will honour for the whole video without a PO Token, and it does so without
+    // an `n` parameter, so first frame costs neither an attestation nor an nsig decode.
     private val FAST_CLIENTS: List<YouTubeClient> =
         listOf(
-            YouTubeClient.ANDROID_VR_1_61_48,
-            YouTubeClient.ANDROID_VR_NO_AUTH,
-            YouTubeClient.ANDROID_VR_1_65_10,
-            YouTubeClient.IPADOS,
-            YouTubeClient.IOS,
-            YouTubeClient.ANDROID_VR_1_43_32,
+            YouTubeClient.VISIONOS,
         )
 
     private val BOT_RESISTANT_CLIENTS: List<YouTubeClient> =
@@ -67,23 +65,38 @@ object InnerTubeVideoStreamExtractor {
             YouTubeClient.TVHTML5_SIMPLY_EMBEDDED_PLAYER,
         )
 
-    // Last-resort token-free clients tried after the durable WEB+SABR path
+    /**
+     * Direct clients GVS now cuts off after ~60s of media without a PO Token Flow cannot mint
+     * (DroidGuard). Kept below the attested SABR path rather than deleted: they still answer, still
+     * carry a full ladder, and are the difference between degraded playback and none when both
+     * VISIONOS and SABR are unavailable. Never promote these above [SABR_CLIENTS].
+     */
+    private val GATED_FALLBACK_CLIENTS: List<YouTubeClient> =
+        listOf(
+            YouTubeClient.ANDROID_VR_1_61_48,
+            YouTubeClient.ANDROID_VR_NO_AUTH,
+            YouTubeClient.ANDROID_VR_1_65_10,
+            YouTubeClient.ANDROID_VR_1_43_32,
+        )
+
+    // Last-resort token-free clients, tried after everything else
     private val LAST_RESORT_CLIENTS: List<YouTubeClient> =
         listOf(
             YouTubeClient.MOBILE,
             YouTubeClient.ANDROID_CREATOR,
         )
 
+    // MWEB first: it carries every dubbed audio track and is web-family, so its GVS token is one
+    // Flow's own BotGuard session can mint.
     private val SABR_CLIENTS: List<YouTubeClient> =
         listOf(
-            YouTubeClient.WEB,
             YouTubeClient.MWEB,
+            YouTubeClient.WEB,
         )
 
     private val LIVE_MANIFEST_CLIENTS: List<YouTubeClient> =
         listOf(
-            YouTubeClient.IOS,
-            YouTubeClient.IPADOS,
+            YouTubeClient.VISIONOS,
             YouTubeClient.TVHTML5_SIMPLY_EMBEDDED_PLAYER,
             YouTubeClient.ANDROID_VR_1_61_48,
         )
@@ -139,12 +152,6 @@ object InnerTubeVideoStreamExtractor {
                 return@withContext result
             }
 
-            tryDirectClients(videoId, BOT_RESISTANT_CLIENTS, failureReasons, liveDetected = liveDetected)?.let { direct ->
-                val result = maybeUpgradeToSabr(videoId, direct, failureReasons)
-                Log.w(TAG, "Extraction OK for $videoId via ${result.usedClient.clientName} (mode=${resultMode(result)})")
-                return@withContext result
-            }
-
             if (liveDetected[0]) {
                 tryLiveClients(videoId, failureReasons)?.let {
                     Log.w(TAG, "Live manifest for $videoId via ${it.usedClient.clientName} (live-clients)")
@@ -152,14 +159,35 @@ object InnerTubeVideoStreamExtractor {
                 }
             }
 
-            // 2) Durable path: web client + BotGuard PoToken + SABR. Survives the LOGIN_REQUIRED bot wall
+            // 2) Durable path: web client + BotGuard PoToken + SABR. Ranked above every remaining
+            // direct client because it is the only other path whose token Flow can actually mint —
+            // the clients below it are all served unattested and can be cut off mid-playback.
             trySabrClients(videoId, failureReasons)?.let {
                 Log.w(TAG, "Extraction OK for $videoId via ${it.usedClient.clientName} (mode=SABR)")
                 PlayerDiagnostics.logWarning(TAG, "extract OK $videoId mode=SABR (durable) via ${it.usedClient.clientName}")
                 return@withContext if (liveDetected[0] && !it.isLive) it.copy(isLive = true) else it
             }
 
-            // 3) Last resort: remaining token-free clients
+            tryDirectClients(videoId, BOT_RESISTANT_CLIENTS, failureReasons, liveDetected = liveDetected)?.let { direct ->
+                val result = maybeUpgradeToSabr(videoId, direct, failureReasons)
+                Log.w(TAG, "Extraction OK for $videoId via ${result.usedClient.clientName} (mode=${resultMode(result)})")
+                return@withContext result
+            }
+
+            // 3) Gated direct clients. Playable, but GVS stops serving them ~60s in, so they rank
+            // below anything attested and are only reached when the paths above are unavailable.
+            tryDirectClients(videoId, GATED_FALLBACK_CLIENTS, failureReasons, liveDetected = liveDetected)?.let { direct ->
+                val result = maybeUpgradeToSabr(videoId, direct, failureReasons)
+                Log.w(TAG, "Extraction OK for $videoId via ${result.usedClient.clientName} (mode=${resultMode(result)}/gated)")
+                PlayerDiagnostics.logWarning(
+                    TAG,
+                    "extract OK $videoId via ${result.usedClient.clientName} mode=${resultMode(result)}/GATED — " +
+                        "unattested, GVS may stop serving ~60s in",
+                )
+                return@withContext result
+            }
+
+            // 4) Last resort: remaining token-free clients
             tryDirectClients(videoId, LAST_RESORT_CLIENTS, failureReasons, allowUntransformedN = true, liveDetected = liveDetected)?.let {
                 Log.w(TAG, "Extraction OK for $videoId via ${it.usedClient.clientName} (mode=DIRECT/last-resort)")
                 PlayerDiagnostics.logWarning(TAG, "extract OK $videoId via ${it.usedClient.clientName} mode=DIRECT/last-resort")
@@ -287,14 +315,13 @@ object InnerTubeVideoStreamExtractor {
                 try {
                     Log.d(TAG, "Trying ${client.clientName} v${client.clientVersion}")
 
-                    // ANDROID_VR's /player request must be called WITHOUT a PoToken: injecting the
-                    // WEB-bound BotGuard token makes YT reject the request (non-OK / empty
-                    // streamingData), which was silently dropping playback onto the slower clients.
-                    // Its URLs still need GVS protection — that is the `pot=` URL param attached to
-                    // the winner's formats below, not the /player token. Other fast clients keep the
-                    // /player attestation.
-                    val isAndroidVr = client.clientName == "ANDROID_VR"
-                    val clientPoToken = if (isAndroidVr) null else awaitMint()?.playerRequestPoToken
+                    // Only web-family clients get the BotGuard token. Injecting it into an
+                    // ANDROID_VR/IOS /player request makes YT reject it outright (non-OK / empty
+                    // streamingData), and stamping it on their URLs is worse than sending nothing:
+                    // it is a claim GVS validates and refuses. Those clients are usable only for as
+                    // long as YouTube serves them unattested.
+                    val webAttested = client.attestation == AttestationPlatform.WEB
+                    val clientPoToken = if (webAttested) awaitMint()?.playerRequestPoToken else null
 
                     val playerResponse =
                         withTimeoutOrNull(PER_CLIENT_TIMEOUT_MS) {
@@ -405,8 +432,12 @@ object InnerTubeVideoStreamExtractor {
                     )
 
                     val urlPot =
-                        withTimeoutOrNull(STREAM_POT_ATTACH_GRACE_MS) { awaitMint() }?.streamingDataPoToken
-                    if (urlPot == null) {
+                        if (webAttested) {
+                            withTimeoutOrNull(STREAM_POT_ATTACH_GRACE_MS) { awaitMint() }?.streamingDataPoToken
+                        } else {
+                            null
+                        }
+                    if (urlPot == null && webAttested) {
                         PlayerDiagnostics.logWarning(
                             TAG,
                             "${client.clientName} winner for $videoId shipping pot-less (mint not ready in " +
@@ -524,8 +555,15 @@ object InnerTubeVideoStreamExtractor {
                 return null
             }
 
-            // StreamerContext.po_token carries the videoId-bound content token. The visitor-bound streaming token here draws
-            // sabr.media_serving_enforcement_id_error from GVS.
+            // StreamerContext.po_token carries the videoId-bound content token, which is what GVS
+            // accepts here in practice.
+            //
+            // The visitor-bound token used to draw sabr.media_serving_enforcement_id_error, and the
+            // reason is now understood: it was minted against the whole visitorData blob rather than
+            // the 11-char visitor ID GVS actually binds to (see [VisitorId]). That binding is fixed,
+            // so the streaming token is a candidate here too — but this path is the durable fallback
+            // and the videoId-bound token is the one measured to work, so switching wants an
+            // on-device A/B rather than an assumption.
             val resolved =
                 if (targetHeight > 0) {
                     SabrUrlResolver.resolveForQuality(
@@ -652,13 +690,14 @@ object InnerTubeVideoStreamExtractor {
         return null
     }
 
-    private fun PlayerResponse.isLiveNow(): Boolean {
-        val details = videoDetails
-        return details?.isLive == true ||
-            details?.isPostLiveDvr == true ||
-            playabilityStatus.liveStreamability != null ||
-            !streamingData?.hlsManifestUrl.isNullOrBlank()
-    }
+    private fun PlayerResponse.isLiveNow(): Boolean =
+        LiveDetectionRules.isLiveNow(
+            isLive = videoDetails?.isLive,
+            isPostLiveDvr = videoDetails?.isPostLiveDvr,
+            hasLiveStreamability = playabilityStatus.liveStreamability != null,
+            hasHlsManifest = !streamingData?.hlsManifestUrl.isNullOrBlank(),
+            hasAdaptiveFormats = !streamingData?.adaptiveFormats.isNullOrEmpty(),
+        )
 
     private fun PlayerResponse.toLiveResultOrNull(client: YouTubeClient): VideoExtractionResult? {
         val hls = streamingData?.hlsManifestUrl?.takeIf { it.isNotBlank() }

--- a/app/src/main/java/io/github/aedev/flow/player/stream/LiveDetectionRules.kt
+++ b/app/src/main/java/io/github/aedev/flow/player/stream/LiveDetectionRules.kt
@@ -1,0 +1,28 @@
+package io.github.aedev.flow.player.stream
+
+/**
+ * Decides whether a player response should be played as a live stream rather than as a VOD ladder.
+ *
+ * Kept pure and separate because getting it wrong is silent and expensive: a VOD misread as live is
+ * handed to the player with no video/audio formats at all, so quality and audio-track selection come
+ * up empty rather than failing loudly.
+ */
+object LiveDetectionRules {
+    /**
+     * @param hasHlsManifest whether `streamingData.hlsManifestUrl` is present. Deliberately weak
+     *   evidence: Apple-family clients (VISIONOS, IOS) return a manifest for ordinary VODs as well
+     *   as for live, so it only implies live when there is no adaptive ladder to play instead.
+     * @param hasAdaptiveFormats whether the response carries any adaptive formats.
+     */
+    fun isLiveNow(
+        isLive: Boolean?,
+        isPostLiveDvr: Boolean?,
+        hasLiveStreamability: Boolean,
+        hasHlsManifest: Boolean,
+        hasAdaptiveFormats: Boolean,
+    ): Boolean {
+        if (isLive == true || isPostLiveDvr == true) return true
+        if (hasLiveStreamability) return true
+        return hasHlsManifest && !hasAdaptiveFormats
+    }
+}

--- a/app/src/main/java/io/github/aedev/flow/utils/MusicPlayerUtils.kt
+++ b/app/src/main/java/io/github/aedev/flow/utils/MusicPlayerUtils.kt
@@ -11,11 +11,10 @@ import io.github.aedev.flow.innertube.models.YouTubeClient.Companion.ANDROID_CRE
 import io.github.aedev.flow.innertube.models.YouTubeClient.Companion.ANDROID_VR_1_43_32
 import io.github.aedev.flow.innertube.models.YouTubeClient.Companion.ANDROID_VR_1_61_48
 import io.github.aedev.flow.innertube.models.YouTubeClient.Companion.ANDROID_VR_NO_AUTH
-import io.github.aedev.flow.innertube.models.YouTubeClient.Companion.IOS
-import io.github.aedev.flow.innertube.models.YouTubeClient.Companion.IPADOS
 import io.github.aedev.flow.innertube.models.YouTubeClient.Companion.MOBILE
 import io.github.aedev.flow.innertube.models.YouTubeClient.Companion.TVHTML5
 import io.github.aedev.flow.innertube.models.YouTubeClient.Companion.TVHTML5_SIMPLY_EMBEDDED_PLAYER
+import io.github.aedev.flow.innertube.models.YouTubeClient.Companion.VISIONOS
 import io.github.aedev.flow.innertube.models.YouTubeClient.Companion.WEB
 import io.github.aedev.flow.innertube.models.YouTubeClient.Companion.WEB_CREATOR
 import io.github.aedev.flow.innertube.models.YouTubeClient.Companion.WEB_REMIX
@@ -62,22 +61,25 @@ object MusicPlayerUtils {
             ANDROID_VR_1_43_32,
             ANDROID_VR_1_61_48,
             ANDROID_CREATOR,
-            IPADOS,
             ANDROID_VR_NO_AUTH,
             MOBILE,
-            IOS,
             WEB,
             WEB_CREATOR,
         )
 
+    /**
+     * Tried before [STREAM_FALLBACK_CLIENTS]. VISIONOS leads because it is the only direct client
+     * GVS still serves past ~60s without a PO Token — the rest are unattested and get cut off
+     * mid-track, which is what stopped playlists at 59 seconds. IOS/IPADOS are gone entirely: they
+     * now return SABR-only responses with no direct URLs at all.
+     */
     private val FAST_DIRECT_STREAM_CLIENTS: Array<YouTubeClient> =
         arrayOf(
+            VISIONOS,
             ANDROID_VR_1_43_32,
             ANDROID_VR_1_61_48,
             ANDROID_VR_NO_AUTH,
-            IPADOS,
             MOBILE,
-            IOS,
             ANDROID_CREATOR,
         )
 
@@ -488,10 +490,13 @@ object MusicPlayerUtils {
             return null
         }
 
+        // Direct-URL clients skip the probe: their URLs are playable as returned, and the extra
+        // round trip would sit on the critical path to first audio.
         val needsValidation =
             validate &&
                 !client.clientName.startsWith("ANDROID") &&
-                client.clientName != "IOS"
+                client.clientName != "IOS" &&
+                client.clientName != "VISIONOS"
         if (needsValidation && !checkUrl(resolved.url, client.userAgent)) {
             Log.d(TAG, "URL validation failed for ${client.clientName}")
             return null

--- a/app/src/main/java/io/github/aedev/flow/utils/potoken/PoTokenGenerator.kt
+++ b/app/src/main/java/io/github/aedev/flow/utils/potoken/PoTokenGenerator.kt
@@ -148,10 +148,14 @@ object PoTokenGenerator {
                 // GVS honors cold/low-trust attestations only briefly (the mid-playback 403).
                 // Re-run the full BotGuard challenge until the minted token reaches the
                 // documented 110-128 byte range, like the desktop minter's retry loop.
+                // Bound to the 11-char visitor ID, not the visitorData blob it sits inside: GVS
+                // validates the streaming token against the ID, so minting against the blob yields
+                // a token that is accepted at load time and refused once enforcement kicks in.
+                val gvsBinding = VisitorId.gvsBinding(sessionId)
                 var attempt = 0
                 while (attempt < STREAMING_POT_ATTEMPTS) {
                     val generator = attestedGenerator()
-                    val pot = generator.generatePoToken(sessionId)
+                    val pot = generator.generatePoToken(gvsBinding)
                     newStreamingPot = pot
                     lowTrust = PoTokenAttestationPolicy.isLowTrust(pot)
                     if (!lowTrust) break

--- a/app/src/main/java/io/github/aedev/flow/utils/potoken/VisitorId.kt
+++ b/app/src/main/java/io/github/aedev/flow/utils/potoken/VisitorId.kt
@@ -1,0 +1,44 @@
+package io.github.aedev.flow.utils.potoken
+
+import java.net.URLDecoder
+import java.util.Base64
+
+/**
+ * Extracts the 11-character visitor ID that a GVS PoToken must be bound to.
+ *
+ * `visitorData` is a base64url protobuf several hundred characters long, and its first field is the
+ * short visitor ID. GVS binds a logged-out streaming token to **that ID**, not to the surrounding
+ * blob — binding to the blob produces a token the server rejects (`sabr.media_serving_enforcement_id_error`
+ * on the SABR path, a plain 403 past the free window on direct URLs).
+ *
+ * Mirrors yt-dlp's `_extract_visitor_id` in `youtube/pot/utils.py`, including its default of
+ * preferring the visitor ID over the raw blob.
+ */
+object VisitorId {
+    /** Field 1 (`0x0A`), length 11 (`0x0B`) — the two header bytes before the ID itself. */
+    private const val ID_START = 2
+    private const val ID_LENGTH = 11
+    private val ID_PATTERN = Regex("[A-Za-z0-9_-]{$ID_LENGTH}")
+
+    /**
+     * The visitor ID inside [visitorData], or null when it cannot be read — a caller that gets null
+     * should bind to [visitorData] unchanged rather than skip attestation, matching yt-dlp's fallback.
+     */
+    fun extract(visitorData: String?): String? {
+        if (visitorData.isNullOrBlank()) return null
+        return try {
+            // Padding is optional in the wild, so decode without it and add our own.
+            val decoded = URLDecoder.decode(visitorData, Charsets.UTF_8.name()).trimEnd('=')
+            val padded = decoded.padEnd(decoded.length + (4 - decoded.length % 4) % 4, '=')
+            val bytes = Base64.getUrlDecoder().decode(padded)
+            if (bytes.size < ID_START + ID_LENGTH) return null
+            val id = String(bytes, ID_START, ID_LENGTH, Charsets.UTF_8)
+            id.takeIf { ID_PATTERN.matches(it) }
+        } catch (e: IllegalArgumentException) {
+            null
+        }
+    }
+
+    /** The identifier a GVS/streaming token should be minted against for this session. */
+    fun gvsBinding(visitorData: String): String = extract(visitorData) ?: visitorData
+}

--- a/app/src/test/java/io/github/aedev/flow/player/stream/LiveDetectionRulesTest.kt
+++ b/app/src/test/java/io/github/aedev/flow/player/stream/LiveDetectionRulesTest.kt
@@ -1,0 +1,64 @@
+package io.github.aedev.flow.player.stream
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Cases are the real shapes observed from the InnerTube `player` endpoint, not invented ones —
+ * every VISIONOS response carries an HLS manifest, which is what made the naive rule misfire.
+ */
+class LiveDetectionRulesTest {
+    private fun rule(
+        isLive: Boolean? = null,
+        isPostLiveDvr: Boolean? = null,
+        hasLiveStreamability: Boolean = false,
+        hasHlsManifest: Boolean = false,
+        hasAdaptiveFormats: Boolean = false,
+    ) = LiveDetectionRules.isLiveNow(
+        isLive = isLive,
+        isPostLiveDvr = isPostLiveDvr,
+        hasLiveStreamability = hasLiveStreamability,
+        hasHlsManifest = hasHlsManifest,
+        hasAdaptiveFormats = hasAdaptiveFormats,
+    )
+
+    @Test
+    fun `visionos VOD ships an hls manifest and is not live`() {
+        // The regression: 98 adaptive formats alongside a manifest. Reading this as live returns an
+        // empty ladder, so codecs and audio tracks vanish from the UI.
+        assertFalse(rule(hasHlsManifest = true, hasAdaptiveFormats = true))
+    }
+
+    @Test
+    fun `visionos short ships an hls manifest and is not live`() {
+        assertFalse(rule(hasHlsManifest = true, hasAdaptiveFormats = true))
+    }
+
+    @Test
+    fun `a broadcasting stream is live`() {
+        assertTrue(rule(isLive = true, hasLiveStreamability = true, hasHlsManifest = true, hasAdaptiveFormats = true))
+    }
+
+    @Test
+    fun `a post-live dvr stream is live even with an adaptive ladder`() {
+        assertTrue(rule(isPostLiveDvr = true, hasHlsManifest = true, hasAdaptiveFormats = true))
+    }
+
+    @Test
+    fun `live streamability alone is enough`() {
+        assertTrue(rule(hasLiveStreamability = true))
+    }
+
+    @Test
+    fun `a manifest with nothing else playable is still treated as live`() {
+        // The clause's original purpose, preserved: SABR-only live responses expose no adaptive
+        // formats, so the manifest is the only thing there is to play.
+        assertTrue(rule(hasHlsManifest = true, hasAdaptiveFormats = false))
+    }
+
+    @Test
+    fun `a plain VOD with neither manifest nor live flags is not live`() {
+        assertFalse(rule(hasAdaptiveFormats = true))
+    }
+}

--- a/app/src/test/java/io/github/aedev/flow/utils/potoken/VisitorIdTest.kt
+++ b/app/src/test/java/io/github/aedev/flow/utils/potoken/VisitorIdTest.kt
@@ -1,0 +1,44 @@
+package io.github.aedev.flow.utils.potoken
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class VisitorIdTest {
+    /** A real visitorData captured from youtube.com; its visitor ID is `rlqDISqy6-0`. */
+    private val realVisitorData =
+        "CgtybHFESVNxeTYtMCjA9pLUBjIKCgJMQhIEGgAgP2LfAgrcAjIxLllUPWhpRGRwQmZwWFRUNU9WRkJT"
+
+    @Test
+    fun `extracts the visitor id from real visitor data`() {
+        assertEquals("rlqDISqy6-0", VisitorId.extract(realVisitorData))
+    }
+
+    @Test
+    fun `url-encoded padding does not defeat extraction`() {
+        assertEquals("rlqDISqy6-0", VisitorId.extract("$realVisitorData%3D%3D"))
+    }
+
+    @Test
+    fun `gvsBinding prefers the visitor id over the blob`() {
+        val binding = VisitorId.gvsBinding(realVisitorData)
+        assertEquals("rlqDISqy6-0", binding)
+        // The whole point: GVS binds to the short id, not the several-hundred-character blob.
+        assertEquals(11, binding.length)
+    }
+
+    @Test
+    fun `gvsBinding falls back to the raw value when no id can be read`() {
+        val notProtobuf = "not-base64-at-all!!"
+        assertEquals(notProtobuf, VisitorId.gvsBinding(notProtobuf))
+    }
+
+    @Test
+    fun `blank and malformed input yield null`() {
+        assertNull(VisitorId.extract(null))
+        assertNull(VisitorId.extract(""))
+        assertNull(VisitorId.extract("   "))
+        // Valid base64, but too short to contain an id.
+        assertNull(VisitorId.extract("CgQ="))
+    }
+}


### PR DESCRIPTION
## Summary

Playback stopped at ~60 s on every video with `HTTP 403`, then retried until it gave up.

Around 2 Aug 2026 YouTube began requiring a GVS PO Token for the `ANDROID_VR` client
(yt-dlp [#17261](https://github.com/yt-dlp/yt-dlp/commit/69ea200067c274667984c6495578a957ab7ca606)).
Flow's fast ladder was four `ANDROID_VR` entries plus `IOS`/`IPADOS`, and the `pot=` it stamped on
those URLs came from the **WEB** BotGuard WebView. A PO Token is minted by BotGuard (Web),
DroidGuard (Android) or iOSGuard (iOS) and never crosses platforms, so GVS served the free first
minute and refused everything after it. Flow cannot mint an Android token — DroidGuard lives inside
Play Services and attests the calling package — so this is not fixable by keeping `ANDROID_VR`.

**`VISIONOS` now leads extraction.** It is the only client that still serves direct URLs GVS honours
for a whole video without a token, and it carries no `n` parameter, so first frame costs neither an
attestation nor an nsig decode — the two properties `ANDROID_VR` was chosen for. Measured against
the video from #922, no token minted anywhere:

| Client | Direct URLs | Audio tracks | Max h | nsig | Gate @5s / @300s |
|---|---|---|---|---|---|
| **VISIONOS** | **98** | **16** | 1080 | 0 | **206 / 206** |
| ANDROID_VR | 22 | 1 | 1080 | 0 | 206 / **403** |
| IOS | **0** (SABR-only) | — | — | — | — |
| MWEB | 123 | 16 | 1080 | 123 | **403 / 403** |

Ladder is now `VISIONOS` → `MWEB`/`WEB` SABR → `TVHTML5_SIMPLY_EMBEDDED_PLAYER` → `ANDROID_VR` ×4
→ last resort. SABR moved **above** the direct fallbacks: it is the only other path whose token Flow
can actually mint. `ANDROID_VR` is retained but demoted rather than deleted — it still answers and is
the difference between degraded playback and none. `IOS`/`IPADOS` are removed from the fast path
entirely; they now return SABR-only responses with zero direct URLs.

Three implementation decisions worth review:

- **`AttestationPlatform` on `YouTubeClient`** (`WEB`/`DROIDGUARD`/`IOSGUARD`). Token attachment now
  gates on this instead of a `clientName == "ANDROID_VR"` string check, which excluded the right
  client for the wrong reason — `IOS`/`IPADOS` were still being handed a WEB player token. The
  reason this bug shipped is that the code had no way to express *"this token does not belong on
  this URL"*.
- **GVS PO Token binding fixed.** For a logged-out WebPO client the token binds to the **11-character
  visitor ID**, not the `visitorData` blob it sits inside (yt-dlp `pot/utils.py`, `bind_to_visitor_id`
  defaults true). Flow was minting against the full 520-char blob. New `VisitorId` extracts it. This
  also explains the long-standing `sabr.media_serving_enforcement_id_error` comment — an *ID* mismatch
  — and repairs `PoTokenAttestationPolicy.isLowTrust()`, which could never fire against a 598-byte token.
- **`LiveDetectionRules` extracted.** `isLiveNow()` treated any HLS manifest as live. That held while
  no VOD client returned one; `VISIONOS` is Apple-family and ships a manifest for ordinary VODs, so
  every video took the live branch and came back with an empty ladder — no codecs, no audio tracks.
  The clause's real intent was "a manifest and nothing else playable", now expressed as
  `hasHlsManifest && !hasAdaptiveFormats`.

`VISIONOS` was already defined but stale and unwired (`0.1` / `RealityDevice14,1`). The version bump
is substantive, not cosmetic: the old build still answers but serves **17 formats and 1 audio track**
versus 98 and 16.

## Related issue

Closes #921
Closes #922

## Change type

- [x] Bug fix
- [ ] Feature
- [x] Refactor or maintenance
- [ ] Build, packaging, or CI
- [ ] Documentation

## Validation

- [x] `./gradlew :app:assembleGithubDebug` — passed
- [x] `./gradlew :app:testGithubDebugUnitTest` — **698 tests, 0 failures** (was 691; +12 new)
- [x] I ran any additional flavor-specific build or test tasks affected by this change.
      `./gradlew :app:compileFossDebugKotlin` — passed
- [x] I manually tested the affected behavior on an Android device or emulator.
      Video, Shorts and music playback all confirmed working and fast.

Also run:

- **ktlint 1.8.0 directly on all 8 changed files — 0 violations.** `spotlessCheck` fails locally on
  182 files starting with ones this PR never touches; that is the known Windows CRLF vs
  `end_of_line = lf` condition, not a rule violation (verified: a flagged file passes ktlint cleanly,
  while a deliberately malformed control file produces 6 violations). CI runs on Linux where sources
  are LF.
- **Clean-room reproduction and verification** via a standalone Python probe against
  `youtubei/v1/player` with no PO token minted: `ANDROID_VR` returns 206 through 60 s of media and
  403 from 62 s on all 10 itags tested — the 60 s byte offset is 1,155,876 and the 403 in the #922
  log fired at 1,162,011 (60.32 s). `VISIONOS` returned 206 at 60 s, 600 s and 1624 s (95% into a
  28.5-minute video). Content sweep: **7/7 pass, 0 gated** across long-form, music, kids and Shorts.
  Shorts return correct portrait ladders (1080×1920); music reaches 2160p and behaves identically on
  `music.youtube.com`; live returns HLS manifests.
- Re-probed using the values **as committed to the Kotlin**, to catch transcription slips.

**Test device and Android version:** <!-- fill in -->

## Screenshots or recordings

Not applicable — no UI changed. The quality and audio-track menus now populate from a fuller ladder
(16 dubbed tracks and AV1/VP9/H.264 where offered), but that is data, not layout.

## Risk and compatibility

**Playback — high impact, the point of the PR.** Every non-downloaded video and music track now
resolves through a different InnerTube client. Startup latency should be unchanged or better:
`VISIONOS` needs no attestation and no nsig on the path to first frame, and it is exempted from the
music path's `checkUrl` probe exactly as `ANDROID_VR`/`IOS` already were.

**Network behavior.** The `/player` request carries a different client identity. No new endpoints, no
change in request volume. Non-web clients now correctly receive **no** PO Token, so cold-start does
slightly less BotGuard work on the fast path.

**Known limitations:**

- **Age-restricted content is unverified on `VISIONOS`** — no reliable test case was found. This is
  the most likely coverage gap; yt-dlp keeps `web_embedded` as its age-restricted fallback and Flow
  does not have that client. Most likely follow-up if reports come in.
- yt-dlp's source notes *"Made for kids" videos aren't available with this client*. Neither confirmed
  nor refuted here: the one `UNPLAYABLE` video in testing failed on **every** client including
  `ANDROID_VR` and `MWEB`, so it was video-level, not client-level.
- **`VISIONOS` is Apple-family.** If YouTube enforces there next, the token would need iOSGuard and
  we are back in the same position. `AttestationPlatform` is the insurance: the next shift becomes a
  one-line change rather than a week of diagnosis.
- SABR still injects `playerRequestPoToken` rather than the newly-corrected streaming token.
  yt-dlp says GVS should be visitor-ID-bound, but the videoId-bound token is what is empirically
  working on that path and YouTube has a live experiment flag (`_gvs_bind_to_video_id`) covering
  exactly this. Left as a marked on-device A/B rather than gambling the durable fallback.
- Post-live DVR streams still route to the HLS-only path despite carrying an adaptive ladder.
  Pre-existing behavior, deliberately untouched.
- No probe ran from a residential IP; testing came from a datacenter address where YouTube is
  stricter. A phone should do at least as well.

- [x] The change does not introduce secrets, private data, or unexpected telemetry.
- [x] New user-facing text uses Android string resources. — N/A, no new user-facing text.
- [x] Dependency and lockfile changes are intentional and limited to this PR. — N/A, no dependency changes.
- [x] Room schema changes include the required version bump and migration, or this PR does not change the Room schema. — no schema change.
- [x] Breaking changes and upgrade steps are clearly documented. — none; no preference or data migration.