### PR TITLE
fix: preserve paused video after backgrounding

### DIFF
--- a/app/src/main/java/io/github/aedev/flow/player/MemoryPressurePolicy.kt
+++ b/app/src/main/java/io/github/aedev/flow/player/MemoryPressurePolicy.kt
@@ -5,7 +5,7 @@ import android.content.ComponentCallbacks2
 object MemoryPressurePolicy {
     @Suppress("DEPRECATION")
     fun shouldReleaseVideoPlayback(trimLevel: Int): Boolean =
-        trimLevel >= ComponentCallbacks2.TRIM_MEMORY_BACKGROUND ||
+        trimLevel >= ComponentCallbacks2.TRIM_MEMORY_MODERATE ||
             trimLevel in ComponentCallbacks2.TRIM_MEMORY_RUNNING_CRITICAL until
                 ComponentCallbacks2.TRIM_MEMORY_UI_HIDDEN
 }

--- a/app/src/main/java/io/github/aedev/flow/player/MemoryPressurePolicy.kt
+++ b/app/src/main/java/io/github/aedev/flow/player/MemoryPressurePolicy.kt
@@ -7,5 +7,5 @@ object MemoryPressurePolicy {
     fun shouldReleaseVideoPlayback(trimLevel: Int): Boolean =
         trimLevel >= ComponentCallbacks2.TRIM_MEMORY_MODERATE ||
             trimLevel in ComponentCallbacks2.TRIM_MEMORY_RUNNING_CRITICAL until
-                ComponentCallbacks2.TRIM_MEMORY_UI_HIDDEN
+            ComponentCallbacks2.TRIM_MEMORY_UI_HIDDEN
 }

--- a/app/src/main/java/io/github/aedev/flow/player/MemoryPressurePolicy.kt
+++ b/app/src/main/java/io/github/aedev/flow/player/MemoryPressurePolicy.kt
@@ -2,6 +2,18 @@ package io.github.aedev.flow.player
 
 import android.content.ComponentCallbacks2
 
+/**
+ * Android 14 stopped delivering every trim level except [ComponentCallbacks2.TRIM_MEMORY_UI_HIDDEN]
+ * and [ComponentCallbacks2.TRIM_MEMORY_BACKGROUND]; Android 15 deprecated the rest. Neither
+ * surviving level signals pressure — BACKGROUND arrives whenever the process lands on the LRU list
+ * — so treating it as critical cleared a paused video a few minutes after backgrounding and lost
+ * the user's position (#920). Recovery could not undo that either: it replays the already-extracted
+ * stream URLs, which have expired by then.
+ *
+ * The levels below do mean the system is walking the LRU list to reclaim memory, and releasing
+ * there still buys a low-memory device some headroom before it kills us outright. They are all
+ * deprecated and only reach pre-34 devices, so on Android 14 and above this always returns false.
+ */
 object MemoryPressurePolicy {
     @Suppress("DEPRECATION")
     fun shouldReleaseVideoPlayback(trimLevel: Int): Boolean =

--- a/app/src/test/java/io/github/aedev/flow/player/MemoryPressurePolicyTest.kt
+++ b/app/src/test/java/io/github/aedev/flow/player/MemoryPressurePolicyTest.kt
@@ -10,8 +10,8 @@ class MemoryPressurePolicyTest {
     fun `ui hidden does not release video playback`() {
         assertThat(
             MemoryPressurePolicy.shouldReleaseVideoPlayback(
-                ComponentCallbacks2.TRIM_MEMORY_UI_HIDDEN
-            )
+                ComponentCallbacks2.TRIM_MEMORY_UI_HIDDEN,
+            ),
         ).isFalse()
     }
 
@@ -20,8 +20,8 @@ class MemoryPressurePolicyTest {
     fun `running critical releases video playback on older Android versions`() {
         assertThat(
             MemoryPressurePolicy.shouldReleaseVideoPlayback(
-                ComponentCallbacks2.TRIM_MEMORY_RUNNING_CRITICAL
-            )
+                ComponentCallbacks2.TRIM_MEMORY_RUNNING_CRITICAL,
+            ),
         ).isTrue()
     }
 
@@ -30,8 +30,8 @@ class MemoryPressurePolicyTest {
     fun `background state preserves paused video playback`() {
         assertThat(
             MemoryPressurePolicy.shouldReleaseVideoPlayback(
-                ComponentCallbacks2.TRIM_MEMORY_BACKGROUND
-            )
+                ComponentCallbacks2.TRIM_MEMORY_BACKGROUND,
+            ),
         ).isFalse()
     }
 
@@ -40,8 +40,8 @@ class MemoryPressurePolicyTest {
     fun `running low does not clear the active playlist`() {
         assertThat(
             MemoryPressurePolicy.shouldReleaseVideoPlayback(
-                ComponentCallbacks2.TRIM_MEMORY_RUNNING_LOW
-            )
+                ComponentCallbacks2.TRIM_MEMORY_RUNNING_LOW,
+            ),
         ).isFalse()
     }
 
@@ -50,8 +50,8 @@ class MemoryPressurePolicyTest {
     fun `moderate background pressure releases rebuildable video playback`() {
         assertThat(
             MemoryPressurePolicy.shouldReleaseVideoPlayback(
-                ComponentCallbacks2.TRIM_MEMORY_MODERATE
-            )
+                ComponentCallbacks2.TRIM_MEMORY_MODERATE,
+            ),
         ).isTrue()
     }
 
@@ -60,8 +60,8 @@ class MemoryPressurePolicyTest {
     fun `complete background pressure releases rebuildable video playback`() {
         assertThat(
             MemoryPressurePolicy.shouldReleaseVideoPlayback(
-                ComponentCallbacks2.TRIM_MEMORY_COMPLETE
-            )
+                ComponentCallbacks2.TRIM_MEMORY_COMPLETE,
+            ),
         ).isTrue()
     }
 }

