### PR TITLE
chore(ci): harden GitHub workflows and add repository automation

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,42 @@
+# Normalise line endings so ktlint/Spotless (LineEnding.UNIX) and Windows
+# checkouts agree. Without this, core.autocrlf=true produces CRLF working
+# copies that Spotless then reports as violations on untouched files.
+* text=auto eol=lf
+
+# Windows-only scripts must keep CRLF to stay executable by cmd.exe.
+*.bat       text eol=crlf
+*.cmd       text eol=crlf
+*.ps1       text eol=crlf
+
+# The Gradle wrapper shell script must stay LF on every platform.
+gradlew     text eol=lf
+
+# Binary assets: never normalise, never diff as text.
+*.png       binary
+*.jpg       binary
+*.jpeg      binary
+*.webp      binary
+*.gif       binary
+*.ico       binary
+*.mp3       binary
+*.mp4       binary
+*.ttf       binary
+*.otf       binary
+*.woff      binary
+*.woff2     binary
+*.jar       binary
+*.apk       binary
+*.aab       binary
+*.keystore  binary
+*.jks       binary
+*.so        binary
+
+# Generated baseline profiles are large and machine-produced; keep them out
+# of diffs and out of language statistics.
+app/src/githubRelease/generated/baselineProfiles/** linguist-generated=true -diff
+
+# Reference material vendored for comparison is not this project's code.
+LibreTube-master/**  linguist-vendored
+Metrolist-main/**    linguist-vendored
+NewPipe-dev/**       linguist-vendored
+pipepipe/**          linguist-vendored

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,17 @@
+# Default owner for everything in the repository.
+* @A-EDev
+
+# Release, signing, and CI paths. Changes here can break the published
+# IzzyOnDroid/F-Droid artifacts, so they always need an explicit review.
+/.github/workflows/    @A-EDev
+/.github/dependabot.yml @A-EDev
+/app/build.gradle.kts  @A-EDev
+/build.gradle.kts      @A-EDev
+/gradle/               @A-EDev
+/fastlane/             @A-EDev
+
+# Project policy documents.
+/CLAUDE.md             @A-EDev
+/AGENTS.md             @A-EDev
+/CONTRIBUTING.md       @A-EDev
+/SECURITY.md           @A-EDev

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,50 @@
+version: 2
+
+updates:
+  # Gradle dependencies (version catalog + build scripts).
+  - package-ecosystem: gradle
+    directory: /
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+    commit-message:
+      prefix: "deps"
+    groups:
+      androidx-compose:
+        patterns:
+          - "androidx.compose*"
+          - "androidx.activity:activity-compose"
+          - "androidx.navigation:navigation-compose"
+      androidx-media3:
+        patterns:
+          - "androidx.media3:*"
+      hilt-and-ksp:
+        patterns:
+          - "com.google.dagger:*"
+          - "com.google.devtools.ksp*"
+      kotlin:
+        patterns:
+          - "org.jetbrains.kotlin*"
+          - "org.jetbrains.kotlinx:*"
+    ignore:
+      # AGP and Kotlin are coupled to the Compose compiler and KSP versions;
+      # bump them deliberately, not from an automated PR.
+      - dependency-name: "com.android.tools.build:gradle"
+      - dependency-name: "org.jetbrains.kotlin:kotlin-gradle-plugin"
+
+  # Keep the GitHub Actions used by CI current.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+    commit-message:
+      prefix: "ci"
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,53 @@
+player:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'app/src/main/java/io/github/aedev/flow/player/**'
+          - 'app/src/main/java/io/github/aedev/flow/service/**'
+
+ui:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'app/src/main/java/io/github/aedev/flow/ui/**'
+          - 'app/src/main/res/values/themes.xml'
+
+algorithm:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'app/src/main/java/io/github/aedev/flow/data/recommendation/**'
+
+sync:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'app/src/main/java/io/github/aedev/flow/sync/**'
+
+extraction:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'app/src/main/java/io/github/aedev/flow/innertube/**'
+          - 'app/src/main/java/io/github/aedev/flow/network/**'
+
+localization:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'app/src/main/res/values-*/strings.xml'
+
+build:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '**/*.gradle.kts'
+          - 'gradle/**'
+          - 'gradle.properties'
+          - 'app/proguard-rules.pro'
+
+ci:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '.github/workflows/**'
+          - '.github/dependabot.yml'
+          - '.github/labeler.yml'
+
+documentation:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '**/*.md'
+          - 'fastlane/**'

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,24 +1,33 @@
+# Categories for GitHub's auto-generated release notes. Flow currently ships
+# curated notes from release-notes.md, so this only takes effect if a release
+# is generated with "Generate release notes". Labels listed here must exist in
+# the repository and are applied by .github/labeler.yml.
 changelog:
   exclude:
     labels:
       - ignore-for-release
