### PR TITLE
feat(home): show 3 columns in home grid and related videos

### DIFF
--- a/app/src/main/java/io/github/aedev/flow/ui/components/FeedGridLayout.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/components/FeedGridLayout.kt
@@ -18,10 +18,10 @@ data class FeedGridLayout(
 @Composable
 fun rememberFeedGridLayout(maxWidth: Dp): FeedGridLayout = remember(maxWidth) {
     when {
-        maxWidth < 480.dp -> FeedGridLayout(columns = 1, contentPadding = 0.dp, cardSpacing = 12.dp)
-        maxWidth < 700.dp -> FeedGridLayout(columns = 1, contentPadding = 12.dp, cardSpacing = 14.dp)
-        maxWidth < 900.dp -> FeedGridLayout(columns = 2, contentPadding = 16.dp, cardSpacing = 12.dp)
-        maxWidth < 1200.dp -> FeedGridLayout(columns = 3, contentPadding = 20.dp, cardSpacing = 14.dp)
-        else -> FeedGridLayout(columns = 4, contentPadding = 24.dp, cardSpacing = 16.dp)
+        maxWidth < 360.dp -> FeedGridLayout(columns = 2, contentPadding = 8.dp, cardSpacing = 8.dp)
+        maxWidth < 700.dp -> FeedGridLayout(columns = 3, contentPadding = 12.dp, cardSpacing = 10.dp)
+        maxWidth < 900.dp -> FeedGridLayout(columns = 3, contentPadding = 16.dp, cardSpacing = 12.dp)
+        maxWidth < 1200.dp -> FeedGridLayout(columns = 4, contentPadding = 20.dp, cardSpacing = 14.dp)
+        else -> FeedGridLayout(columns = 5, contentPadding = 24.dp, cardSpacing = 16.dp)
     }
 }

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/home/HomeScreen.kt
@@ -68,13 +68,7 @@ private fun rememberHomeLayoutConfig(maxWidth: Dp): HomeLayoutConfig {
     val base = rememberFeedGridLayout(maxWidth)
     return remember(base, maxWidth) {
         val shortsShelfAfterIndex =
-            when {
-                maxWidth < 480.dp -> 1
-                maxWidth < 700.dp -> 2
-                maxWidth < 900.dp -> 2
-                maxWidth < 1200.dp -> 3
-                else -> 4
-            }
+            if (maxWidth < 700.dp) base.columns * 2 else base.columns
         HomeLayoutConfig(
             columns = base.columns,
             contentPadding = base.contentPadding,

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/player/EnhancedVideoPlayerScreen.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/player/EnhancedVideoPlayerScreen.kt
@@ -184,7 +184,7 @@ fun EnhancedVideoPlayerScreen(
                                 if (isTabletPortrait) {
                                     relatedVideosGridContent(
                                         relatedVideos = uiState.relatedVideos,
-                                        columns = 2,
+                                        columns = 3,
                                         onVideoClick = onVideoClick,
                                         onChannelClick = onChannelClick,
                                         cardStyle = relatedCardStyle


### PR DESCRIPTION
## Summary

Home's Grid view rendered a single full-width thumbnail per row on typical phone widths, and the tablet-portrait related videos grid under a playing video was capped at 2 columns.

- `FeedGridLayout.kt` (shared by Home and Subscriptions): reworked the width breakpoints so typical phone widths (`< 700dp`) now get 3 columns instead of 1, and every wider tier shifted up by one column accordingly.
- `HomeScreen.kt`: the shorts-shelf insertion index is now derived from the actual column count (`columns * 2` on narrow widths, `columns` otherwise) instead of a separate hardcoded breakpoint table, so the shelf still lands on a row boundary with the new column counts.
- `EnhancedVideoPlayerScreen.kt`: the tablet-portrait related-videos grid shown under a playing video now uses 3 columns instead of 2.

## Related issue

Closes #855

## Change type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor or maintenance
- [ ] Build, packaging, or CI
- [ ] Documentation

## Validation

- [ ] `./gradlew :app:assembleGithubDebug`
- [ ] `./gradlew :app:testGithubDebugUnitTest`
- [ ] I ran any additional flavor-specific build or test tasks affected by this change.
- [ ] I manually tested the affected behavior on an Android device or emulator.

No Android SDK / emulator was available in the environment this change was made in, so none of the above could actually be run — please run the build/tests and a manual check on-device before merging.

**Test device and Android version:** Not tested on-device (see note above).

## Screenshots or recordings

Not captured — no emulator/device available in this environment.

## Risk and compatibility

- [x] The change does not introduce secrets, private data, or unexpected telemetry.
- [x] New user-facing text uses Android string resources. (no new user-facing strings)
- [x] Dependency and lockfile changes are intentional and limited to this PR. (no dependency changes)
- [x] Room schema changes include the required version bump and migration, or this PR does not change the Room schema. (no Room schema changes)
- [x] Breaking changes and upgrade steps are clearly documented. (no breaking changes; purely a layout/column-count adjustment)