--- a/app/src/test/java/io/github/aedev/flow/player/MemoryPressurePolicyTest.kt
+++ b/app/src/test/java/io/github/aedev/flow/player/MemoryPressurePolicyTest.kt
@@ -27,12 +27,12 @@ class MemoryPressurePolicyTest {
 
     @Suppress("DEPRECATION")
     @Test
-    fun `background pressure releases rebuildable video playback`() {
+    fun `background state preserves paused video playback`() {
         assertThat(
             MemoryPressurePolicy.shouldReleaseVideoPlayback(
                 ComponentCallbacks2.TRIM_MEMORY_BACKGROUND
             )
-        ).isTrue()
+        ).isFalse()
     }
 
     @Suppress("DEPRECATION")
@@ -43,5 +43,25 @@ class MemoryPressurePolicyTest {
                 ComponentCallbacks2.TRIM_MEMORY_RUNNING_LOW
             )
         ).isFalse()
+    }
+
+    @Suppress("DEPRECATION")
+    @Test
+    fun `moderate background pressure releases rebuildable video playback`() {
+        assertThat(
+            MemoryPressurePolicy.shouldReleaseVideoPlayback(
+                ComponentCallbacks2.TRIM_MEMORY_MODERATE
+            )
+        ).isTrue()
+    }
+
+    @Suppress("DEPRECATION")
+    @Test
+    fun `complete background pressure releases rebuildable video playback`() {
+        assertThat(
+            MemoryPressurePolicy.shouldReleaseVideoPlayback(
+                ComponentCallbacks2.TRIM_MEMORY_COMPLETE
+            )
+        ).isTrue()
     }
 }


### PR DESCRIPTION
## Summary

Refine `MemoryPressurePolicy.shouldReleaseVideoPlayback` so routine background classification and UI-hidden callbacks preserve the paused player, while genuinely severe callbacks such as running-critical and higher background-pressure levels still release rebuildable video state. Keep the decision centralized in the existing policy consumed by `MainActivity.onTrimMemory`; do not add a parallel lifecycle timer or a new player abstraction. Update `MemoryPressurePolicyTest` to define the boundary explicitly for UI-hidden, background, moderate/complete pressure, running-low, and running-critical levels.

Paused video playback can lose its media item and position after Flow remains backgrounded for roughly three to five minutes, causing a return to start at 0:00 or buffer indefinitely. The lifecycle path already pauses playback normally, but `MemoryPressurePolicy` treats the routine `TRIM_MEMORY_BACKGROUND` callback as critical and directs `EnhancedPlayerManager` to clear paused media. That threshold makes ordinary background residency indistinguishable from real memory pressure, matching the reporter's delay and the regression surface. The fix is limited to the memory-pressure decision and does not change player ownership, service lifecycle, or persistence schemas.

Closes #920

## Related issue

Not applicable to this change.

## Change type

- Refine `MemoryPressurePolicy.shouldReleaseVideoPlayback` so routine background classification and UI-hidden callbacks preserve the paused player, while genuinely severe callbacks such as running-critical and higher background-pressure levels still release rebuildable video state. Keep the decision centralized in the existing policy consumed by `MainActivity.onTrimMemory`; do not add a parallel lifecycle timer or a new player abstraction. Update `MemoryPressurePolicyTest` to define the boundary explicitly for UI-hidden, background, moderate/complete pressure, running-low, and running-critical levels.

## Validation

Pause an on-demand video after seeking beyond 0:00, background Flow for longer than five minutes, then reopen it; the same video remains paused at the previous timestamp without an endless buffering state.
Deliver `TRIM_MEMORY_UI_HIDDEN` and `TRIM_MEMORY_BACKGROUND`; the policy does not request video release, while `TRIM_MEMORY_RUNNING_CRITICAL`, `TRIM_MEMORY_MODERATE`, and `TRIM_MEMORY_COMPLETE` still do.
Deliver `TRIM_MEMORY_RUNNING_LOW`; the active media item and position remain intact because that level is not the established release threshold.
With background playback enabled, leave a playing video in the background and return; playback continues through the existing service handoff and the policy change does not create a duplicate player or restart at 0:00.
Under a genuinely severe memory callback, verify the existing release/recovery path still frees video-heavy state and can restore playback without changing queue, local-media, PiP, or service ownership behavior.

## Screenshots or recordings

No user-visible surface changes in this PR, so there is nothing to show.

## Risk and compatibility

- [ ] The change does not introduce secrets, private data, or unexpected telemetry.
- [ ] New user-facing text uses Android string resources.
- [ ] Dependency and lockfile changes are intentional and limited to this PR.
- [ ] Room schema changes include the required version bump and migration, or this PR does not change the Room schema.
- [ ] Breaking changes and upgrade steps are clearly documented.