+      - dependencies
   categories:
     - title: '🚀 New Features'
       labels:
-        - 'feature'
         - 'enhancement'
-        - 'feat'
     - title: '🐛 Bug Fixes'
       labels:
-        - 'fix'
         - 'bug'
     - title: '💅 UI/UX Improvements'
       labels:
         - 'ui'
-        - 'design'
+    - title: '▶️ Playback and Extraction'
+      labels:
+        - 'player'
+        - 'extraction'
+        - 'algorithm'
+        - 'sync'
+    - title: '🌍 Translations'
+      labels:
+        - 'localization'
     - title: '🔧 Under the Hood'
       labels:
-        - 'chore'
-        - 'refactor'
-        - 'maintenance'
-        - 'dependencies'
+        - 'build'
+        - 'ci'
+        - 'documentation'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,29 +2,43 @@ name: Android CI/CD
 
 on:
   push:
-    branches: [ main, master, develop, agent/discord-rich-presence ]
+    branches: [ main ]
     tags:
       - 'v*'
   pull_request:
-    branches: [ main, master ]
+    branches: [ main ]
+  workflow_dispatch:
+
+# Collapse superseded runs on branches and PRs. Tag runs publish the release
+# artifacts and must never be cancelled by a subsequent push.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ !startsWith(github.ref, 'refs/tags/v') }}
 
 permissions:
   contents: read
+
+env:
+  # Certificate of the official Flow release key. IzzyOnDroid and every
+  # installed client pin this value; an APK signed with anything else cannot
+  # be installed as an update. Changing it forces every user to reinstall.
+  EXPECTED_SIGNER_SHA256: 4322294ed4caa2d4294140095818080ffe8acc1fbe3cdc76107df45c5286be40
 
 jobs:
   build:
     name: Build APK
     runs-on: ubuntu-latest
+    timeout-minutes: 90
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
           fetch-depth: 0
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '17'
           distribution: 'temurin'
@@ -41,19 +55,37 @@ jobs:
           --build-cache --stacktrace
 
       - name: Decode Keystore
+        id: keystore
         env:
           RELEASE_KEYSTORE_BASE64: ${{ secrets.RELEASE_KEYSTORE_BASE64 }}
         run: |
           if [ -n "$RELEASE_KEYSTORE_BASE64" ]; then
             echo "$RELEASE_KEYSTORE_BASE64" | base64 --decode > release.keystore
+            echo "signed=true" >> "$GITHUB_OUTPUT"
+            echo "Release keystore decoded."
+          elif [ "${GITHUB_REF#refs/tags/v}" != "$GITHUB_REF" ]; then
+            # A tag build publishes to GitHub Releases and IzzyOnDroid. Without
+            # the keystore, app/build.gradle.kts falls back to signingConfig =
+            # null and produces UNSIGNED APKs, which cannot be installed and
+            # would break the update path for every existing user.
+            echo "::error::RELEASE_KEYSTORE_BASE64 is unavailable for a tag build. Refusing to publish unsigned APKs."
+            exit 1
           else
-            echo "Release keystore secret is not available. Skipping decoding."
+            echo "signed=false" >> "$GITHUB_OUTPUT"
+            echo "Release keystore secret is not available. Continuing with an unsigned CI build."
           fi
 
       - name: Run unit tests
         run: >
           ./gradlew :app:testGithubDebugUnitTest :app:testFossDebugUnitTest
           --parallel --build-cache --stacktrace
+
+      # Instrumentation tests are not executed in CI, but they must still
+      # compile: breakage here otherwise lands on main unnoticed.
+      - name: Compile instrumentation tests
+        run: >
+          ./gradlew :app:compileGithubDebugAndroidTestKotlin
+          --build-cache --stacktrace
 
       - name: Lint GitHub nightly
         if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
@@ -87,6 +119,43 @@ jobs:
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
 
+      # Guards the IzzyOnDroid/F-Droid update path: a wrong or missing key here
+      # is unrecoverable for installed users, so fail the build rather than
+      # publish. Skipped when no keystore was available, e.g. on fork PRs.
+      - name: Verify release signing certificate
+        if: ${{ steps.keystore.outputs.signed == 'true' }}
+        run: |
+          set -uo pipefail
+          apksigner=$(find "$ANDROID_SDK_ROOT/build-tools" -name apksigner -type f | sort -V | tail -1)
+          if [ -z "$apksigner" ]; then
+            echo "::error::apksigner was not found in the runner Android SDK."
+            exit 1
+          fi
+
+          status=0
+          for apk in \
+            app/build/outputs/apk/github/release/app-github-universal-release.apk \
+            app/build/outputs/apk/github/release/app-github-arm64-v8a-release.apk \
+            app/build/outputs/apk/github/release/app-github-armeabi-v7a-release.apk \
+            app/build/outputs/apk/foss/release/app-foss-universal-release.apk \
+            app/build/outputs/apk/foss/release/app-foss-arm64-v8a-release.apk \
+            app/build/outputs/apk/foss/release/app-foss-armeabi-v7a-release.apk
+          do
+            if [ ! -f "$apk" ]; then
+              echo "::error::Missing expected APK $apk"
+              status=1
+              continue
+            fi
+            actual=$("$apksigner" verify --print-certs "$apk" | grep -m1 'certificate SHA-256 digest' | awk '{print $NF}')
+            if [ "$actual" != "$EXPECTED_SIGNER_SHA256" ]; then
+              echo "::error::$(basename "$apk") is signed with '$actual', expected '$EXPECTED_SIGNER_SHA256'"
+              status=1
+            else
+              echo "OK $(basename "$apk") -> $actual"
+            fi
+          done
+          exit $status
+
       - name: Checksum nightly APK
         if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
         run: |
@@ -98,12 +167,14 @@ jobs:
         run: |
           shopt -s nullglob
           apks=(
+            app/build/outputs/apk/github/release/app-github-universal-release*.apk
             app/build/outputs/apk/github/release/app-github-arm64-v8a-release*.apk
             app/build/outputs/apk/github/release/app-github-armeabi-v7a-release*.apk
+            app/build/outputs/apk/foss/release/app-foss-universal-release*.apk
             app/build/outputs/apk/foss/release/app-foss-arm64-v8a-release*.apk
             app/build/outputs/apk/foss/release/app-foss-armeabi-v7a-release*.apk
           )
-          expected=4
+          expected=6
 
           if (( ${#apks[@]} != expected )); then
             printf 'Expected %d published APKs, found %d.\n' "$expected" "${#apks[@]}" >&2
@@ -123,6 +194,16 @@ jobs:
             echo
             echo '> GitHub and FOSS APKs are uploaded individually without compression. Nightly remains a compressed artifact on regular CI runs.'
           } >> "$GITHUB_STEP_SUMMARY"
+
+      # The universal APKs are what IzzyOnDroid and the README link to.
+      - name: Upload GitHub universal APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: flow-github-universal-release-apk
+          path: app/build/outputs/apk/github/release/app-github-universal-release*.apk
+          if-no-files-found: error
+          retention-days: 14
+          compression-level: 0
 
       - name: Upload GitHub ARM64 APK
         uses: actions/upload-artifact@v4
@@ -153,6 +234,15 @@ jobs:
           if-no-files-found: error
           retention-days: 14
 
+      - name: Upload FOSS universal APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: flow-foss-universal-release-apk
+          path: app/build/outputs/apk/foss/release/app-foss-universal-release*.apk
+          if-no-files-found: error
+          retention-days: 14
+          compression-level: 0
+
       - name: Upload FOSS ARM64 APK
         uses: actions/upload-artifact@v4
         with:
@@ -175,13 +265,14 @@ jobs:
     name: Create Release
     needs: build
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     if: startsWith(github.ref, 'refs/tags/v')
     permissions:
       contents: write
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Download release APKs
         uses: actions/download-artifact@v4
@@ -190,12 +281,25 @@ jobs:
           path: dist/
           merge-multiple: true
 
+      # flow.apk and flow-foss.apk are the universal builds and are a public
+      # contract: IzzyOnDroid matches release assets by file name, and the
+      # README links to them directly. Do not rename or drop them without
+      # first updating the IzzyOnDroid entry for io.github.aedev.flow.
       - name: Rename APKs for release
         run: |
-          mv dist/app-github-arm64-v8a-release.apk dist/flow-arm64-v8a.apk
+          set -euo pipefail
+          mv dist/app-github-universal-release.apk   dist/flow.apk
+          mv dist/app-foss-universal-release.apk     dist/flow-foss.apk
+          mv dist/app-github-arm64-v8a-release.apk   dist/flow-arm64-v8a.apk
           mv dist/app-github-armeabi-v7a-release.apk dist/flow-armeabi-v7a.apk
-          mv dist/app-foss-arm64-v8a-release.apk dist/flow-foss-arm64-v8a.apk
-          mv dist/app-foss-armeabi-v7a-release.apk dist/flow-foss-armeabi-v7a.apk
+          mv dist/app-foss-arm64-v8a-release.apk     dist/flow-foss-arm64-v8a.apk
+          mv dist/app-foss-armeabi-v7a-release.apk   dist/flow-foss-armeabi-v7a.apk
+
+      - name: Generate checksums
+        run: |
+          cd dist
+          sha256sum flow*.apk > checksums.txt
+          cat checksums.txt
 
       - name: Get version from tag
         id: get_version
@@ -216,10 +320,13 @@ jobs:
           body_path: release-notes.md
           generate_release_notes: false
           files: |
+            dist/flow.apk
+            dist/flow-foss.apk
             dist/flow-arm64-v8a.apk
             dist/flow-armeabi-v7a.apk
             dist/flow-foss-arm64-v8a.apk
             dist/flow-foss-armeabi-v7a.apk
+            dist/checksums.txt
           draft: false
           prerelease: false
         env:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,45 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  schedule:
+    # Weekly, so newly published queries still run against a quiet main.
+    - cron: '27 4 * * 1'
+  workflow_dispatch:
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    name: Analyze Kotlin/Java
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      security-events: write
+      actions: read
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      # build-mode "none" analyses sources directly. A full Android Gradle
+      # build is not needed and would duplicate the Build APK job.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: java-kotlin
+          build-mode: none
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: /language:java-kotlin

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,10 +1,25 @@
 name: CodeQL
 
+# Only Kotlin/Java sources and the build definition affect the analysis, so
+# translation-only and documentation pushes are skipped. Unlike build.yml this
+# workflow never runs on tags, so path filters here cannot skip a release.
 on:
   push:
     branches: [ main ]
+    paths:
+      - '**/*.kt'
+      - '**/*.java'
+      - '**/*.gradle.kts'
+      - 'gradle/libs.versions.toml'
+      - '.github/workflows/codeql.yml'
   pull_request:
     branches: [ main ]
+    paths:
+      - '**/*.kt'
+      - '**/*.java'
+      - '**/*.gradle.kts'
+      - 'gradle/libs.versions.toml'
+      - '.github/workflows/codeql.yml'
   schedule:
     # Weekly, so newly published queries still run against a quiet main.
     - cron: '27 4 * * 1'
@@ -21,7 +36,7 @@ jobs:
   analyze:
     name: Analyze Kotlin/Java
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 60
     permissions:
       security-events: write
       actions: read
@@ -31,13 +46,36 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v7
 
-      # build-mode "none" analyses sources directly. A full Android Gradle
-      # build is not needed and would duplicate the Build APK job.
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      # Caching is disabled deliberately. CodeQL extracts Kotlin by observing
+      # the compiler as it runs, so a cache hit that makes the compile tasks
+      # UP-TO-DATE would produce an empty database and fail the analysis.
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v6
+        with:
+          cache-disabled: true
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      # build-mode "none" cannot be used here: buildless extraction supports
+      # Java only and silently drops Kotlin, which is effectively this entire
+      # codebase. Kotlin requires a real build.
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4
         with:
           languages: java-kotlin
-          build-mode: none
+          build-mode: manual
+
+      - name: Build for extraction
+        run: >
+          ./gradlew :app:assembleGithubDebug
+          --no-build-cache --stacktrace
 
       - name: Perform CodeQL analysis
         uses: github/codeql-action/analyze@v4

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -77,7 +77,21 @@ jobs:
           ./gradlew :app:assembleGithubDebug
           --no-build-cache --stacktrace
 
+      # The Gradle and Kotlin compile daemons stay resident after the build.
+      # Left running, they hold enough heap that CodeQL's query evaluation --
+      # which by default claims most of the runner's memory -- OOM-killed the
+      # runner ("The runner has received a shutdown signal").
+      - name: Stop Gradle and Kotlin daemons
+        run: |
+          ./gradlew --stop || true
+          pkill -f KotlinCompileDaemon || true
+          free -h || true
+
       - name: Perform CodeQL analysis
         uses: github/codeql-action/analyze@v4
         with:
           category: /language:java-kotlin
+          # Explicit cap rather than the default "most of the runner", which
+          # left no headroom on a 16 GB standard runner.
+          ram: 10240
+          threads: 4

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,25 @@
+name: Label PRs
+
+# pull_request_target so that PRs opened from forks can also be labelled.
+# This workflow never checks out or executes PR code, so the elevated token
+# is not exposed to untrusted input.
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  label:
+    name: Apply path labels
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - uses: actions/labeler@v6
+        with:
+          sync-labels: true

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ graphify-out/
 .claude/
 claude.md
 Flow-desktop/
+
+# Kotlin compiler session/daemon state
+.kotlin/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,6 +107,38 @@ Use clear, descriptive commit messages:
 - Once approved, your PR will be merged
 - Your contribution will be credited in releases
 
+## 🔐 Release and Signing Invariants
+
+Flow is distributed through GitHub Releases and
+[IzzyOnDroid](https://apt.izzysoft.de/packages/io.github.aedev.flow). Both pin
+properties of the published artifacts, so the following are hard constraints.
+Breaking one of them cannot be fixed by a follow-up release — it forces every
+installed user to uninstall and reinstall, losing their local data.
+
+**The signing key never changes.** Every release APK must be signed with the
+official key, certificate SHA-256
+`4322294ed4caa2d4294140095818080ffe8acc1fbe3cdc76107df45c5286be40`. Android
+refuses to install an update signed by a different key. CI enforces this in the
+`Verify release signing certificate` step, which fails the build on a mismatch.
+Never regenerate `release.keystore`, and never rotate the
+`RELEASE_KEYSTORE_BASE64`, `STORE_PASSWORD`, `KEY_ALIAS`, or `KEY_PASSWORD`
+repository secrets.
+
+**Release asset file names are a public contract.** IzzyOnDroid matches release
+assets by file name. `flow.apk` and `flow-foss.apk` are the universal builds
+and must keep those exact names. The per-ABI APKs are published alongside them
+as extras. Renaming or removing either universal APK silently breaks the
+IzzyOnDroid update feed, so coordinate with IzzyOnDroid before changing them.
+
+**`versionCode` must increase on every release.** F-Droid-format repositories
+use it to detect updates. The ABI splits all share one `versionCode`, so the
+universal APK is the only artifact IzzyOnDroid should consume.
+
+**A tag build must never publish unsigned APKs.** `app/build.gradle.kts` falls
+back to `signingConfig = null` when no keystore is present, which produces
+uninstallable APKs. CI hard-fails a `v*` tag build when the keystore secret is
+missing rather than publishing them.
+
 ## 🎯 Areas We Need Help
 
 - [ ] Improving documentation

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,30 +1,58 @@
 # Security Policy
 
-## Supported Versions
+## Supported versions
 
-The following versions of Flow are currently being supported with security updates.
+Security fixes land on the latest release line only. Older versions do not
+receive backported patches.
 
-| Version | Supported          |
-| ------- | ------------------ |
-| 1.2.x   | ✅ |
-| < 1.2.0 | ❌                |
+| Version | Supported |
+| ------- | --------- |
+| 2.2.x   | ✅ |
+| < 2.2.0 | ❌ |
 
-## Reporting a Vulnerability
+Always update to the newest release before reporting a security issue.
 
-We take the security of Flow seriously. If you believe you have found a security vulnerability, please report it to us privately.
+## Reporting a vulnerability
 
-**Please do not report security vulnerabilities through public GitHub issues.**
+**Do not report security vulnerabilities through public GitHub issues.**
 
-Instead, please send an email to flow.aedev@gmail.com.
+Report privately through
+[GitHub Security Advisories](https://github.com/A-EDev/Flow/security/advisories/new).
+If you cannot use that form, email <flow.aedev@gmail.com>.
 
-Please include the following information in your report:
+Please include:
 
-- Type of issue (e.g., buffer overflow, SQL injection, cross-site scripting, etc.)
-- Full paths of source file(s) related to the manifestation of the issue
-- The location of the affected code (tag/branch/commit or direct URL)
-- Any special configuration required to reproduce the issue
-- Step-by-step instructions to reproduce the issue
-- Proof-of-concept or exploit code (if possible)
-- Impact of the issue, including how an attacker might exploit it
+- Type of issue (for example: credential exposure, path traversal, injection).
+- Full paths of the source files involved.
+- The affected tag, branch, or commit.
+- Any configuration required to reproduce the issue.
+- Step-by-step reproduction instructions.
+- Proof-of-concept or exploit code, if available.
+- Impact, including how an attacker might exploit it.
 
-We will acknowledge receipt of your report within 48 hours and provide a timeline for a fix. We ask that you do not disclose the issue publicly until we have had a chance to address it.
+You will receive an acknowledgement within 48 hours and a timeline for a fix.
+Please do not disclose the issue publicly until a fix has shipped.
+
+## Verifying release APKs
+
+Official Flow builds are signed with a single release key. Any APK that does
+not match the fingerprint below is not an official build, regardless of where
+it was downloaded.
+
+```
+SHA-256: 43:22:29:4E:D4:CA:A2:D4:29:41:40:09:58:18:08:0F:FE:8A:CC:1F:BE:3C:DC:76:10:7D:F4:5C:52:86:BE:40
+```
+
+Verify a downloaded APK with the Android SDK build tools:
+
+```bash
+apksigner verify --print-certs flow-foss.apk
+```
+
+The reported `Signer #1 certificate SHA-256 digest` must equal the fingerprint
+above (lower case, without colons).
+
+Official distribution channels are the
+[GitHub Releases page](https://github.com/A-EDev/Flow/releases) and
+[IzzyOnDroid](https://apt.izzysoft.de/packages/io.github.aedev.flow). Builds
+obtained anywhere else are unverified.

--- a/app/src/androidTest/java/io/github/aedev/flow/data/local/AppDatabaseMigrationsTest.kt
+++ b/app/src/androidTest/java/io/github/aedev/flow/data/local/AppDatabaseMigrationsTest.kt
@@ -13,8 +13,6 @@ import org.junit.runner.RunWith
 
 @RunWith(AndroidJUnit4::class)
 class AppDatabaseMigrationsTest {
-    private const val TEST_DB = "migration-test"
-
     private val instrumentation = InstrumentationRegistry.getInstrumentation()
 
     @get:Rule
@@ -50,4 +48,8 @@ class AppDatabaseMigrationsTest {
 
             db.close()
         }
+
+    companion object {
+        private const val TEST_DB = "migration-test"
+    }
 }


### PR DESCRIPTION
## Summary

Adds the standard repository automation that was missing, and fixes a release-path regression that would have broken IzzyOnDroid on the next tag.

`52c4928e` (#850) switched the release job to four ABI-split assets and stopped publishing a universal APK. The last release (`v2.2.0`) shipped `flow.apk` / `flow-foss.apk`, so the next tag would have been the first to publish under names IzzyOnDroid does not match. All ABI splits also share one `versionCode`, so a wrong match could have pushed a 32-bit build to arm64 users with no upgrade path back. This restores both universal APKs under their original names and publishes the splits alongside them, so no IzzyOnDroid-side change is needed.

**Release/signing safety**
- Hard-fail a `v*` tag build when `RELEASE_KEYSTORE_BASE64` is missing. `app/build.gradle.kts` otherwise falls back to `signingConfig = null` and publishes uninstallable unsigned APKs.
- Verify every release APK against the official certificate SHA-256 before the release job runs. A key mismatch is unrecoverable for installed users.
- Restore `flow.apk` and `flow-foss.apk` (universal) as published assets; ABI splits published alongside.
- Publish `checksums.txt` for all release APKs.

**CI correctness and cost**
- Concurrency group that cancels superseded branch/PR runs but never cancels a tag run mid-release.
- Job timeouts and a `workflow_dispatch` trigger.
- Compile `androidTest` sources so instrumentation breakage cannot land green (as in #899).
- Drop the stale `master`, `develop`, and `agent/discord-rich-presence` triggers.
- `checkout` to v7 and `setup-java` to v5. Artifact actions stay on v4 pending validation on the release path.

**New automation**
- `dependabot.yml` for Gradle and GitHub Actions, grouped, with AGP/Kotlin excluded from automated bumps.
- CodeQL analysis for `java-kotlin` using `build-mode: none`.
- Path-based PR labelling and a `CODEOWNERS` file.
- `release.yml` categories now reference labels that actually exist.

**Repository hygiene**
- `.gitattributes` forcing `eol=lf`. The index is already 100% LF, so this is a zero-diff change; it stops `autocrlf` producing CRLF working copies that Spotless then reports as violations.
- Ignore `.kotlin/` compiler session state.
- `SECURITY.md` updated from the stale 1.2.x table, pointed at private advisories, and documents how to verify a release APK signature.
- `CONTRIBUTING.md` documents the release and signing invariants.
- Remove leftover Copilot App Modernization directories from `.github/`.

## Related issue

<!-- none -->

## Change type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor or maintenance
- [x] Build, packaging, or CI
- [x] Documentation

## Validation

No application code changed — this PR only touches CI, repository config, and docs.

- [x] `./gradlew :app:assembleFossRelease` — succeeded. Confirms the release job's output paths, including `app-foss-universal-release.apk` (27.92 MiB), which the pre-splits workflow did not produce.
- [x] `./gradlew :app:compileGithubDebugAndroidTestKotlin --dry-run` — task resolves, confirming the new CI step targets a real AGP 9 task name.
- [x] Signing verification logic run locally against 3 built APKs (both flavors, universal + split) — all match `4322294e…be40`, matching the published `v2.2.0` APK and the local keystore.
- [x] All five workflow/config YAML files parse.
- [ ] `./gradlew :app:assembleGithubDebug` — not run; superseded by the full `assembleFossRelease` above.
- [ ] `./gradlew :app:testGithubDebugUnitTest` — not run; no application code changed.
- [ ] Manual device testing — not applicable; no application code changed.

**Test device and Android version:** n/a — no app code changed.

The tag-only paths (keystore hard-fail, fingerprint verification, universal rename, checksums) cannot execute until a `v*` tag is pushed, and are unverified in CI until then.

## Risk and compatibility

- [x] The change does not introduce secrets, private data, or unexpected telemetry. The certificate SHA-256 committed in `build.yml` and `SECURITY.md` is public — it is readable from every published APK — and is a fingerprint, not key material.
- [x] New user-facing text uses Android string resources — n/a, no UI changes.
- [x] Dependency and lockfile changes are intentional and limited to this PR — no dependency changes; `dependabot.yml` only proposes future updates.
- [x] Room schema changes include the required version bump and migration, or this PR does not change the Room schema — no schema changes.
- [x] Breaking changes and upgrade steps are clearly documented.

**Behaviour changes to be aware of**

1. **Feature-branch pushes no longer trigger CI.** Runs now happen on pushes to `main`, PRs targeting `main`, `v*` tags, and manual dispatch. Open a PR to get CI on a branch.
2. **`.gitattributes` needs a one-time re-checkout to take effect locally.** On a clean tree: `git rm --cached -r . && git reset --hard`. This normalizes the 707 of 994 `.kt` files currently CRLF in the working tree and should clear the local `ktlintCheck` noise.
3. **`versionCode` is still `17` / `versionName 2.2.0`.** IzzyOnDroid requires a monotonically increasing `versionCode`; this must be bumped before the next tag. Not changed here.