### PR TITLE
fix(ui): unify screen top bars so settings and notifications stay rea…

### DIFF
--- a/app/src/androidTest/java/io/github/aedev/flow/ui/components/layout/topbar/FlowTopBarTest.kt
+++ b/app/src/androidTest/java/io/github/aedev/flow/ui/components/layout/topbar/FlowTopBarTest.kt
@@ -1,0 +1,100 @@
+package io.github.aedev.flow.ui.components.layout.topbar
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.test.platform.app.InstrumentationRegistry
+import io.github.aedev.flow.R
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.Rule
+import org.junit.Test
+
+/**
+ * Guards the rule that fixes the "settings and notifications disappear when Home is disabled" bug:
+ * a top bar with no back affordance is a root destination and must offer both shell actions.
+ */
+class FlowTopBarTest {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    private val context = InstrumentationRegistry.getInstrumentation().targetContext
+
+    private fun setBar(
+        unread: Int = 0,
+        content: @Composable () -> Unit,
+    ) {
+        composeRule.setContent {
+            MaterialTheme {
+                ProvideFlowGlobalActions(
+                    unreadNotifications = MutableStateFlow(unread),
+                    onOpenNotifications = {},
+                    onOpenSettings = {},
+                    content = content,
+                )
+            }
+        }
+    }
+
+    @Test
+    fun rootDestinationShowsNotificationsAndSettings() {
+        setBar { FlowTopBar(title = "Library") }
+
+        composeRule
+            .onNodeWithContentDescription(context.getString(R.string.notifications))
+            .assertIsDisplayed()
+        composeRule
+            .onNodeWithContentDescription(context.getString(R.string.settings))
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun detailDestinationShowsNeitherShellAction() {
+        setBar { FlowTopBar(title = "Buffer", onBack = {}) }
+
+        composeRule
+            .onNodeWithContentDescription(context.getString(R.string.notifications))
+            .assertDoesNotExist()
+        composeRule
+            .onNodeWithContentDescription(context.getString(R.string.settings))
+            .assertDoesNotExist()
+        composeRule
+            .onNodeWithContentDescription(context.getString(R.string.btn_back))
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun brandedLeadingSlotStillCountsAsARootDestination() {
+        setBar { FlowTopBar(title = "FLOW", leading = {}) }
+
+        composeRule
+            .onNodeWithContentDescription(context.getString(R.string.settings))
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun unreadCountRendersABadge() {
+        setBar(unread = 3) { FlowTopBar(title = "Home") }
+
+        composeRule.onNodeWithText("3").assertIsDisplayed()
+    }
+
+    @Test
+    fun searchBarNeverShowsShellActions() {
+        setBar {
+            FlowSearchTopBar(
+                query = "",
+                onQueryChange = {},
+                onClose = {},
+                placeholder = "Search settings",
+                autoFocus = false,
+            )
+        }
+
+        composeRule
+            .onNodeWithContentDescription(context.getString(R.string.settings))
+            .assertDoesNotExist()
+    }
+}

--- a/app/src/main/assets/changelog/v2.2.1.txt
+++ b/app/src/main/assets/changelog/v2.2.1.txt
@@ -1,6 +1,6 @@
 FLOW CHANGE LOG
 VERSION: 2.2.1
-DATE: 2026-08-20
+DATE: 2026-08-25
 STATUS: PRE-RELEASE
 
 NEW FEATURES
@@ -100,6 +100,7 @@ FIXES AND STABILITY
 - Keep every device's learned interests when syncing with a device that has synced with a third one
 - Fix Back abandoning the whole sync screen instead of returning to the previous step
 - Fix the empty band above the title on the sync screen
+- Fix Settings and Notifications being unreachable after turning off the home tab
 
 DEPENDENCY
 - Bump NewPipeExtractor to v0.26.5

--- a/app/src/main/java/io/github/aedev/flow/ui/FlowApp.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/FlowApp.kt
@@ -49,10 +49,12 @@ import io.github.aedev.flow.ui.components.MusicPlayerSheetState
 import io.github.aedev.flow.ui.components.PersistentMiniMusicPlayer
 import io.github.aedev.flow.ui.components.PlayerSheetValue
 import io.github.aedev.flow.ui.components.SleepTimerSheet
+import io.github.aedev.flow.ui.components.layout.topbar.ProvideFlowGlobalActions
 import io.github.aedev.flow.ui.components.rememberMusicPlayerSheetState
 import io.github.aedev.flow.ui.components.rememberPlayerDraggableState
 import io.github.aedev.flow.ui.screens.home.HomeViewModel
 import io.github.aedev.flow.ui.screens.music.EnhancedMusicPlayerScreen
+import io.github.aedev.flow.ui.screens.notifications.NotificationViewModel
 import io.github.aedev.flow.ui.screens.player.VideoPlayerViewModel
 import io.github.aedev.flow.ui.theme.CustomThemePalettes
 import io.github.aedev.flow.ui.theme.ThemeMode
@@ -89,6 +91,8 @@ fun FlowApp(
     val snackbarHostState = remember { androidx.compose.material3.SnackbarHostState() }
 
     val playerViewModel: VideoPlayerViewModel = hiltViewModel(activity!!)
+    // Activity-scoped so the unread badge has exactly one collector for the whole shell.
+    val notificationViewModel: NotificationViewModel = hiltViewModel(activity)
     val playerUiStateResult = playerViewModel.uiState.collectAsStateWithLifecycle()
     val playerUiState by playerUiStateResult
     val enhancedPlayerManager = remember { EnhancedPlayerManager.getInstance() }
@@ -539,71 +543,77 @@ fun FlowApp(
                             homeViewModel.initialize(context.applicationContext)
                         }
 
-                        NavHost(
-                            navController = navController,
-                            startDestination = if (needsOnboarding == true) "onboarding" else defaultStartRoute,
-                            enterTransition = {
-                                fadeIn(animationSpec = tween(250, easing = FastOutSlowInEasing)) +
-                                    slideInHorizontally(
-                                        initialOffsetX = { (it * 0.06f).toInt() },
-                                        animationSpec =
-                                            spring(
-                                                dampingRatio = Spring.DampingRatioNoBouncy,
-                                                stiffness = Spring.StiffnessMediumLow,
-                                            ),
-                                    )
-                            },
-                            exitTransition = {
-                                fadeOut(animationSpec = tween(200, easing = FastOutLinearInEasing))
-                            },
-                            popEnterTransition = {
-                                fadeIn(animationSpec = tween(250, easing = FastOutSlowInEasing))
-                            },
-                            popExitTransition = {
-                                fadeOut(animationSpec = tween(200, easing = FastOutLinearInEasing)) +
-                                    slideOutHorizontally(
-                                        targetOffsetX = { (it * 0.06f).toInt() },
-                                        animationSpec =
-                                            spring(
-                                                dampingRatio = Spring.DampingRatioNoBouncy,
-                                                stiffness = Spring.StiffnessMediumLow,
-                                            ),
-                                    )
-                            },
+                        ProvideFlowGlobalActions(
+                            unreadNotifications = notificationViewModel.unreadCount,
+                            onOpenNotifications = { navController.navigate("notifications") },
+                            onOpenSettings = { navController.navigate("settings") },
                         ) {
-                            flowAppGraph(
+                            NavHost(
                                 navController = navController,
-                                currentRoute = currentRoute,
-                                showBottomNav = showBottomNav,
-                                selectedBottomNavIndex = selectedBottomNavIndex,
-                                playerSheetState = playerSheetState,
-                                musicPlayerSheetState = musicPlayerSheetState,
-                                homeViewModel = homeViewModel,
-                                playerViewModel = playerViewModel,
-                                playerUiStateResult = playerUiStateResult,
-                                playerVisibleState = playerVisibleState,
-                                currentTheme = currentTheme,
-                                themeVariant = themeVariant,
-                                customThemePalettes = customThemePalettes,
-                                systemLightThemeMode = systemLightThemeMode,
-                                systemDarkThemeMode = systemDarkThemeMode,
-                                systemDarkThemeVariant = systemDarkThemeVariant,
-                                onThemeChange = onThemeChange,
-                                onThemeVariantChange = onThemeVariantChange,
-                                onCustomThemePalettesChange = onCustomThemePalettesChange,
-                                onSystemLightThemeChange = onSystemLightThemeChange,
-                                onSystemDarkThemeChange = onSystemDarkThemeChange,
-                                onSystemDarkThemeVariantChange = onSystemDarkThemeVariantChange,
-                                disableShortsPlayer = disableShortsPlayer,
-                                defaultStartRoute = defaultStartRoute,
-                                bottomNavOverlayPadding = {
-                                    if (showBottomNav.value && isNavScrolledVisible) {
-                                        bottomNavContentHeightDp
-                                    } else {
-                                        0.dp
-                                    }
+                                startDestination = if (needsOnboarding == true) "onboarding" else defaultStartRoute,
+                                enterTransition = {
+                                    fadeIn(animationSpec = tween(250, easing = FastOutSlowInEasing)) +
+                                        slideInHorizontally(
+                                            initialOffsetX = { (it * 0.06f).toInt() },
+                                            animationSpec =
+                                                spring(
+                                                    dampingRatio = Spring.DampingRatioNoBouncy,
+                                                    stiffness = Spring.StiffnessMediumLow,
+                                                ),
+                                        )
                                 },
-                            )
+                                exitTransition = {
+                                    fadeOut(animationSpec = tween(200, easing = FastOutLinearInEasing))
+                                },
+                                popEnterTransition = {
+                                    fadeIn(animationSpec = tween(250, easing = FastOutSlowInEasing))
+                                },
+                                popExitTransition = {
+                                    fadeOut(animationSpec = tween(200, easing = FastOutLinearInEasing)) +
+                                        slideOutHorizontally(
+                                            targetOffsetX = { (it * 0.06f).toInt() },
+                                            animationSpec =
+                                                spring(
+                                                    dampingRatio = Spring.DampingRatioNoBouncy,
+                                                    stiffness = Spring.StiffnessMediumLow,
+                                                ),
+                                        )
+                                },
+                            ) {
+                                flowAppGraph(
+                                    navController = navController,
+                                    currentRoute = currentRoute,
+                                    showBottomNav = showBottomNav,
+                                    selectedBottomNavIndex = selectedBottomNavIndex,
+                                    playerSheetState = playerSheetState,
+                                    musicPlayerSheetState = musicPlayerSheetState,
+                                    homeViewModel = homeViewModel,
+                                    playerViewModel = playerViewModel,
+                                    playerUiStateResult = playerUiStateResult,
+                                    playerVisibleState = playerVisibleState,
+                                    currentTheme = currentTheme,
+                                    themeVariant = themeVariant,
+                                    customThemePalettes = customThemePalettes,
+                                    systemLightThemeMode = systemLightThemeMode,
+                                    systemDarkThemeMode = systemDarkThemeMode,
+                                    systemDarkThemeVariant = systemDarkThemeVariant,
+                                    onThemeChange = onThemeChange,
+                                    onThemeVariantChange = onThemeVariantChange,
+                                    onCustomThemePalettesChange = onCustomThemePalettesChange,
+                                    onSystemLightThemeChange = onSystemLightThemeChange,
+                                    onSystemDarkThemeChange = onSystemDarkThemeChange,
+                                    onSystemDarkThemeVariantChange = onSystemDarkThemeVariantChange,
+                                    disableShortsPlayer = disableShortsPlayer,
+                                    defaultStartRoute = defaultStartRoute,
+                                    bottomNavOverlayPadding = {
+                                        if (showBottomNav.value && isNavScrolledVisible) {
+                                            bottomNavContentHeightDp
+                                        } else {
+                                            0.dp
+                                        }
+                                    },
+                                )
+                            }
                         }
                     }
                 }

--- a/app/src/main/java/io/github/aedev/flow/ui/FlowNavigation.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/FlowNavigation.kt
@@ -143,12 +143,6 @@ fun NavGraphBuilder.flowAppGraph(
             onSearchClick = {
                 navController.navigate("search")
             },
-            onNotificationClick = {
-                navController.navigate("notifications")
-            },
-            onSettingsClick = {
-                navController.navigate("settings")
-            },
             onChannelClick = { channelId ->
                 navController.navigateToYoutubeChannel(channelId)
             },
@@ -347,7 +341,6 @@ fun NavGraphBuilder.flowAppGraph(
         showBottomNav.value = true
         selectedBottomNavIndex.intValue = 6
         io.github.aedev.flow.ui.screens.categories.CategoriesScreen(
-            onBackClick = { navController.popBackStack() },
             onVideoClick = { video ->
                 if (video.isShort && !disableShortsPlayer) {
                     navController.openShorts(ShortsQueueSource.SeededFeed(video.id))
@@ -891,7 +884,6 @@ fun NavGraphBuilder.flowAppGraph(
         val musicPlayerViewModel: MusicPlayerViewModel = hiltViewModel()
 
         EnhancedMusicScreen(
-            onBackClick = { navController.popBackStack() },
             onSongClick = { track, queue, source ->
                 musicPlayerViewModel.loadAndPlayTrack(track, queue, source)
 
@@ -912,9 +904,6 @@ fun NavGraphBuilder.flowAppGraph(
             },
             onRecognizeClick = {
                 navController.navigate("musicRecognize")
-            },
-            onSettingsClick = {
-                navController.navigate("settings")
             },
             onAlbumClick = { albumId ->
                 navController.navigate("musicPlaylist/$albumId")

--- a/app/src/main/java/io/github/aedev/flow/ui/components/layout/topbar/FlowGlobalActions.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/components/layout/topbar/FlowGlobalActions.kt
@@ -1,0 +1,54 @@
+package io.github.aedev.flow.ui.components.layout.topbar
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.staticCompositionLocalOf
+import kotlinx.coroutines.flow.StateFlow
+
+/**
+ * App-shell destinations that must stay reachable from every root screen.
+ *
+ * Before this existed, `notifications` had a single entry point — the Home top bar — so turning
+ * Home off in navigation settings orphaned the screen entirely. Root tabs 3 (Subscriptions) and 4
+ * (Library) can never be hidden, so rendering these actions on every backless destination
+ * guarantees reachability for any navigation configuration.
+ *
+ * [unreadNotifications] is the flow rather than the current value so that a new notification
+ * invalidates only the badge that collects it, instead of the whole shell that provides it.
+ */
+@Immutable
+data class FlowGlobalActions(
+    val unreadNotifications: StateFlow<Int>,
+    val onOpenNotifications: () -> Unit,
+    val onOpenSettings: () -> Unit,
+)
+
+/**
+ * Static because the provided value is remembered for the lifetime of the shell and never changes;
+ * reading it must never invalidate a screen.
+ */
+val LocalFlowGlobalActions = staticCompositionLocalOf<FlowGlobalActions?> { null }
+
+/**
+ * Publishes the shell's global actions to every [FlowTopBar] below it. Call once, around the
+ * `NavHost`.
+ */
+@Composable
+fun ProvideFlowGlobalActions(
+    unreadNotifications: StateFlow<Int>,
+    onOpenNotifications: () -> Unit,
+    onOpenSettings: () -> Unit,
+    content: @Composable () -> Unit,
+) {
+    val actions =
+        remember(unreadNotifications, onOpenNotifications, onOpenSettings) {
+            FlowGlobalActions(
+                unreadNotifications = unreadNotifications,
+                onOpenNotifications = onOpenNotifications,
+                onOpenSettings = onOpenSettings,
+            )
+        }
+    CompositionLocalProvider(LocalFlowGlobalActions provides actions, content = content)
+}

--- a/app/src/main/java/io/github/aedev/flow/ui/components/layout/topbar/FlowSearchTopBar.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/components/layout/topbar/FlowSearchTopBar.kt
@@ -1,0 +1,93 @@
+package io.github.aedev.flow.ui.components.layout.topbar
+
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Close
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.input.ImeAction
+import io.github.aedev.flow.R
+
+/**
+ * Search variant of [FlowTopBar]: back button, inline field, optional trailing actions.
+ *
+ * Used for in-place filtering of a screen's own content (Settings search, Subscriptions manage
+ * mode), not for the Search tab. Global actions are never shown — the user is in a focused mode and
+ * the leading affordance dismisses it rather than navigating back.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun FlowSearchTopBar(
+    query: String,
+    onQueryChange: (String) -> Unit,
+    onClose: () -> Unit,
+    placeholder: String,
+    modifier: Modifier = Modifier,
+    actions: @Composable RowScope.() -> Unit = {},
+    autoFocus: Boolean = true,
+    windowInsets: WindowInsets = FlowTopBarDefaults.WindowInsets,
+) {
+    val focusRequester = remember { FocusRequester() }
+
+    if (autoFocus) {
+        LaunchedEffect(Unit) { focusRequester.requestFocus() }
+    }
+
+    FlowTopBar(
+        modifier = modifier,
+        title = {
+            TextField(
+                value = query,
+                onValueChange = onQueryChange,
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .focusRequester(focusRequester),
+                placeholder = {
+                    Text(text = placeholder, style = MaterialTheme.typography.bodyLarge)
+                },
+                singleLine = true,
+                keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
+                keyboardActions = KeyboardActions(onSearch = {}),
+                colors =
+                    TextFieldDefaults.colors(
+                        focusedContainerColor = Color.Transparent,
+                        unfocusedContainerColor = Color.Transparent,
+                        focusedIndicatorColor = Color.Transparent,
+                        unfocusedIndicatorColor = Color.Transparent,
+                    ),
+            )
+        },
+        onBack = onClose,
+        actions = {
+            if (query.isNotEmpty()) {
+                IconButton(onClick = { onQueryChange("") }) {
+                    Icon(
+                        imageVector = Icons.Outlined.Close,
+                        contentDescription = stringResource(R.string.top_bar_clear_search),
+                    )
+                }
+            }
+            actions()
+        },
+        globalActions = FlowGlobalActionsMode.None,
+        windowInsets = windowInsets,
+    )
+}

--- a/app/src/main/java/io/github/aedev/flow/ui/components/layout/topbar/FlowTopBar.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/components/layout/topbar/FlowTopBar.kt
@@ -1,0 +1,151 @@
+package io.github.aedev.flow.ui.components.layout.topbar
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
+import io.github.aedev.flow.R
+
+/**
+ * Which screens show the app-shell actions ([FlowGlobalActions]).
+ *
+ * [Auto] is the default and resolves from the bar's own shape: a bar with no back affordance is a
+ * root destination, and every root destination must be able to reach Notifications and Settings.
+ * A new root tab therefore cannot forget them — it would have to opt out with [None].
+ */
+enum class FlowGlobalActionsMode {
+    Auto,
+    Always,
+    None,
+}
+
+/**
+ * The single top bar for every non-player screen.
+ *
+ * Pass [onBack] for a detail screen; leave it null for a root tab. See [FlowTopBarDefaults] for why
+ * the colours and window insets differ from the Material defaults.
+ *
+ * @param leading replaces the default back button — used by Home for its logo + wordmark. A bar
+ *   with a [leading] slot is still treated as a root destination.
+ * @param actions screen-specific actions. Keep this to two on a root destination; put the rest in
+ *   [FlowTopBarOverflow] so the title keeps its width.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun FlowTopBar(
+    title: String,
+    modifier: Modifier = Modifier,
+    subtitle: String? = null,
+    onBack: (() -> Unit)? = null,
+    leading: @Composable (() -> Unit)? = null,
+    actions: @Composable RowScope.() -> Unit = {},
+    globalActions: FlowGlobalActionsMode = FlowGlobalActionsMode.Auto,
+    windowInsets: WindowInsets = FlowTopBarDefaults.WindowInsets,
+) {
+    FlowTopBar(
+        modifier = modifier,
+        title = {
+            FlowTopBarTitle(title = title, subtitle = subtitle)
+        },
+        onBack = onBack,
+        leading = leading,
+        actions = actions,
+        globalActions = globalActions,
+        windowInsets = windowInsets,
+    )
+}
+
+/**
+ * Slot-based overload for bars whose title is not plain text — a branded wordmark, a tab row, or an
+ * inline field. Prefer the string overload; this exists so such screens still share the container,
+ * colours, insets and global-action behaviour instead of hand-rolling a bar.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun FlowTopBar(
+    title: @Composable () -> Unit,
+    modifier: Modifier = Modifier,
+    onBack: (() -> Unit)? = null,
+    leading: @Composable (() -> Unit)? = null,
+    actions: @Composable RowScope.() -> Unit = {},
+    globalActions: FlowGlobalActionsMode = FlowGlobalActionsMode.Auto,
+    windowInsets: WindowInsets = FlowTopBarDefaults.WindowInsets,
+) {
+    val showGlobalActions =
+        when (globalActions) {
+            FlowGlobalActionsMode.Always -> true
+            FlowGlobalActionsMode.None -> false
+            FlowGlobalActionsMode.Auto -> onBack == null
+        }
+
+    TopAppBar(
+        modifier = modifier,
+        title = title,
+        navigationIcon = {
+            when {
+                leading != null -> {
+                    leading()
+                }
+
+                onBack != null -> {
+                    IconButton(onClick = onBack) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = stringResource(R.string.btn_back),
+                        )
+                    }
+                }
+            }
+        },
+        actions = {
+            actions()
+            if (showGlobalActions) {
+                FlowGlobalActionsRow()
+            }
+        },
+        colors = FlowTopBarDefaults.colors(),
+        windowInsets = windowInsets,
+    )
+}
+
+@Composable
+private fun FlowTopBarTitle(
+    title: String,
+    subtitle: String?,
+) {
+    if (subtitle == null) {
+        Text(
+            text = title,
+            style = FlowTopBarDefaults.titleStyle,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+    } else {
+        Column {
+            Text(
+                text = title,
+                style = FlowTopBarDefaults.titleStyle,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            Text(
+                text = subtitle,
+                style = FlowTopBarDefaults.subtitleStyle,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+    }
+}

--- a/app/src/main/java/io/github/aedev/flow/ui/components/layout/topbar/FlowTopBarActions.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/components/layout/topbar/FlowTopBarActions.kt
@@ -1,0 +1,154 @@
+package io.github.aedev.flow.ui.components.layout.topbar
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.MoreVert
+import androidx.compose.material.icons.outlined.Notifications
+import androidx.compose.material.icons.outlined.Settings
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import io.github.aedev.flow.R
+
+/**
+ * The Notifications and Settings actions every root destination gets.
+ *
+ * Renders nothing when the shell has not provided [LocalFlowGlobalActions] — the case in previews
+ * and in isolated Compose tests.
+ */
+@Composable
+internal fun FlowGlobalActionsRow() {
+    val actions = LocalFlowGlobalActions.current ?: return
+    val unreadCount by actions.unreadNotifications.collectAsStateWithLifecycle()
+
+    FlowNotificationsAction(
+        unreadCount = unreadCount,
+        onClick = actions.onOpenNotifications,
+    )
+    IconButton(onClick = actions.onOpenSettings) {
+        Icon(
+            imageVector = Icons.Outlined.Settings,
+            contentDescription = stringResource(R.string.settings),
+        )
+    }
+}
+
+@Composable
+private fun FlowNotificationsAction(
+    unreadCount: Int,
+    onClick: () -> Unit,
+) {
+    IconButton(onClick = onClick) {
+        Box(contentAlignment = Alignment.TopEnd) {
+            Icon(
+                imageVector = Icons.Outlined.Notifications,
+                contentDescription = stringResource(R.string.notifications),
+            )
+            if (unreadCount > 0) {
+                Box(
+                    modifier =
+                        Modifier
+                            .offset(x = 6.dp, y = (-4).dp)
+                            .background(MaterialTheme.colorScheme.primary, shape = CircleShape)
+                            .size(16.dp),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Text(
+                        text =
+                            if (unreadCount > 9) {
+                                stringResource(R.string.notification_badge_9_plus)
+                            } else {
+                                unreadCount.toString()
+                            },
+                        color = MaterialTheme.colorScheme.onPrimary,
+                        style =
+                            MaterialTheme.typography.labelSmall.copy(
+                                fontSize = 9.sp,
+                                fontWeight = FontWeight.Bold,
+                                lineHeight = 9.sp,
+                            ),
+                    )
+                }
+            }
+        }
+    }
+}
+
+/**
+ * One entry in a top bar overflow menu.
+ *
+ * Deliberately not `FlowMenuItemData` — that models the card-list menus rendered inside screen
+ * content, while this is a plain Material 3 `DropdownMenuItem`.
+ */
+@Immutable
+data class FlowTopBarMenuItem(
+    val label: String,
+    val onClick: () -> Unit,
+    val enabled: Boolean = true,
+    val icon: ImageVector? = null,
+)
+
+/**
+ * Collapses extra actions behind a single overflow button.
+ *
+ * A root destination has room for two screen-specific actions before the two global ones; anything
+ * past that belongs here rather than competing with the title for width.
+ */
+@Composable
+fun FlowTopBarOverflow(
+    items: List<FlowTopBarMenuItem>,
+    modifier: Modifier = Modifier,
+    contentDescription: String = stringResource(R.string.more_options),
+) {
+    if (items.isEmpty()) return
+    var expanded by remember { mutableStateOf(false) }
+
+    Box(modifier = modifier) {
+        IconButton(onClick = { expanded = true }) {
+            Icon(
+                imageVector = Icons.Default.MoreVert,
+                contentDescription = contentDescription,
+            )
+        }
+        DropdownMenu(
+            expanded = expanded,
+            onDismissRequest = { expanded = false },
+        ) {
+            items.forEach { item ->
+                DropdownMenuItem(
+                    text = { Text(item.label) },
+                    enabled = item.enabled,
+                    leadingIcon =
+                        item.icon?.let { icon ->
+                            { Icon(imageVector = icon, contentDescription = null) }
+                        },
+                    onClick = {
+                        expanded = false
+                        item.onClick()
+                    },
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/io/github/aedev/flow/ui/components/layout/topbar/FlowTopBarDefaults.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/components/layout/topbar/FlowTopBarDefaults.kt
@@ -1,0 +1,45 @@
+package io.github.aedev.flow.ui.components.layout.topbar
+
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.TopAppBarColors
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+
+/**
+ * Shared look of every non-player top bar.
+ *
+ * The values here are not Material defaults on purpose: Flow paints screens on
+ * `colorScheme.background` rather than `surface`, and [WindowInsets] owns no status-bar padding
+ * because the root `Scaffold` in `FlowApp` already consumes `WindowInsets.systemBars`. Letting a
+ * `TopAppBar` apply its own insets would double the status-bar gap on every screen.
+ */
+object FlowTopBarDefaults {
+    /** Status bar padding is applied once by the root scaffold, never by an individual bar. */
+    val WindowInsets: WindowInsets = WindowInsets(0.dp)
+
+    /**
+     * Internal because [TopAppBarColors] is an experimental Material type: exposing it would force
+     * every calling screen to opt in, which is exactly what this component exists to avoid.
+     */
+    @OptIn(ExperimentalMaterial3Api::class)
+    @Composable
+    internal fun colors(): TopAppBarColors =
+        TopAppBarDefaults.topAppBarColors(
+            containerColor = MaterialTheme.colorScheme.background,
+            scrolledContainerColor = MaterialTheme.colorScheme.surface,
+            titleContentColor = MaterialTheme.colorScheme.onBackground,
+            navigationIconContentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+            actionIconContentColor = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+
+    val titleStyle: TextStyle
+        @Composable get() = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold)
+
+    val subtitleStyle: TextStyle
+        @Composable get() = MaterialTheme.typography.bodySmall
+}

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/categories/CategoriesScreen.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/categories/CategoriesScreen.kt
@@ -5,14 +5,14 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyRow
-import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.lazy.itemsIndexed
-import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
@@ -40,6 +40,7 @@ import io.github.aedev.flow.ui.components.ShimmerVideoCardFullWidth
 import io.github.aedev.flow.ui.components.ShimmerVideoCardHorizontal
 import io.github.aedev.flow.ui.components.VideoCardFullWidth
 import io.github.aedev.flow.ui.components.VideoCardHorizontal
+import io.github.aedev.flow.ui.components.layout.topbar.FlowTopBar
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.filter
 
@@ -47,111 +48,131 @@ private data class CategoryTab(
     val category: TrendingCategory,
     val labelRes: Int,
     val iconRes: ImageVector? = null,
-    val iconResId: Int? = null
+    val iconResId: Int? = null,
 )
 
 private data class CategoriesLayoutConfig(
     val columns: Int,
     val contentPadding: Dp,
-    val cardSpacing: Dp
+    val cardSpacing: Dp,
 )
 
 @Composable
-private fun rememberCategoriesLayoutConfig(maxWidth: Dp): CategoriesLayoutConfig {
-    return remember(maxWidth) {
+private fun rememberCategoriesLayoutConfig(maxWidth: Dp): CategoriesLayoutConfig =
+    remember(maxWidth) {
         when {
-            maxWidth < 480.dp  -> CategoriesLayoutConfig(columns = 1, contentPadding = 0.dp,  cardSpacing = 12.dp)
-            maxWidth < 700.dp  -> CategoriesLayoutConfig(columns = 1, contentPadding = 12.dp, cardSpacing = 14.dp)
-            maxWidth < 900.dp  -> CategoriesLayoutConfig(columns = 2, contentPadding = 16.dp, cardSpacing = 12.dp)
+            maxWidth < 480.dp -> CategoriesLayoutConfig(columns = 1, contentPadding = 0.dp, cardSpacing = 12.dp)
+            maxWidth < 700.dp -> CategoriesLayoutConfig(columns = 1, contentPadding = 12.dp, cardSpacing = 14.dp)
+            maxWidth < 900.dp -> CategoriesLayoutConfig(columns = 2, contentPadding = 16.dp, cardSpacing = 12.dp)
             maxWidth < 1200.dp -> CategoriesLayoutConfig(columns = 3, contentPadding = 20.dp, cardSpacing = 14.dp)
-            else               -> CategoriesLayoutConfig(columns = 4, contentPadding = 24.dp, cardSpacing = 16.dp)
+            else -> CategoriesLayoutConfig(columns = 4, contentPadding = 24.dp, cardSpacing = 16.dp)
         }
     }
-}
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun CategoriesScreen(
-    onBackClick: () -> Unit,
     onVideoClick: (Video) -> Unit,
     onChannelClick: (String) -> Unit = {},
-    viewModel: CategoriesViewModel = hiltViewModel()
+    viewModel: CategoriesViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val trendingRegion by viewModel.trendingRegion.collectAsStateWithLifecycle()
     val showRegionPicker by viewModel.showRegionPickerInExplore.collectAsStateWithLifecycle()
     var showRegionDialog by remember { mutableStateOf(false) }
 
-    val tabs = remember {
-        listOf(
-            CategoryTab(TrendingCategory.ALL,     R.string.category_all),
-            CategoryTab(TrendingCategory.GAMING,   R.string.category_gaming),
-            CategoryTab(TrendingCategory.MUSIC,    R.string.category_music),
-            CategoryTab(TrendingCategory.MOVIES,   R.string.category_movies),
-            CategoryTab(TrendingCategory.LIVE,     R.string.category_live),
-        )
-    }
+    val tabs =
+        remember {
+            listOf(
+                CategoryTab(TrendingCategory.ALL, R.string.category_all),
+                CategoryTab(TrendingCategory.GAMING, R.string.category_gaming),
+                CategoryTab(TrendingCategory.MUSIC, R.string.category_music),
+                CategoryTab(TrendingCategory.MOVIES, R.string.category_movies),
+                CategoryTab(TrendingCategory.LIVE, R.string.category_live),
+            )
+        }
 
     Scaffold(
         topBar = {
-            CategoriesTopBar(
-                isListView = uiState.isListView,
-                currentRegion = trendingRegion,
-                showRegionPicker = showRegionPicker,
-                onBackClick = onBackClick,
-                onToggleViewMode = { viewModel.toggleViewMode() },
-                onRegionPickerClick = { showRegionDialog = true }
+            FlowTopBar(
+                title = stringResource(R.string.categories_title),
+                actions = {
+                    if (showRegionPicker) {
+                        IconButton(onClick = { showRegionDialog = true }) {
+                            Icon(
+                                imageVector = Icons.Outlined.Language,
+                                contentDescription = stringResource(R.string.categories_region_picker_desc, trendingRegion),
+                            )
+                        }
+                    }
+                    IconButton(onClick = { viewModel.toggleViewMode() }) {
+                        Icon(
+                            imageVector = if (uiState.isListView) Icons.Outlined.GridView else Icons.Outlined.List,
+                            contentDescription =
+                                if (uiState.isListView) {
+                                    stringResource(R.string.categories_switch_to_grid)
+                                } else {
+                                    stringResource(R.string.categories_switch_to_list)
+                                },
+                        )
+                    }
+                },
             )
         },
         containerColor = MaterialTheme.colorScheme.background,
-        contentWindowInsets = WindowInsets(0.dp)
+        contentWindowInsets = WindowInsets(0.dp),
     ) { innerPadding ->
         Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(innerPadding)
-                .background(MaterialTheme.colorScheme.background)
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .padding(innerPadding)
+                    .background(MaterialTheme.colorScheme.background),
         ) {
             // Category filter chips row
             LazyRow(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(vertical = 8.dp),
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 8.dp),
                 contentPadding = PaddingValues(horizontal = 16.dp),
-                horizontalArrangement = Arrangement.spacedBy(8.dp)
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
             ) {
                 items(tabs) { tab ->
                     val selected = uiState.selectedCategory == tab.category
                     ContentFilterChip(
                         title = stringResource(tab.labelRes),
                         isSelected = selected,
-                        onClick = { viewModel.selectCategory(tab.category) }
+                        onClick = { viewModel.selectCategory(tab.category) },
                     )
                 }
             }
 
             HorizontalDivider(
                 color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.4f),
-                thickness = 0.5.dp
+                thickness = 0.5.dp,
             )
 
             // Content area
             BoxWithConstraints(
-                modifier = Modifier
-                    .weight(1f)
-                    .fillMaxWidth()
+                modifier =
+                    Modifier
+                        .weight(1f)
+                        .fillMaxWidth(),
             ) {
                 val layoutConfig = rememberCategoriesLayoutConfig(maxWidth)
                 when {
                     uiState.isLoading -> {
                         ShimmerContent(isListView = uiState.isListView, layoutConfig = layoutConfig)
                     }
+
                     uiState.error != null && uiState.videos.isEmpty() -> {
                         ErrorContent(
                             message = uiState.error!!,
-                            onRetry = { viewModel.refresh() }
+                            onRetry = { viewModel.refresh() },
                         )
                     }
+
                     else -> {
                         if (uiState.isListView) {
                             ListContent(
@@ -160,7 +181,7 @@ fun CategoriesScreen(
                                 isLoadingMore = uiState.isLoadingMore,
                                 onVideoClick = onVideoClick,
                                 onChannelClick = onChannelClick,
-                                onLoadMore = { viewModel.loadMore() }
+                                onLoadMore = { viewModel.loadMore() },
                             )
                         } else {
                             GridContent(
@@ -170,7 +191,7 @@ fun CategoriesScreen(
                                 onVideoClick = onVideoClick,
                                 onChannelClick = onChannelClick,
                                 onLoadMore = { viewModel.loadMore() },
-                                layoutConfig = layoutConfig
+                                layoutConfig = layoutConfig,
                             )
                         }
                     }
@@ -183,13 +204,17 @@ fun CategoriesScreen(
     if (showRegionDialog) {
         var regionSearchQuery by remember { mutableStateOf("") }
         val allRegions = remember { REGION_NAMES.toList() }
-        val filteredRegions = remember(regionSearchQuery) {
-            if (regionSearchQuery.isBlank()) allRegions
-            else allRegions.filter { (code, name) ->
-                name.contains(regionSearchQuery, ignoreCase = true) ||
-                code.contains(regionSearchQuery, ignoreCase = true)
+        val filteredRegions =
+            remember(regionSearchQuery) {
+                if (regionSearchQuery.isBlank()) {
+                    allRegions
+                } else {
+                    allRegions.filter { (code, name) ->
+                        name.contains(regionSearchQuery, ignoreCase = true) ||
+                            code.contains(regionSearchQuery, ignoreCase = true)
+                    }
+                }
             }
-        }
         AlertDialog(
             onDismissRequest = { showRegionDialog = false },
             title = { Text(stringResource(R.string.settings_region_dialog_title)) },
@@ -201,7 +226,7 @@ fun CategoriesScreen(
                         placeholder = { Text(stringResource(R.string.search_hint)) },
                         leadingIcon = { Icon(Icons.Outlined.Search, contentDescription = null) },
                         singleLine = true,
-                        modifier = Modifier.fillMaxWidth()
+                        modifier = Modifier.fillMaxWidth(),
                     )
                     Spacer(Modifier.height(8.dp))
                     LazyColumn(Modifier.heightIn(max = 260.dp)) {
@@ -213,9 +238,8 @@ fun CategoriesScreen(
                                     .clickable {
                                         viewModel.setRegion(code)
                                         showRegionDialog = false
-                                    }
-                                    .padding(12.dp),
-                                verticalAlignment = Alignment.CenterVertically
+                                    }.padding(12.dp),
+                                verticalAlignment = Alignment.CenterVertically,
                             ) {
                                 RadioButton(selected = trendingRegion == code, onClick = null)
                                 Spacer(Modifier.width(8.dp))
@@ -230,61 +254,8 @@ fun CategoriesScreen(
                 TextButton(onClick = { showRegionDialog = false }) {
                     Text(stringResource(R.string.cancel))
                 }
-            }
+            },
         )
-    }
-}
-
-@Composable
-private fun CategoriesTopBar(
-    isListView: Boolean,
-    currentRegion: String,
-    showRegionPicker: Boolean,
-    onBackClick: () -> Unit,
-    onToggleViewMode: () -> Unit,
-    onRegionPickerClick: () -> Unit
-) {
-    Surface(
-        modifier = Modifier.fillMaxWidth(),
-        color = MaterialTheme.colorScheme.background
-    ) {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 4.dp, vertical = 4.dp),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            IconButton(onClick = onBackClick) {
-                Icon(
-                    imageVector = Icons.Default.ArrowBack,
-                    contentDescription = stringResource(R.string.btn_back)
-                )
-            }
-            Text(
-                text = stringResource(R.string.categories_title),
-                style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
-                modifier = Modifier.weight(1f)
-            )
-            if (showRegionPicker) {
-                IconButton(onClick = onRegionPickerClick) {
-                    Icon(
-                        imageVector = Icons.Outlined.Language,
-                        contentDescription = stringResource(R.string.categories_region_picker_desc, currentRegion),
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant
-                    )
-                }
-            }
-            IconButton(onClick = onToggleViewMode) {
-                Icon(
-                    imageVector = if (isListView) Icons.Outlined.GridView else Icons.Outlined.List,
-                    contentDescription = if (isListView)
-                        stringResource(R.string.categories_switch_to_grid)
-                    else
-                        stringResource(R.string.categories_switch_to_list),
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant
-                )
-            }
-        }
     }
 }
 
@@ -296,7 +267,7 @@ private fun GridContent(
     onVideoClick: (Video) -> Unit,
     onChannelClick: (String) -> Unit,
     onLoadMore: () -> Unit,
-    layoutConfig: CategoriesLayoutConfig
+    layoutConfig: CategoriesLayoutConfig,
 ) {
     val gridState = rememberLazyGridState()
 
@@ -307,20 +278,20 @@ private fun GridContent(
                 if (layoutInfo.totalItemsCount == 0) return@filter false
                 val lastVisible = layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0
                 lastVisible >= layoutInfo.totalItemsCount - 4
-            }
-            .collect { if (canLoadMore && !isLoadingMore) onLoadMore() }
+            }.collect { if (canLoadMore && !isLoadingMore) onLoadMore() }
     }
 
     LazyVerticalGrid(
         columns = GridCells.Fixed(layoutConfig.columns),
         state = gridState,
-        contentPadding = PaddingValues(
-            horizontal = layoutConfig.contentPadding,
-            vertical = 12.dp
-        ),
+        contentPadding =
+            PaddingValues(
+                horizontal = layoutConfig.contentPadding,
+                vertical = 12.dp,
+            ),
         horizontalArrangement = Arrangement.spacedBy(layoutConfig.cardSpacing),
         verticalArrangement = Arrangement.spacedBy(layoutConfig.cardSpacing),
-        modifier = Modifier.fillMaxSize()
+        modifier = Modifier.fillMaxSize(),
     ) {
         items(videos, key = { it.id }) { video ->
             VideoCardFullWidth(
@@ -328,21 +299,22 @@ private fun GridContent(
                 useInternalPadding = false,
                 modifier = Modifier.fillMaxWidth(),
                 onChannelClick = onChannelClick,
-                onClick = { onVideoClick(video) }
+                onClick = { onVideoClick(video) },
             )
         }
 
         if (canLoadMore) {
             item(span = { GridItemSpan(maxLineSpan) }) {
                 Box(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(16.dp),
-                    contentAlignment = Alignment.Center
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .padding(16.dp),
+                    contentAlignment = Alignment.Center,
                 ) {
                     CircularProgressIndicator(
                         modifier = Modifier.size(28.dp),
-                        strokeWidth = 2.dp
+                        strokeWidth = 2.dp,
                     )
                 }
             }
@@ -357,7 +329,7 @@ private fun ListContent(
     isLoadingMore: Boolean,
     onVideoClick: (Video) -> Unit,
     onChannelClick: (String) -> Unit,
-    onLoadMore: () -> Unit
+    onLoadMore: () -> Unit,
 ) {
     val listState = rememberLazyListState()
 
@@ -368,35 +340,35 @@ private fun ListContent(
                 if (layoutInfo.totalItemsCount == 0) return@filter false
                 val lastVisible = layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0
                 lastVisible >= layoutInfo.totalItemsCount - 3
-            }
-            .collect { if (canLoadMore && !isLoadingMore) onLoadMore() }
+            }.collect { if (canLoadMore && !isLoadingMore) onLoadMore() }
     }
 
     LazyColumn(
         state = listState,
         contentPadding = PaddingValues(vertical = 8.dp),
-        modifier = Modifier.fillMaxSize()
+        modifier = Modifier.fillMaxSize(),
     ) {
         items(videos, key = { it.id }) { video ->
             VideoCardHorizontal(
                 video = video,
                 modifier = Modifier.fillMaxWidth(),
                 onChannelClick = onChannelClick,
-                onClick = { onVideoClick(video) }
+                onClick = { onVideoClick(video) },
             )
         }
 
         if (canLoadMore) {
             item {
                 Box(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(16.dp),
-                    contentAlignment = Alignment.Center
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .padding(16.dp),
+                    contentAlignment = Alignment.Center,
                 ) {
                     CircularProgressIndicator(
                         modifier = Modifier.size(28.dp),
-                        strokeWidth = 2.dp
+                        strokeWidth = 2.dp,
                     )
                 }
             }
@@ -405,12 +377,15 @@ private fun ListContent(
 }
 
 @Composable
-private fun ShimmerContent(isListView: Boolean, layoutConfig: CategoriesLayoutConfig) {
+private fun ShimmerContent(
+    isListView: Boolean,
+    layoutConfig: CategoriesLayoutConfig,
+) {
     if (isListView) {
         LazyColumn(
             contentPadding = PaddingValues(vertical = 8.dp),
             modifier = Modifier.fillMaxSize(),
-            userScrollEnabled = false
+            userScrollEnabled = false,
         ) {
             items(8) {
                 ShimmerVideoCardHorizontal()
@@ -419,14 +394,15 @@ private fun ShimmerContent(isListView: Boolean, layoutConfig: CategoriesLayoutCo
     } else {
         LazyVerticalGrid(
             columns = GridCells.Fixed(layoutConfig.columns),
-            contentPadding = PaddingValues(
-                horizontal = layoutConfig.contentPadding,
-                vertical = 12.dp
-            ),
+            contentPadding =
+                PaddingValues(
+                    horizontal = layoutConfig.contentPadding,
+                    vertical = 12.dp,
+                ),
             horizontalArrangement = Arrangement.spacedBy(layoutConfig.cardSpacing),
             verticalArrangement = Arrangement.spacedBy(layoutConfig.cardSpacing),
             modifier = Modifier.fillMaxSize(),
-            userScrollEnabled = false
+            userScrollEnabled = false,
         ) {
             items(12) {
                 if (layoutConfig.columns == 1) {
@@ -440,62 +416,167 @@ private fun ShimmerContent(isListView: Boolean, layoutConfig: CategoriesLayoutCo
 }
 
 @Composable
-private fun ErrorContent(message: String, onRetry: () -> Unit) {
+private fun ErrorContent(
+    message: String,
+    onRetry: () -> Unit,
+) {
     Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(32.dp),
+        modifier =
+            Modifier
+                .fillMaxSize()
+                .padding(32.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.Center
+        verticalArrangement = Arrangement.Center,
     ) {
         Text(
             text = message,
             style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
         Spacer(modifier = Modifier.height(16.dp))
         Button(
             onClick = onRetry,
-            shape = RoundedCornerShape(12.dp)
+            shape = RoundedCornerShape(12.dp),
         ) {
             Text(stringResource(R.string.retry))
         }
     }
 }
 
-private val REGION_NAMES = mapOf(
-    "DZ" to "Algeria", "AS" to "American Samoa", "AI" to "Anguilla", "AR" to "Argentina",
-    "AW" to "Aruba", "AU" to "Australia", "AT" to "Austria", "AZ" to "Azerbaijan",
-    "BH" to "Bahrain", "BD" to "Bangladesh", "BY" to "Belarus", "BE" to "Belgium",
-    "BM" to "Bermuda", "BO" to "Bolivia", "BA" to "Bosnia and Herzegovina", "BR" to "Brazil",
-    "IO" to "British Indian Ocean Territory", "VG" to "British Virgin Islands", "BG" to "Bulgaria", "KH" to "Cambodia",
-    "CA" to "Canada", "KY" to "Cayman Islands", "CL" to "Chile", "CO" to "Colombia",
-    "CR" to "Costa Rica", "HR" to "Croatia", "CY" to "Cyprus", "CZ" to "Czech Republic",
-    "DK" to "Denmark", "DO" to "Dominican Republic", "EC" to "Ecuador", "EG" to "Egypt",
-    "SV" to "El Salvador", "EE" to "Estonia", "FK" to "Falkland Islands", "FO" to "Faroe Islands",
-    "FI" to "Finland", "FR" to "France", "GF" to "French Guiana", "PF" to "French Polynesia",
-    "GE" to "Georgia", "DE" to "Germany", "GH" to "Ghana", "GI" to "Gibraltar",
-    "GR" to "Greece", "GL" to "Greenland", "GP" to "Guadeloupe", "GU" to "Guam",
-    "GT" to "Guatemala", "HN" to "Honduras", "HK" to "Hong Kong", "HU" to "Hungary",
-    "IS" to "Iceland", "IN" to "India", "ID" to "Indonesia", "IQ" to "Iraq",
-    "IE" to "Ireland", "IL" to "Israel", "IT" to "Italy", "JM" to "Jamaica",
-    "JP" to "Japan", "JO" to "Jordan", "KZ" to "Kazakhstan", "KE" to "Kenya",
-    "KW" to "Kuwait", "LA" to "Laos", "LV" to "Latvia", "LB" to "Lebanon",
-    "LY" to "Libya", "LI" to "Liechtenstein", "LT" to "Lithuania", "LU" to "Luxembourg",
-    "MY" to "Malaysia", "MT" to "Malta", "MQ" to "Martinique", "YT" to "Mayotte",
-    "MX" to "Mexico", "MD" to "Moldova", "ME" to "Montenegro", "MS" to "Montserrat",
-    "MA" to "Morocco", "NP" to "Nepal", "NL" to "Netherlands", "NC" to "New Caledonia",
-    "NZ" to "New Zealand", "NI" to "Nicaragua", "NG" to "Nigeria", "NF" to "Norfolk Island",
-    "MP" to "Northern Mariana Islands", "NO" to "Norway", "OM" to "Oman", "PK" to "Pakistan",
-    "PA" to "Panama", "PG" to "Papua New Guinea", "PY" to "Paraguay", "PE" to "Peru",
-    "PH" to "Philippines", "PL" to "Poland", "PT" to "Portugal", "PR" to "Puerto Rico",
-    "QA" to "Qatar", "RE" to "Reunion", "RO" to "Romania", "RU" to "Russia",
-    "SH" to "Saint Helena", "PM" to "Saint Pierre and Miquelon", "SA" to "Saudi Arabia", "SN" to "Senegal",
-    "RS" to "Serbia", "SG" to "Singapore", "SK" to "Slovakia", "SI" to "Slovenia",
-    "ZA" to "South Africa", "KR" to "South Korea", "ES" to "Spain", "LK" to "Sri Lanka",
-    "SJ" to "Svalbard and Jan Mayen", "SE" to "Sweden", "CH" to "Switzerland", "TW" to "Taiwan",
-    "TZ" to "Tanzania", "TH" to "Thailand", "TN" to "Tunisia", "TR" to "Turkey",
-    "TC" to "Turks and Caicos Islands", "UG" to "Uganda", "UA" to "Ukraine", "AE" to "United Arab Emirates",
-    "GB" to "United Kingdom", "US" to "United States", "VI" to "U.S. Virgin Islands", "UY" to "Uruguay",
-    "VE" to "Venezuela", "VN" to "Vietnam"
-).toList().sortedBy { it.second }.toMap()
+private val REGION_NAMES =
+    mapOf(
+        "DZ" to "Algeria",
+        "AS" to "American Samoa",
+        "AI" to "Anguilla",
+        "AR" to "Argentina",
+        "AW" to "Aruba",
+        "AU" to "Australia",
+        "AT" to "Austria",
+        "AZ" to "Azerbaijan",
+        "BH" to "Bahrain",
+        "BD" to "Bangladesh",
+        "BY" to "Belarus",
+        "BE" to "Belgium",
+        "BM" to "Bermuda",
+        "BO" to "Bolivia",
+        "BA" to "Bosnia and Herzegovina",
+        "BR" to "Brazil",
+        "IO" to "British Indian Ocean Territory",
+        "VG" to "British Virgin Islands",
+        "BG" to "Bulgaria",
+        "KH" to "Cambodia",
+        "CA" to "Canada",
+        "KY" to "Cayman Islands",
+        "CL" to "Chile",
+        "CO" to "Colombia",
+        "CR" to "Costa Rica",
+        "HR" to "Croatia",
+        "CY" to "Cyprus",
+        "CZ" to "Czech Republic",
+        "DK" to "Denmark",
+        "DO" to "Dominican Republic",
+        "EC" to "Ecuador",
+        "EG" to "Egypt",
+        "SV" to "El Salvador",
+        "EE" to "Estonia",
+        "FK" to "Falkland Islands",
+        "FO" to "Faroe Islands",
+        "FI" to "Finland",
+        "FR" to "France",
+        "GF" to "French Guiana",
+        "PF" to "French Polynesia",
+        "GE" to "Georgia",
+        "DE" to "Germany",
+        "GH" to "Ghana",
+        "GI" to "Gibraltar",
+        "GR" to "Greece",
+        "GL" to "Greenland",
+        "GP" to "Guadeloupe",
+        "GU" to "Guam",
+        "GT" to "Guatemala",
+        "HN" to "Honduras",
+        "HK" to "Hong Kong",
+        "HU" to "Hungary",
+        "IS" to "Iceland",
+        "IN" to "India",
+        "ID" to "Indonesia",
+        "IQ" to "Iraq",
+        "IE" to "Ireland",
+        "IL" to "Israel",
+        "IT" to "Italy",
+        "JM" to "Jamaica",
+        "JP" to "Japan",
+        "JO" to "Jordan",
+        "KZ" to "Kazakhstan",
+        "KE" to "Kenya",
+        "KW" to "Kuwait",
+        "LA" to "Laos",
+        "LV" to "Latvia",
+        "LB" to "Lebanon",
+        "LY" to "Libya",
+        "LI" to "Liechtenstein",
+        "LT" to "Lithuania",
+        "LU" to "Luxembourg",
+        "MY" to "Malaysia",
+        "MT" to "Malta",
+        "MQ" to "Martinique",
+        "YT" to "Mayotte",
+        "MX" to "Mexico",
+        "MD" to "Moldova",
+        "ME" to "Montenegro",
+        "MS" to "Montserrat",
+        "MA" to "Morocco",
+        "NP" to "Nepal",
+        "NL" to "Netherlands",
+        "NC" to "New Caledonia",
+        "NZ" to "New Zealand",
+        "NI" to "Nicaragua",
+        "NG" to "Nigeria",
+        "NF" to "Norfolk Island",
+        "MP" to "Northern Mariana Islands",
+        "NO" to "Norway",
+        "OM" to "Oman",
+        "PK" to "Pakistan",
+        "PA" to "Panama",
+        "PG" to "Papua New Guinea",
+        "PY" to "Paraguay",
+        "PE" to "Peru",
+        "PH" to "Philippines",
+        "PL" to "Poland",
+        "PT" to "Portugal",
+        "PR" to "Puerto Rico",
+        "QA" to "Qatar",
+        "RE" to "Reunion",
+        "RO" to "Romania",
+        "RU" to "Russia",
+        "SH" to "Saint Helena",
+        "PM" to "Saint Pierre and Miquelon",
+        "SA" to "Saudi Arabia",
+        "SN" to "Senegal",
+        "RS" to "Serbia",
+        "SG" to "Singapore",
+        "SK" to "Slovakia",
+        "SI" to "Slovenia",
+        "ZA" to "South Africa",
+        "KR" to "South Korea",
+        "ES" to "Spain",
+        "LK" to "Sri Lanka",
+        "SJ" to "Svalbard and Jan Mayen",
+        "SE" to "Sweden",
+        "CH" to "Switzerland",
+        "TW" to "Taiwan",
+        "TZ" to "Tanzania",
+        "TH" to "Thailand",
+        "TN" to "Tunisia",
+        "TR" to "Turkey",
+        "TC" to "Turks and Caicos Islands",
+        "UG" to "Uganda",
+        "UA" to "Ukraine",
+        "AE" to "United Arab Emirates",
+        "GB" to "United Kingdom",
+        "US" to "United States",
+        "VI" to "U.S. Virgin Islands",
+        "UY" to "Uruguay",
+        "VE" to "Venezuela",
+        "VN" to "Vietnam",
+    ).toList().sortedBy { it.second }.toMap()

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/history/HistoryScreen.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/history/HistoryScreen.kt
@@ -75,6 +75,9 @@ import io.github.aedev.flow.data.model.hasLikelyCollaborationByline
 import io.github.aedev.flow.data.repository.VideoCollaboratorResolver
 import io.github.aedev.flow.data.shorts.queue.ShortsQueueSource
 import io.github.aedev.flow.ui.components.ShortsCard
+import io.github.aedev.flow.ui.components.layout.topbar.FlowTopBar
+import io.github.aedev.flow.ui.components.layout.topbar.FlowTopBarMenuItem
+import io.github.aedev.flow.ui.components.layout.topbar.FlowTopBarOverflow
 import io.github.aedev.flow.ui.screens.music.MusicTrack
 import io.github.aedev.flow.ui.screens.music.MusicTrackRow
 import java.text.SimpleDateFormat
@@ -139,63 +142,33 @@ fun HistoryScreen(
     Scaffold(
         contentWindowInsets = WindowInsets(0.dp),
         topBar = {
-            Surface(
-                modifier = Modifier.fillMaxWidth(),
-                color = MaterialTheme.colorScheme.background,
-            ) {
-                Row(
-                    modifier =
-                        Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = 4.dp, vertical = 8.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    IconButton(onClick = onBackClick) {
-                        Icon(
-                            imageVector = Icons.Default.ArrowBack,
-                            contentDescription = stringResource(R.string.btn_back),
-                        )
-                    }
-                    Text(
-                        text = stringResource(R.string.library_history_label),
-                        style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                        modifier = Modifier.weight(1f),
-                    )
-                    Box {
-                        IconButton(onClick = { showMenu = true }) {
-                            Icon(
-                                imageVector = Icons.Default.MoreVert,
-                                contentDescription = stringResource(R.string.more_options),
-                            )
-                        }
-                        DropdownMenu(
-                            expanded = showMenu,
-                            onDismissRequest = { showMenu = false },
-                        ) {
-                            if (uiState.shortsEnabled) {
-                                DropdownMenuItem(
-                                    text = { Text(stringResource(R.string.history_delete_shorts)) },
-                                    enabled = uiState.historyEntries.any { it.isShort },
-                                    onClick = {
-                                        showMenu = false
-                                        showClearShortsDialog = true
-                                    },
+            FlowTopBar(
+                title = stringResource(R.string.library_history_label),
+                onBack = onBackClick,
+                actions = {
+                    FlowTopBarOverflow(
+                        items =
+                            buildList {
+                                if (uiState.shortsEnabled) {
+                                    add(
+                                        FlowTopBarMenuItem(
+                                            label = stringResource(R.string.history_delete_shorts),
+                                            enabled = uiState.historyEntries.any { it.isShort },
+                                            onClick = { showClearShortsDialog = true },
+                                        ),
+                                    )
+                                }
+                                add(
+                                    FlowTopBarMenuItem(
+                                        label = stringResource(R.string.clear_all),
+                                        enabled = uiState.historyEntries.isNotEmpty(),
+                                        onClick = { showClearDialog = true },
+                                    ),
                                 )
-                            }
-                            DropdownMenuItem(
-                                text = { Text(stringResource(R.string.clear_all)) },
-                                enabled = uiState.historyEntries.isNotEmpty(),
-                                onClick = {
-                                    showMenu = false
-                                    showClearDialog = true
-                                },
-                            )
-                        }
-                    }
-                }
-            }
+                            },
+                    )
+                },
+            )
         },
         containerColor = MaterialTheme.colorScheme.background,
     ) { paddingValues ->

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/home/HomeScreen.kt
@@ -51,7 +51,7 @@ import io.github.aedev.flow.data.model.Video
 import io.github.aedev.flow.player.DeepFlowManager
 import io.github.aedev.flow.ui.TabScrollEventBus
 import io.github.aedev.flow.ui.components.*
-import io.github.aedev.flow.ui.screens.notifications.NotificationViewModel
+import io.github.aedev.flow.ui.components.layout.topbar.FlowTopBar
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.debounce
@@ -95,18 +95,14 @@ fun HomeScreen(
     onVideoClick: (Video) -> Unit,
     onShortClick: (io.github.aedev.flow.data.shorts.queue.ShortsQueueSource) -> Unit,
     onSearchClick: () -> Unit,
-    onNotificationClick: () -> Unit,
-    onSettingsClick: () -> Unit,
     onChannelClick: (String) -> Unit = {},
     onNavigateToHistory: () -> Unit = {},
     onOpenShortsFeed: () -> Unit = {},
     modifier: Modifier = Modifier,
     viewModel: HomeViewModel = hiltViewModel(),
-    notificationViewModel: NotificationViewModel = hiltViewModel(),
 ) {
     val context = LocalContext.current
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
-    val unreadNotifications by notificationViewModel.unreadCount.collectAsStateWithLifecycle()
     val preferences =
         remember {
             io.github.aedev.flow.data.local
@@ -176,23 +172,20 @@ fun HomeScreen(
         modifier = modifier.fillMaxSize(),
         contentWindowInsets = WindowInsets(0.dp),
         topBar = {
-            Surface(
-                modifier = Modifier.fillMaxWidth(),
-                color = MaterialTheme.colorScheme.background,
-            ) {
-                Row(
-                    modifier =
-                        Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = 12.dp, vertical = 4.dp),
-                    horizontalArrangement = Arrangement.SpaceBetween,
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.spacedBy(6.dp),
-                    ) {
-                        if (showAppLogoIcon) {
+            FlowTopBar(
+                title = {
+                    Text(
+                        stringResource(R.string.app_name_uppercase),
+                        style =
+                            MaterialTheme.typography.titleLarge.copy(
+                                fontWeight = FontWeight.ExtraBold,
+                                letterSpacing = 1.sp,
+                            ),
+                    )
+                },
+                leading =
+                    if (showAppLogoIcon) {
+                        {
                             FlowHeaderLogoIcon(
                                 isDeepFlowActive = deepFlowActive,
                                 onToggleDeepFlow = {
@@ -203,80 +196,18 @@ fun HomeScreen(
                                 modifier = Modifier.size(32.dp),
                             )
                         }
-                        Text(
-                            stringResource(R.string.app_name_uppercase),
-                            style =
-                                MaterialTheme.typography.titleLarge.copy(
-                                    fontWeight = FontWeight.ExtraBold,
-                                    letterSpacing = 1.sp,
-                                ),
+                    } else {
+                        null
+                    },
+                actions = {
+                    IconButton(onClick = onSearchClick) {
+                        Icon(
+                            Icons.Outlined.Search,
+                            contentDescription = stringResource(R.string.search),
                         )
                     }
-                    Row(
-                        horizontalArrangement = Arrangement.spacedBy(0.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        IconButton(
-                            onClick = onSearchClick,
-                            modifier = Modifier.size(40.dp),
-                        ) {
-                            Icon(
-                                Icons.Outlined.Search,
-                                contentDescription = stringResource(R.string.search),
-                                modifier = Modifier.size(24.dp),
-                            )
-                        }
-                        IconButton(
-                            onClick = onNotificationClick,
-                            modifier = Modifier.size(40.dp),
-                        ) {
-                            Box(contentAlignment = Alignment.TopEnd) {
-                                Icon(
-                                    imageVector = Icons.Outlined.Notifications,
-                                    contentDescription = stringResource(R.string.notifications),
-                                    modifier = Modifier.size(24.dp),
-                                )
-                                if (unreadNotifications > 0) {
-                                    Box(
-                                        modifier =
-                                            Modifier
-                                                .offset(x = 4.dp, y = (-2).dp)
-                                                .background(MaterialTheme.colorScheme.primary, shape = CircleShape)
-                                                .size(16.dp),
-                                        contentAlignment = Alignment.Center,
-                                    ) {
-                                        Text(
-                                            text =
-                                                if (unreadNotifications > 9) {
-                                                    stringResource(R.string.notification_badge_9_plus)
-                                                } else {
-                                                    unreadNotifications.toString()
-                                                },
-                                            color = MaterialTheme.colorScheme.onPrimary,
-                                            style =
-                                                MaterialTheme.typography.labelSmall.copy(
-                                                    fontSize = 9.sp,
-                                                    fontWeight = FontWeight.Bold,
-                                                    lineHeight = 9.sp,
-                                                ),
-                                        )
-                                    }
-                                }
-                            }
-                        }
-                        IconButton(
-                            onClick = onSettingsClick,
-                            modifier = Modifier.size(40.dp),
-                        ) {
-                            Icon(
-                                Icons.Outlined.Settings,
-                                contentDescription = stringResource(R.string.settings),
-                                modifier = Modifier.size(24.dp),
-                            )
-                        }
-                    }
-                }
-            }
+                },
+            )
         },
     ) { padding ->
         ResettableHomePullToRefreshBox(

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/library/DownloadsScreen.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/library/DownloadsScreen.kt
@@ -55,6 +55,7 @@ import io.github.aedev.flow.data.local.entity.DownloadItemStatus
 import io.github.aedev.flow.data.local.entity.DownloadWithItems
 import io.github.aedev.flow.data.music.DownloadedTrack
 import io.github.aedev.flow.data.video.DownloadedVideo
+import io.github.aedev.flow.ui.components.layout.topbar.FlowTopBar
 import io.github.aedev.flow.utils.formatDuration
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -115,30 +116,10 @@ fun DownloadsScreen(
         modifier = modifier.fillMaxSize(),
         contentWindowInsets = WindowInsets(0.dp),
         topBar = {
-            Surface(
-                modifier = Modifier.fillMaxWidth(),
-                color = MaterialTheme.colorScheme.background,
-            ) {
-                Row(
-                    modifier =
-                        Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = 4.dp, vertical = 8.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    IconButton(onClick = onBackClick) {
-                        Icon(
-                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = stringResource(R.string.close),
-                        )
-                    }
-                    Text(
-                        text = stringResource(R.string.downloads_title),
-                        style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                        modifier = Modifier.weight(1f),
-                    )
+            FlowTopBar(
+                title = stringResource(R.string.downloads_title),
+                onBack = onBackClick,
+                actions = {
                     if (uiState.incompleteDownloadCount > 0) {
                         IconButton(onClick = { showRemoveIncompleteDialog = true }) {
                             Icon(
@@ -147,8 +128,8 @@ fun DownloadsScreen(
                             )
                         }
                     }
-                }
-            }
+                },
+            )
         },
         containerColor = MaterialTheme.colorScheme.background,
     ) { padding ->

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/library/LibraryScreen.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/library/LibraryScreen.kt
@@ -32,6 +32,7 @@ import io.github.aedev.flow.R
 import io.github.aedev.flow.data.model.Video
 import io.github.aedev.flow.data.music.DownloadedTrack
 import io.github.aedev.flow.data.video.DownloadedVideo
+import io.github.aedev.flow.ui.components.layout.topbar.FlowTopBar
 import io.github.aedev.flow.ui.screens.music.MusicTrack
 
 @Composable
@@ -64,7 +65,7 @@ fun LibraryScreen(
 
     Scaffold(
         contentWindowInsets = WindowInsets(0.dp),
-        topBar = { LibraryTopBar() },
+        topBar = { FlowTopBar(title = stringResource(R.string.library)) },
     ) { padding ->
         LazyColumn(
             modifier =
@@ -168,28 +169,6 @@ fun LibraryScreen(
                     Spacer(modifier = Modifier.height(8.dp))
                 }
             }
-        }
-    }
-}
-
-@Composable
-private fun LibraryTopBar() {
-    Surface(
-        modifier = Modifier.fillMaxWidth(),
-        color = MaterialTheme.colorScheme.background,
-    ) {
-        Row(
-            modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp, vertical = 8.dp),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            Text(
-                text = stringResource(R.string.library),
-                style = MaterialTheme.typography.titleLarge,
-                fontWeight = FontWeight.Bold,
-            )
         }
     }
 }

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/library/LocalMediaScreen.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/library/LocalMediaScreen.kt
@@ -54,6 +54,7 @@ import coil3.compose.AsyncImage
 import coil3.request.ImageRequest
 import coil3.request.crossfade
 import io.github.aedev.flow.R
+import io.github.aedev.flow.ui.components.layout.topbar.FlowTopBar
 import io.github.aedev.flow.utils.formatDuration
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -99,30 +100,10 @@ fun LocalMediaScreen(
         modifier = modifier.fillMaxSize(),
         contentWindowInsets = WindowInsets(0.dp),
         topBar = {
-            Surface(
-                modifier = Modifier.fillMaxWidth(),
-                color = MaterialTheme.colorScheme.background,
-            ) {
-                Row(
-                    modifier =
-                        Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = 4.dp, vertical = 8.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    IconButton(onClick = onBackClick) {
-                        Icon(
-                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = stringResource(R.string.close),
-                        )
-                    }
-                    Text(
-                        text = stringResource(R.string.local_media_title),
-                        style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                        modifier = Modifier.weight(1f),
-                    )
+            FlowTopBar(
+                title = stringResource(R.string.local_media_title),
+                onBack = onBackClick,
+                actions = {
                     IconButton(
                         onClick = {
                             if (hasAnyPermission()) {
@@ -137,8 +118,8 @@ fun LocalMediaScreen(
                             contentDescription = stringResource(R.string.local_media_rescan),
                         )
                     }
-                }
-            }
+                },
+            )
         },
         containerColor = MaterialTheme.colorScheme.background,
     ) { padding ->

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/library/SavedShortsGridScreen.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/library/SavedShortsGridScreen.kt
@@ -29,6 +29,7 @@ import io.github.aedev.flow.R
 import io.github.aedev.flow.data.local.PlaylistRepository
 import io.github.aedev.flow.data.model.Video
 import io.github.aedev.flow.ui.components.ShortWatchedIndicator
+import io.github.aedev.flow.ui.components.layout.topbar.FlowTopBar
 import kotlinx.coroutines.flow.collectLatest
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -51,29 +52,10 @@ fun SavedShortsGridScreen(
     Scaffold(
         contentWindowInsets = WindowInsets(0.dp),
         topBar = {
-            Surface(
-                modifier = Modifier.fillMaxWidth(),
-                color = MaterialTheme.colorScheme.background,
-            ) {
-                Row(
-                    modifier =
-                        Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = 4.dp, vertical = 8.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    IconButton(onClick = onBackClick) {
-                        Icon(Icons.Default.ArrowBack, contentDescription = stringResource(R.string.ui_back))
-                    }
-                    Text(
-                        text = stringResource(R.string.library_saved_shorts_label),
-                        style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                        modifier = Modifier.weight(1f),
-                    )
-                }
-            }
+            FlowTopBar(
+                title = stringResource(R.string.library_saved_shorts_label),
+                onBack = onBackClick,
+            )
         },
         containerColor = MaterialTheme.colorScheme.background,
     ) { padding ->

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/likedvideos/LikedVideosScreen.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/likedvideos/LikedVideosScreen.kt
@@ -55,6 +55,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import coil3.compose.AsyncImage
 import io.github.aedev.flow.R
 import io.github.aedev.flow.data.local.LikedVideoInfo
+import io.github.aedev.flow.ui.components.layout.topbar.FlowTopBar
 import io.github.aedev.flow.ui.screens.music.MusicTrack
 import io.github.aedev.flow.ui.screens.music.MusicTrackRow
 
@@ -81,32 +82,10 @@ fun LikesScreen(
 
     Scaffold(
         topBar = {
-            Surface(
-                modifier = Modifier.fillMaxWidth(),
-                color = MaterialTheme.colorScheme.background,
-            ) {
-                Row(
-                    modifier =
-                        Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = 4.dp, vertical = 8.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    IconButton(onClick = onBackClick) {
-                        Icon(
-                            imageVector = Icons.Default.ArrowBack,
-                            contentDescription = stringResource(R.string.btn_back),
-                        )
-                    }
-                    Text(
-                        text = stringResource(R.string.likes),
-                        style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
-                        maxLines = 1,
-                        overflow = TextOverflow.Ellipsis,
-                        modifier = Modifier.weight(1f),
-                    )
-                }
-            }
+            FlowTopBar(
+                title = stringResource(R.string.likes),
+                onBack = onBackClick,
+            )
         },
         containerColor = MaterialTheme.colorScheme.background,
     ) { paddingValues ->

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/music/ArtistItemsScreen.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/music/ArtistItemsScreen.kt
@@ -37,6 +37,7 @@ import io.github.aedev.flow.innertube.models.SongItem
 import io.github.aedev.flow.ui.components.MusicCollectionActionItem
 import io.github.aedev.flow.ui.components.MusicCollectionQuickActionsSheet
 import io.github.aedev.flow.ui.components.MusicQuickActionsSheet
+import io.github.aedev.flow.ui.components.layout.topbar.FlowTopBar
 import io.github.aedev.flow.ui.screens.music.components.TrackListItem
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
@@ -128,19 +129,9 @@ fun ArtistItemsScreen(
     Scaffold(
         contentWindowInsets = WindowInsets(0, 0, 0, 0),
         topBar = {
-            TopAppBar(
-                title = { Text(text = artistItemsPage?.title ?: "") },
-                navigationIcon = {
-                    IconButton(onClick = onBackClick) {
-                        Icon(Icons.Default.ArrowBack, contentDescription = stringResource(R.string.btn_back))
-                    }
-                },
-                windowInsets = WindowInsets(0, 0, 0, 0),
-                colors =
-                    TopAppBarDefaults.topAppBarColors(
-                        containerColor = MaterialTheme.colorScheme.background,
-                        scrolledContainerColor = MaterialTheme.colorScheme.background,
-                    ),
+            FlowTopBar(
+                title = artistItemsPage?.title ?: "",
+                onBack = onBackClick,
             )
         },
     ) { padding ->

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/music/EnhancedMusicScreen.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/music/EnhancedMusicScreen.kt
@@ -33,6 +33,7 @@ import io.github.aedev.flow.R
 import io.github.aedev.flow.player.EnhancedMusicPlayerManager
 import io.github.aedev.flow.ui.TabScrollEventBus
 import io.github.aedev.flow.ui.components.*
+import io.github.aedev.flow.ui.components.layout.topbar.FlowTopBar
 import io.github.aedev.flow.ui.screens.music.components.*
 import io.github.aedev.flow.ui.theme.Dimensions
 import kotlinx.coroutines.flow.collectLatest
@@ -48,13 +49,11 @@ private fun List<MusicTrack>.audioMusicOnly(): List<MusicTrack> = filter { it.is
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
 @Composable
 fun EnhancedMusicScreen(
-    onBackClick: () -> Unit,
     onSongClick: (MusicTrack, List<MusicTrack>, String?) -> Unit,
     onVideoClick: (MusicTrack) -> Unit = {},
     onArtistClick: (String) -> Unit = {},
     onSearchClick: () -> Unit = {},
     onRecognizeClick: () -> Unit = {},
-    onSettingsClick: () -> Unit = {},
     onAlbumClick: (String) -> Unit = {},
     onMoodsClick: (io.github.aedev.flow.innertube.pages.MoodAndGenres.Item?) -> Unit = {},
     viewModel: MusicViewModel = hiltViewModel(),
@@ -134,16 +133,8 @@ fun EnhancedMusicScreen(
 
     Scaffold(
         topBar = {
-            TopAppBar(
-                title = {
-                    Text(
-                        text = stringResource(R.string.screen_title_music),
-                        style = MaterialTheme.typography.headlineMedium,
-                        fontWeight = FontWeight.ExtraBold,
-                        color = MaterialTheme.colorScheme.onBackground,
-                        letterSpacing = 2.sp,
-                    )
-                },
+            FlowTopBar(
+                title = stringResource(R.string.screen_title_music),
                 actions = {
                     IconButton(onClick = onRecognizeClick) {
                         Icon(Icons.Outlined.Mic, stringResource(R.string.recognize_music))
@@ -151,15 +142,7 @@ fun EnhancedMusicScreen(
                     IconButton(onClick = onSearchClick) {
                         Icon(Icons.Outlined.Search, stringResource(R.string.search))
                     }
-                    IconButton(onClick = onSettingsClick) {
-                        Icon(Icons.Outlined.Settings, stringResource(R.string.settings))
-                    }
                 },
-                colors =
-                    TopAppBarDefaults.topAppBarColors(
-                        containerColor = MaterialTheme.colorScheme.background,
-                    ),
-                windowInsets = WindowInsets(0, 0, 0, 0),
             )
         },
         containerColor = MaterialTheme.colorScheme.background,

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/music/LibraryScreen.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/music/LibraryScreen.kt
@@ -30,6 +30,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.viewmodel.compose.viewModel
 import coil3.compose.AsyncImage
 import io.github.aedev.flow.R
+import io.github.aedev.flow.ui.components.layout.topbar.FlowTopBar
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -51,23 +52,9 @@ fun LibraryScreen(
     Scaffold(
         contentWindowInsets = WindowInsets(0.dp),
         topBar = {
-            TopAppBar(
-                title = {
-                    Text(
-                        stringResource(R.string.library),
-                        style = MaterialTheme.typography.headlineMedium,
-                        fontWeight = FontWeight.Bold,
-                    )
-                },
-                navigationIcon = {
-                    IconButton(onClick = onBackClick) {
-                        Icon(Icons.Default.ArrowBack, stringResource(R.string.btn_back))
-                    }
-                },
-                colors =
-                    TopAppBarDefaults.topAppBarColors(
-                        containerColor = MaterialTheme.colorScheme.background,
-                    ),
+            FlowTopBar(
+                title = stringResource(R.string.library),
+                onBack = onBackClick,
             )
         },
     ) { padding ->

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/music/MoodsAndGenresScreen.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/music/MoodsAndGenresScreen.kt
@@ -2,8 +2,6 @@ package io.github.aedev.flow.ui.screens.music
 
 import android.content.res.Configuration
 import androidx.compose.foundation.layout.*
-import androidx.compose.ui.res.stringResource
-import io.github.aedev.flow.R
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
@@ -14,80 +12,71 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import io.github.aedev.flow.R
 import io.github.aedev.flow.innertube.pages.MoodAndGenres
 import io.github.aedev.flow.ui.components.MoodAndGenresButton
 import io.github.aedev.flow.ui.components.NavigationTitle
 import io.github.aedev.flow.ui.components.ShimmerHost
 import io.github.aedev.flow.ui.components.ShimmerMoodButton
+import io.github.aedev.flow.ui.components.layout.topbar.FlowTopBar
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun MoodsAndGenresScreen(
     onBackClick: () -> Unit,
     onGenreClick: (MoodAndGenres.Item) -> Unit,
-    viewModel: MoodsAndGenresViewModel = hiltViewModel()
+    viewModel: MoodsAndGenresViewModel = hiltViewModel(),
 ) {
     val moodAndGenresList by viewModel.moodAndGenres.collectAsState()
     val isLoading by viewModel.isLoading.collectAsState()
     val error by viewModel.error.collectAsState()
-    
+
     val localConfiguration = LocalConfiguration.current
     val itemsPerRow = if (localConfiguration.orientation == Configuration.ORIENTATION_LANDSCAPE) 3 else 2
 
     Scaffold(
         topBar = {
-            TopAppBar(
-                title = { 
-                    Text(
-                        text = stringResource(R.string.section_moods_and_genres), 
-                        fontWeight = FontWeight.Bold
-                    ) 
-                },
-                navigationIcon = {
-                    IconButton(onClick = onBackClick) {
-                        Icon(
-                            imageVector = Icons.Filled.ArrowBack, 
-                            contentDescription = stringResource(R.string.btn_back)
-                        )
-                    }
-                },
-                colors = TopAppBarDefaults.topAppBarColors(
-                    containerColor = MaterialTheme.colorScheme.background
-                )
+            FlowTopBar(
+                title = stringResource(R.string.section_moods_and_genres),
+                onBack = onBackClick,
             )
         },
-        containerColor = MaterialTheme.colorScheme.background
+        containerColor = MaterialTheme.colorScheme.background,
     ) { padding ->
         Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(padding)
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .padding(padding),
         ) {
             when {
                 isLoading && moodAndGenresList == null -> {
                     LazyColumn(
                         modifier = Modifier.fillMaxSize(),
-                        contentPadding = PaddingValues(bottom = 80.dp)
+                        contentPadding = PaddingValues(bottom = 80.dp),
                     ) {
                         item(key = "shimmer_loading") {
                             ShimmerHost(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .padding(horizontal = 12.dp)
+                                modifier =
+                                    Modifier
+                                        .fillMaxWidth()
+                                        .padding(horizontal = 12.dp),
                             ) {
                                 repeat(8) {
                                     Row(
-                                        modifier = Modifier
-                                            .fillMaxWidth()
-                                            .padding(vertical = 6.dp),
-                                        horizontalArrangement = Arrangement.spacedBy(12.dp)
+                                        modifier =
+                                            Modifier
+                                                .fillMaxWidth()
+                                                .padding(vertical = 6.dp),
+                                        horizontalArrangement = Arrangement.spacedBy(12.dp),
                                     ) {
                                         repeat(itemsPerRow) {
                                             ShimmerMoodButton(
-                                                modifier = Modifier.weight(1f)
+                                                modifier = Modifier.weight(1f),
                                             )
                                         }
                                     }
@@ -96,19 +85,20 @@ fun MoodsAndGenresScreen(
                         }
                     }
                 }
-                
+
                 error != null && moodAndGenresList == null -> {
                     Column(
-                        modifier = Modifier
-                            .fillMaxSize()
-                            .padding(32.dp),
+                        modifier =
+                            Modifier
+                                .fillMaxSize()
+                                .padding(32.dp),
                         horizontalAlignment = Alignment.CenterHorizontally,
-                        verticalArrangement = Arrangement.Center
+                        verticalArrangement = Arrangement.Center,
                     ) {
                         Text(
                             text = error ?: stringResource(R.string.unknown_error),
                             style = MaterialTheme.typography.bodyLarge,
-                            color = MaterialTheme.colorScheme.error
+                            color = MaterialTheme.colorScheme.error,
                         )
                         Spacer(modifier = Modifier.height(16.dp))
                         Button(onClick = { viewModel.retry() }) {
@@ -116,47 +106,47 @@ fun MoodsAndGenresScreen(
                         }
                     }
                 }
-                
+
                 moodAndGenresList.isNullOrEmpty() -> {
                     Box(
                         modifier = Modifier.fillMaxSize(),
-                        contentAlignment = Alignment.Center
+                        contentAlignment = Alignment.Center,
                     ) {
                         Text(
                             text = stringResource(R.string.empty_moods_genres),
                             style = MaterialTheme.typography.bodyLarge,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
                         )
                     }
                 }
-                
+
                 else -> {
                     LazyColumn(
                         modifier = Modifier.fillMaxSize(),
-                        contentPadding = PaddingValues(bottom = 80.dp)
+                        contentPadding = PaddingValues(bottom = 80.dp),
                     ) {
                         moodAndGenresList?.forEachIndexed { index, moodCategory ->
                             item(key = "category_$index") {
                                 Column(
-                                    modifier = Modifier.padding(horizontal = 6.dp)
+                                    modifier = Modifier.padding(horizontal = 6.dp),
                                 ) {
                                     NavigationTitle(
-                                        title = moodCategory.title
+                                        title = moodCategory.title,
                                     )
-                                    
+
                                     moodCategory.items.chunked(itemsPerRow).forEach { row ->
                                         Row(
                                             modifier = Modifier.padding(horizontal = 6.dp, vertical = 6.dp),
-                                            horizontalArrangement = Arrangement.spacedBy(12.dp)
+                                            horizontalArrangement = Arrangement.spacedBy(12.dp),
                                         ) {
                                             row.forEach { item ->
                                                 MoodAndGenresButton(
                                                     title = item.title,
                                                     onClick = { onGenreClick(item) },
-                                                    modifier = Modifier.weight(1f)
+                                                    modifier = Modifier.weight(1f),
                                                 )
                                             }
-                                            
+
                                             repeat(itemsPerRow - row.size) {
                                                 Spacer(modifier = Modifier.weight(1f))
                                             }

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/music/YouTubeBrowseScreen.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/music/YouTubeBrowseScreen.kt
@@ -14,14 +14,14 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material3.*
-import androidx.compose.ui.res.stringResource
-import io.github.aedev.flow.R
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import io.github.aedev.flow.R
 import io.github.aedev.flow.innertube.models.AlbumItem
 import io.github.aedev.flow.innertube.models.ArtistItem
 import io.github.aedev.flow.innertube.models.PlaylistItem
@@ -29,6 +29,7 @@ import io.github.aedev.flow.innertube.models.SongItem
 import io.github.aedev.flow.innertube.models.YTItem
 import io.github.aedev.flow.player.EnhancedMusicPlayerManager
 import io.github.aedev.flow.ui.components.*
+import io.github.aedev.flow.ui.components.layout.topbar.FlowTopBar
 import io.github.aedev.flow.ui.theme.Dimensions
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
@@ -39,55 +40,41 @@ fun YouTubeBrowseScreen(
     onAlbumClick: (String) -> Unit,
     onArtistClick: (String) -> Unit,
     onPlaylistClick: (String) -> Unit,
-    viewModel: YouTubeBrowseViewModel = hiltViewModel()
+    viewModel: YouTubeBrowseViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsState()
     val currentTrack by EnhancedMusicPlayerManager.currentTrack.collectAsState()
-    
+
     Scaffold(
         topBar = {
-            TopAppBar(
-                title = { 
-                    Text(
-                        text = uiState.title ?: stringResource(R.string.title_browse),
-                        fontWeight = FontWeight.Bold
-                    ) 
-                },
-                navigationIcon = {
-                    IconButton(onClick = onBackClick) {
-                        Icon(
-                            imageVector = Icons.Filled.ArrowBack,
-                            contentDescription = stringResource(R.string.btn_back)
-                        )
-                    }
-                },
-                colors = TopAppBarDefaults.topAppBarColors(
-                    containerColor = MaterialTheme.colorScheme.background
-                )
+            FlowTopBar(
+                title = uiState.title ?: stringResource(R.string.title_browse),
+                onBack = onBackClick,
             )
         },
-        containerColor = MaterialTheme.colorScheme.background
+        containerColor = MaterialTheme.colorScheme.background,
     ) { padding ->
         Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(padding)
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .padding(padding),
         ) {
             when {
                 uiState.isLoading -> {
                     LazyColumn(
                         modifier = Modifier.fillMaxSize(),
-                        contentPadding = PaddingValues(bottom = 80.dp)
+                        contentPadding = PaddingValues(bottom = 80.dp),
                     ) {
                         item {
                             ShimmerHost {
                                 repeat(3) {
                                     ShimmerSectionTitle(
-                                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
+                                        modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
                                     )
                                     LazyRow(
                                         contentPadding = PaddingValues(horizontal = 12.dp),
-                                        horizontalArrangement = Arrangement.spacedBy(12.dp)
+                                        horizontalArrangement = Arrangement.spacedBy(12.dp),
                                     ) {
                                         items(5) {
                                             ShimmerGridItem()
@@ -99,19 +86,20 @@ fun YouTubeBrowseScreen(
                         }
                     }
                 }
-                
+
                 uiState.error != null -> {
                     Column(
-                        modifier = Modifier
-                            .fillMaxSize()
-                            .padding(32.dp),
+                        modifier =
+                            Modifier
+                                .fillMaxSize()
+                                .padding(32.dp),
                         horizontalAlignment = Alignment.CenterHorizontally,
-                        verticalArrangement = Arrangement.Center
+                        verticalArrangement = Arrangement.Center,
                     ) {
                         Text(
                             text = uiState.error ?: stringResource(R.string.unknown_error),
                             style = MaterialTheme.typography.bodyLarge,
-                            color = MaterialTheme.colorScheme.error
+                            color = MaterialTheme.colorScheme.error,
                         )
                         Spacer(modifier = Modifier.height(16.dp))
                         Button(onClick = { viewModel.retry() }) {
@@ -119,24 +107,24 @@ fun YouTubeBrowseScreen(
                         }
                     }
                 }
-                
+
                 uiState.sections.isEmpty() -> {
                     Box(
                         modifier = Modifier.fillMaxSize(),
-                        contentAlignment = Alignment.Center
+                        contentAlignment = Alignment.Center,
                     ) {
                         Text(
                             text = stringResource(R.string.empty_browse_content),
                             style = MaterialTheme.typography.bodyLarge,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
                         )
                     }
                 }
-                
+
                 else -> {
                     LazyColumn(
                         modifier = Modifier.fillMaxSize(),
-                        contentPadding = PaddingValues(bottom = 80.dp)
+                        contentPadding = PaddingValues(bottom = 80.dp),
                     ) {
                         uiState.sections.forEach { section ->
                             if (section.items.isNotEmpty()) {
@@ -144,11 +132,11 @@ fun YouTubeBrowseScreen(
                                     item(key = "title_${title.hashCode()}") {
                                         SectionTitle(
                                             title = title,
-                                            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
+                                            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
                                         )
                                     }
                                 }
-                                
+
                                 if (section.items.all { it is SongItem }) {
                                     item(key = "songs_${section.title?.hashCode() ?: section.hashCode()}") {
                                         val gridState = rememberLazyGridState()
@@ -158,13 +146,14 @@ fun YouTubeBrowseScreen(
                                             contentPadding = PaddingValues(horizontal = 12.dp),
                                             horizontalArrangement = Arrangement.spacedBy(8.dp),
                                             verticalArrangement = Arrangement.spacedBy(4.dp),
-                                            modifier = Modifier
-                                                .height(Dimensions.ListItemHeight * 4 + 12.dp)
-                                                .fillMaxWidth()
+                                            modifier =
+                                                Modifier
+                                                    .height(Dimensions.ListItemHeight * 4 + 12.dp)
+                                                    .fillMaxWidth(),
                                         ) {
                                             items(
                                                 items = section.items,
-                                                key = { it.stableLazyKey("browse_grid_${section.title}") }
+                                                key = { it.stableLazyKey("browse_grid_${section.title}") },
                                             ) { item ->
                                                 val song = item as SongItem
                                                 ListItem(
@@ -173,7 +162,7 @@ fun YouTubeBrowseScreen(
                                                     thumbnailUrl = song.thumbnail,
                                                     isPlaying = currentTrack?.videoId == song.id,
                                                     onClick = { onSongClick(song) },
-                                                    modifier = Modifier.width(300.dp)
+                                                    modifier = Modifier.width(300.dp),
                                                 )
                                             }
                                         }
@@ -182,11 +171,11 @@ fun YouTubeBrowseScreen(
                                     item(key = "items_${section.title?.hashCode() ?: section.hashCode()}") {
                                         LazyRow(
                                             contentPadding = PaddingValues(horizontal = 12.dp),
-                                            horizontalArrangement = Arrangement.spacedBy(12.dp)
+                                            horizontalArrangement = Arrangement.spacedBy(12.dp),
                                         ) {
                                             items(
                                                 items = section.items,
-                                                key = { it.stableLazyKey("browse_row_${section.title}") }
+                                                key = { it.stableLazyKey("browse_row_${section.title}") },
                                             ) { item ->
                                                 when (item) {
                                                     is SongItem -> {
@@ -195,44 +184,48 @@ fun YouTubeBrowseScreen(
                                                             subtitle = item.artists.joinToString(", ") { it.name },
                                                             thumbnailUrl = item.thumbnail,
                                                             thumbnailHeight = currentGridThumbnailHeight(),
-                                                            onClick = { onSongClick(item) }
+                                                            onClick = { onSongClick(item) },
                                                         )
                                                     }
+
                                                     is AlbumItem -> {
                                                         GridItem(
                                                             title = item.title,
                                                             subtitle = item.artists?.joinToString(", ") { it.name } ?: "",
                                                             thumbnailUrl = item.thumbnail,
                                                             thumbnailHeight = currentGridThumbnailHeight(),
-                                                            onClick = { onAlbumClick(item.id) }
+                                                            onClick = { onAlbumClick(item.id) },
                                                         )
                                                     }
+
                                                     is ArtistItem -> {
                                                         Column(
                                                             horizontalAlignment = Alignment.CenterHorizontally,
-                                                            modifier = Modifier
-                                                                .width(100.dp)
-                                                                .clickable { onArtistClick(item.id) }
+                                                            modifier =
+                                                                Modifier
+                                                                    .width(100.dp)
+                                                                    .clickable { onArtistClick(item.id) },
                                                         ) {
                                                             ArtistThumbnail(
                                                                 thumbnailUrl = item.thumbnail,
-                                                                size = 100.dp
+                                                                size = 100.dp,
                                                             )
                                                             Spacer(modifier = Modifier.height(4.dp))
                                                             Text(
                                                                 text = item.title,
                                                                 style = MaterialTheme.typography.bodySmall,
-                                                                maxLines = 1
+                                                                maxLines = 1,
                                                             )
                                                         }
                                                     }
+
                                                     is PlaylistItem -> {
                                                         GridItem(
                                                             title = item.title,
                                                             subtitle = item.author?.name ?: "",
                                                             thumbnailUrl = item.thumbnail,
                                                             thumbnailHeight = currentGridThumbnailHeight(),
-                                                            onClick = { onPlaylistClick(item.id) }
+                                                            onClick = { onPlaylistClick(item.id) },
                                                         )
                                                     }
                                                 }

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/notifications/NotificationScreen.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/notifications/NotificationScreen.kt
@@ -33,6 +33,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import coil3.compose.AsyncImage
 import io.github.aedev.flow.R
 import io.github.aedev.flow.data.local.entity.NotificationEntity
+import io.github.aedev.flow.ui.components.layout.topbar.FlowTopBar
 import java.text.SimpleDateFormat
 import java.util.*
 
@@ -75,40 +76,19 @@ fun NotificationScreen(
                 .fillMaxSize()
                 .background(MaterialTheme.colorScheme.background),
     ) {
-        TopAppBar(
-            title = {
-                Text(
-                    text = stringResource(R.string.notifications),
-                    style = MaterialTheme.typography.titleLarge,
-                    fontWeight = FontWeight.Bold,
-                )
-            },
-            navigationIcon = {
-                IconButton(onClick = onBackClick) {
-                    Icon(
-                        imageVector = Icons.AutoMirrored.Filled.ArrowBack, // AutoMirrored is better for RTL
-                        contentDescription = stringResource(R.string.close),
-                    )
-                }
-            },
+        FlowTopBar(
+            title = stringResource(R.string.notifications),
+            onBack = onBackClick,
             actions = {
                 if (notifications.isNotEmpty()) {
                     IconButton(onClick = { viewModel.clearAll() }) {
                         Icon(
                             imageVector = Icons.Default.DeleteSweep,
                             contentDescription = stringResource(R.string.clear_all_notifications),
-                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
                         )
                     }
                 }
             },
-            // Explicitly set insets to 0 so it doesn't add status bar padding
-            windowInsets = WindowInsets(0.dp),
-            colors =
-                TopAppBarDefaults.topAppBarColors(
-                    containerColor = MaterialTheme.colorScheme.background,
-                    titleContentColor = MaterialTheme.colorScheme.onBackground,
-                ),
         )
 
         if (notifications.isEmpty()) {

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/personality/FlowPersonalityScreen.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/personality/FlowPersonalityScreen.kt
@@ -43,6 +43,7 @@ import io.github.aedev.flow.data.recommendation.FlowNeuroEngine
 import io.github.aedev.flow.data.recommendation.FlowPersona
 import io.github.aedev.flow.data.recommendation.UserBrain
 import io.github.aedev.flow.data.repository.YouTubeRepository
+import io.github.aedev.flow.ui.components.layout.topbar.FlowTopBar
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -52,9 +53,7 @@ import java.util.Locale
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun FlowPersonalityScreen(
-    onNavigateBack: () -> Unit
-) {
+fun FlowPersonalityScreen(onNavigateBack: () -> Unit) {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
 
@@ -74,38 +73,52 @@ fun FlowPersonalityScreen(
         isLoading = false
     }
 
-    val exportLauncher = rememberLauncherForActivityResult(
-        ActivityResultContracts.CreateDocument("application/json")
-    ) { uri: Uri? ->
-        uri ?: return@rememberLauncherForActivityResult
-        scope.launch {
-            val success = context.contentResolver.openOutputStream(uri)?.use { out ->
-                FlowNeuroEngine.exportBrainToStream(out)
-            } ?: false
-            Toast.makeText(
-                context,
-                if (success) context.getString(R.string.profile_export_success) else context.getString(R.string.profile_export_failed),
-                Toast.LENGTH_SHORT
-            ).show()
+    val exportLauncher =
+        rememberLauncherForActivityResult(
+            ActivityResultContracts.CreateDocument("application/json"),
+        ) { uri: Uri? ->
+            uri ?: return@rememberLauncherForActivityResult
+            scope.launch {
+                val success =
+                    context.contentResolver.openOutputStream(uri)?.use { out ->
+                        FlowNeuroEngine.exportBrainToStream(out)
+                    } ?: false
+                Toast
+                    .makeText(
+                        context,
+                        if (success) {
+                            context.getString(R.string.profile_export_success)
+                        } else {
+                            context.getString(R.string.profile_export_failed)
+                        },
+                        Toast.LENGTH_SHORT,
+                    ).show()
+            }
         }
-    }
 
-    val importLauncher = rememberLauncherForActivityResult(
-        ActivityResultContracts.OpenDocument()
-    ) { uri: Uri? ->
-        uri ?: return@rememberLauncherForActivityResult
-        scope.launch {
-            val success = context.contentResolver.openInputStream(uri)?.use { input ->
-                FlowNeuroEngine.importBrainFromStream(context, input)
-            } ?: false
-            if (success) reloadBrain()
-            Toast.makeText(
-                context,
-                if (success) context.getString(R.string.profile_import_success) else context.getString(R.string.profile_import_failed),
-                Toast.LENGTH_SHORT
-            ).show()
+    val importLauncher =
+        rememberLauncherForActivityResult(
+            ActivityResultContracts.OpenDocument(),
+        ) { uri: Uri? ->
+            uri ?: return@rememberLauncherForActivityResult
+            scope.launch {
+                val success =
+                    context.contentResolver.openInputStream(uri)?.use { input ->
+                        FlowNeuroEngine.importBrainFromStream(context, input)
+                    } ?: false
+                if (success) reloadBrain()
+                Toast
+                    .makeText(
+                        context,
+                        if (success) {
+                            context.getString(R.string.profile_import_success)
+                        } else {
+                            context.getString(R.string.profile_import_failed)
+                        },
+                        Toast.LENGTH_SHORT,
+                    ).show()
+            }
         }
-    }
 
     LaunchedEffect(Unit) {
         reloadBrain(initialize = true)
@@ -113,97 +126,85 @@ fun FlowPersonalityScreen(
 
     LaunchedEffect(brain?.channelScores) {
         val snapshot = brain ?: return@LaunchedEffect
-        val idsToFetch = snapshot.channelScores.entries
-            .sortedByDescending { it.value }
-            .take(12)
-            .map { it.key }
-            .filter { it.isNotBlank() && !channelNames.containsKey(it) }
+        val idsToFetch =
+            snapshot.channelScores.entries
+                .sortedByDescending { it.value }
+                .take(12)
+                .map { it.key }
+                .filter { it.isNotBlank() && !channelNames.containsKey(it) }
 
         if (idsToFetch.isEmpty()) return@LaunchedEffect
 
         val repository = YouTubeRepository.getInstance()
-        val fetchedNames = withContext(Dispatchers.IO) {
-            idsToFetch.mapNotNull { channelId ->
-                runCatching {
-                    repository.getChannelInfo(channelId)?.name?.let { channelId to it }
-                }.getOrNull()
+        val fetchedNames =
+            withContext(Dispatchers.IO) {
+                idsToFetch.mapNotNull { channelId ->
+                    runCatching {
+                        repository.getChannelInfo(channelId)?.name?.let { channelId to it }
+                    }.getOrNull()
+                }
             }
-        }
         fetchedNames.forEach { (channelId, name) -> channelNames[channelId] = name }
     }
 
     Scaffold(
         contentWindowInsets = WindowInsets(0.dp),
         topBar = {
-            Surface(
-                modifier = Modifier.fillMaxWidth(),
-                color = MaterialTheme.colorScheme.background
-            ) {
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 4.dp, vertical = 8.dp),
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    IconButton(onClick = onNavigateBack) {
-                        Icon(
-                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = stringResource(R.string.btn_back)
-                        )
-                    }
-                    Text(
-                        text = stringResource(R.string.flow_control_center),
-                        style = MaterialTheme.typography.titleLarge,
-                        modifier = Modifier.weight(1f)
-                    )
+            FlowTopBar(
+                title = stringResource(R.string.flow_control_center),
+                onBack = onNavigateBack,
+                actions = {
                     IconButton(
                         onClick = {
                             isLoading = true
                             scope.launch { reloadBrain() }
-                        }
+                        },
                     ) {
                         Icon(
                             imageVector = Icons.Default.Refresh,
-                            contentDescription = stringResource(R.string.action_refresh)
+                            contentDescription = stringResource(R.string.action_refresh),
                         )
                     }
-                }
-            }
+                },
+            )
         },
-        containerColor = MaterialTheme.colorScheme.background
+        containerColor = MaterialTheme.colorScheme.background,
     ) { padding ->
         val snapshot = brain
         if (isLoading || snapshot == null) {
             Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(padding),
-                contentAlignment = Alignment.Center
+                modifier =
+                    Modifier
+                        .fillMaxSize()
+                        .padding(padding),
+                contentAlignment = Alignment.Center,
             ) {
                 CircularProgressIndicator(
                     modifier = Modifier.size(40.dp),
-                    strokeWidth = 3.dp
+                    strokeWidth = 3.dp,
                 )
             }
             return@Scaffold
         }
 
         LazyColumn(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(padding),
-            contentPadding = PaddingValues(
-                start = 16.dp,
-                top = 12.dp,
-                end = 16.dp,
-                bottom = 28.dp
-            ),
-            verticalArrangement = Arrangement.spacedBy(14.dp)
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .padding(padding),
+            contentPadding =
+                PaddingValues(
+                    start = 16.dp,
+                    top = 12.dp,
+                    end = 16.dp,
+                    bottom = 28.dp,
+                ),
+            verticalArrangement = Arrangement.spacedBy(14.dp),
         ) {
             item(key = "overview") {
                 PersonalityOverviewSection(
                     brain = snapshot,
-                    persona = persona
+                    persona = persona,
                 )
             }
             item(key = "stats") {
@@ -221,13 +222,13 @@ fun FlowPersonalityScreen(
             item(key = "channels") {
                 ChannelMemorySection(
                     brain = snapshot,
-                    channelNames = channelNames
+                    channelNames = channelNames,
                 )
             }
             item(key = "discovery") {
                 DiscoveryStatusSection(
                     brain = snapshot,
-                    queries = discoveryQueries
+                    queries = discoveryQueries,
                 )
             }
             if (snapshot.blockedTopics.isNotEmpty() || snapshot.blockedChannels.isNotEmpty()) {
@@ -246,7 +247,7 @@ fun FlowPersonalityScreen(
                                 FlowNeuroEngine.unblockChannel(context, channelId)
                                 reloadBrain()
                             }
-                        }
+                        },
                     )
                 }
             }
@@ -259,7 +260,7 @@ fun FlowPersonalityScreen(
                     onImport = {
                         importLauncher.launch(arrayOf("application/json", "text/plain"))
                     },
-                    onReset = { showResetDialog = true }
+                    onReset = { showResetDialog = true },
                 )
             }
         }
@@ -274,7 +275,7 @@ fun FlowPersonalityScreen(
                     showResetDialog = false
                     reloadBrain()
                 }
-            }
+            },
         )
     }
 }

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/playlists/PlaylistsScreen.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/playlists/PlaylistsScreen.kt
@@ -42,6 +42,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import io.github.aedev.flow.R
 import io.github.aedev.flow.ui.components.PlaylistCard
+import io.github.aedev.flow.ui.components.layout.topbar.FlowTopBar
 import io.github.aedev.flow.ui.screens.music.MusicPlaylistsViewModel
 
 @Composable
@@ -51,7 +52,7 @@ fun PlaylistsScreen(
     onMusicPlaylistClick: (PlaylistInfo) -> Unit,
     modifier: Modifier = Modifier,
     viewModel: PlaylistsViewModel = hiltViewModel(),
-    musicViewModel: MusicPlaylistsViewModel = hiltViewModel()
+    musicViewModel: MusicPlaylistsViewModel = hiltViewModel(),
 ) {
     val videoState by viewModel.uiState.collectAsStateWithLifecycle()
     val musicState by musicViewModel.uiState.collectAsStateWithLifecycle()
@@ -62,27 +63,31 @@ fun PlaylistsScreen(
     var musicToRename by remember { mutableStateOf<PlaylistInfo?>(null) }
     var musicToDelete by remember { mutableStateOf<PlaylistInfo?>(null) }
 
-    val visibleVideoPlaylists = remember(
-        videoState.playlists,
-        videoState.savedPlaylists,
-        ownershipFilter
-    ) {
-        ownershipFilter.select(videoState.playlists, videoState.savedPlaylists)
-    }
-    val visibleMusicPlaylists = remember(
-        musicState.playlists,
-        musicState.savedPlaylists,
-        ownershipFilter
-    ) {
-        ownershipFilter.select(musicState.playlists, musicState.savedPlaylists)
-    }
-    val ownedMusicPlaylistIds = remember(musicState.playlists) {
-        musicState.playlists.mapTo(HashSet(), PlaylistInfo::id)
-    }
-    val isLoading = when (contentFilter) {
-        PlaylistContentFilter.Videos -> videoState.isLoading
-        PlaylistContentFilter.Music -> musicState.isLoading
-    }
+    val visibleVideoPlaylists =
+        remember(
+            videoState.playlists,
+            videoState.savedPlaylists,
+            ownershipFilter,
+        ) {
+            ownershipFilter.select(videoState.playlists, videoState.savedPlaylists)
+        }
+    val visibleMusicPlaylists =
+        remember(
+            musicState.playlists,
+            musicState.savedPlaylists,
+            ownershipFilter,
+        ) {
+            ownershipFilter.select(musicState.playlists, musicState.savedPlaylists)
+        }
+    val ownedMusicPlaylistIds =
+        remember(musicState.playlists) {
+            musicState.playlists.mapTo(HashSet(), PlaylistInfo::id)
+        }
+    val isLoading =
+        when (contentFilter) {
+            PlaylistContentFilter.Videos -> videoState.isLoading
+            PlaylistContentFilter.Music -> musicState.isLoading
+        }
 
     LaunchedEffect(contentFilter) {
         if (contentFilter == PlaylistContentFilter.Music) {
@@ -93,29 +98,30 @@ fun PlaylistsScreen(
     Scaffold(
         contentWindowInsets = WindowInsets(0.dp),
         topBar = {
-            PlaylistLibraryTopBar(
+            FlowTopBar(
                 title = stringResource(R.string.library_playlists_label),
-                onBackClick = onBackClick
+                onBack = onBackClick,
             )
         },
         floatingActionButton = {
             PlaylistCreationFabMenu(
                 onCreateVideo = { creationTarget = PlaylistCreationTarget.Video },
-                onCreateMusic = { creationTarget = PlaylistCreationTarget.Music }
+                onCreateMusic = { creationTarget = PlaylistCreationTarget.Music },
             )
-        }
+        },
     ) { paddingValues ->
         Column(
-            modifier = modifier
-                .fillMaxSize()
-                .background(MaterialTheme.colorScheme.background)
-                .padding(paddingValues)
+            modifier =
+                modifier
+                    .fillMaxSize()
+                    .background(MaterialTheme.colorScheme.background)
+                    .padding(paddingValues),
         ) {
             PlaylistLibraryFilterRow(
                 selectedContent = contentFilter,
                 onContentSelected = { contentFilter = it },
                 selectedOwnership = ownershipFilter,
-                onOwnershipSelected = { ownershipFilter = it }
+                onOwnershipSelected = { ownershipFilter = it },
             )
 
             Box(modifier = Modifier.fillMaxSize()) {
@@ -125,14 +131,15 @@ fun PlaylistsScreen(
                     LazyVerticalGrid(
                         columns = GridCells.Adaptive(160.dp),
                         modifier = Modifier.fillMaxSize(),
-                        contentPadding = PaddingValues(
-                            start = 16.dp,
-                            top = 8.dp,
-                            end = 16.dp,
-                            bottom = 96.dp
-                        ),
+                        contentPadding =
+                            PaddingValues(
+                                start = 16.dp,
+                                top = 8.dp,
+                                end = 16.dp,
+                                bottom = 96.dp,
+                            ),
                         verticalArrangement = Arrangement.spacedBy(16.dp),
-                        horizontalArrangement = Arrangement.spacedBy(16.dp)
+                        horizontalArrangement = Arrangement.spacedBy(16.dp),
                     ) {
                         when (contentFilter) {
                             PlaylistContentFilter.Videos -> {
@@ -140,7 +147,7 @@ fun PlaylistsScreen(
                                     item(
                                         key = "empty-video-playlists",
                                         span = { GridItemSpan(maxLineSpan) },
-                                        contentType = "empty"
+                                        contentType = "empty",
                                     ) {
                                         EmptyPlaylistLibraryState(isMusic = false)
                                     }
@@ -149,12 +156,12 @@ fun PlaylistsScreen(
                                         items = visibleVideoPlaylists,
                                         key = { "video-${it.id}" },
                                         contentType = { "video-playlist" },
-                                        span = { GridItemSpan(maxLineSpan) }
+                                        span = { GridItemSpan(maxLineSpan) },
                                     ) { playlist ->
                                         PlaylistCard(
                                             playlist = playlist,
                                             onClick = { onVideoPlaylistClick(playlist) },
-                                            onDeleteClick = { videoToDelete = playlist }
+                                            onDeleteClick = { videoToDelete = playlist },
                                         )
                                     }
                                 }
@@ -165,7 +172,7 @@ fun PlaylistsScreen(
                                     item(
                                         key = "empty-music-playlists",
                                         span = { GridItemSpan(maxLineSpan) },
-                                        contentType = "empty"
+                                        contentType = "empty",
                                     ) {
                                         EmptyPlaylistLibraryState(isMusic = true)
                                     }
@@ -173,23 +180,25 @@ fun PlaylistsScreen(
                                     items(
                                         items = visibleMusicPlaylists,
                                         key = { "music-${it.id}" },
-                                        contentType = { "music-playlist" }
+                                        contentType = { "music-playlist" },
                                     ) { playlist ->
                                         val isOwned = playlist.id in ownedMusicPlaylistIds
                                         MusicPlaylistLibraryCard(
                                             playlist = playlist,
                                             onClick = { onMusicPlaylistClick(playlist) },
-                                            onDownload = if (isOwned) {
-                                                { musicViewModel.downloadPlaylist(playlist) }
-                                            } else {
-                                                null
-                                            },
-                                            onRename = if (isOwned) {
-                                                { musicToRename = playlist }
-                                            } else {
-                                                null
-                                            },
-                                            onDelete = { musicToDelete = playlist }
+                                            onDownload =
+                                                if (isOwned) {
+                                                    { musicViewModel.downloadPlaylist(playlist) }
+                                                } else {
+                                                    null
+                                                },
+                                            onRename =
+                                                if (isOwned) {
+                                                    { musicToRename = playlist }
+                                                } else {
+                                                    null
+                                                },
+                                            onDelete = { musicToDelete = playlist },
                                         )
                                     }
                                 }
@@ -209,7 +218,7 @@ fun PlaylistsScreen(
         },
         onCreateMusic = { name, description ->
             musicViewModel.createPlaylist(name, description, isPrivate = true)
-        }
+        },
     )
 
     PlaylistManagementDialogHost(
@@ -230,61 +239,33 @@ fun PlaylistsScreen(
         onConfirmMusicDelete = {
             musicViewModel.deletePlaylist(it.id)
             musicToDelete = null
-        }
+        },
     )
-}
-
-@Composable
-private fun PlaylistLibraryTopBar(
-    title: String,
-    onBackClick: () -> Unit
-) {
-    Surface(
-        modifier = Modifier.fillMaxWidth(),
-        color = MaterialTheme.colorScheme.background
-    ) {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 4.dp, vertical = 8.dp),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            IconButton(onClick = onBackClick) {
-                Icon(Icons.AutoMirrored.Filled.ArrowBack, stringResource(R.string.btn_back))
-            }
-            Text(
-                text = title,
-                style = MaterialTheme.typography.titleLarge,
-                fontWeight = FontWeight.Bold,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-                modifier = Modifier.weight(1f)
-            )
-        }
-    }
 }
 
 @Composable
 private fun EmptyPlaylistLibraryState(isMusic: Boolean) {
     Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(vertical = 48.dp),
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .padding(vertical = 48.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.spacedBy(16.dp)
+        verticalArrangement = Arrangement.spacedBy(16.dp),
     ) {
         Icon(
             imageVector = if (isMusic) Icons.Default.MusicNote else Icons.AutoMirrored.Outlined.PlaylistPlay,
             contentDescription = null,
             tint = MaterialTheme.colorScheme.onSurfaceVariant,
-            modifier = Modifier.padding(12.dp)
+            modifier = Modifier.padding(12.dp),
         )
         Text(
-            text = stringResource(
-                if (isMusic) R.string.empty_music_playlists else R.string.no_playlists_found
-            ),
+            text =
+                stringResource(
+                    if (isMusic) R.string.empty_music_playlists else R.string.no_playlists_found,
+                ),
             style = MaterialTheme.typography.titleMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
     }
 }

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/settings/AboutScreen.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/settings/AboutScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import io.github.aedev.flow.R
+import io.github.aedev.flow.ui.components.layout.topbar.FlowTopBar
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
@@ -127,19 +128,9 @@ fun AboutScreen(
     Scaffold(
         contentWindowInsets = WindowInsets(0.dp),
         topBar = {
-            TopAppBar(
-                title = { Text(stringResource(R.string.about_title)) },
-                navigationIcon = {
-                    IconButton(onClick = onNavigateBack) {
-                        Icon(Icons.Default.ArrowBack, stringResource(R.string.btn_back))
-                    }
-                },
-                colors =
-                    TopAppBarDefaults.topAppBarColors(
-                        containerColor = MaterialTheme.colorScheme.background,
-                        titleContentColor = MaterialTheme.colorScheme.onBackground,
-                    ),
-                windowInsets = WindowInsets(0),
+            FlowTopBar(
+                title = stringResource(R.string.about_title),
+                onBack = onNavigateBack,
             )
         },
         containerColor = MaterialTheme.colorScheme.background,

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/settings/AppIconPickerScreen.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/settings/AppIconPickerScreen.kt
@@ -57,6 +57,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import io.github.aedev.flow.R
 import io.github.aedev.flow.data.local.PlayerPreferences
+import io.github.aedev.flow.ui.components.layout.topbar.FlowTopBar
 import kotlinx.coroutines.launch
 
 private const val ICON_NAMESPACE = "io.github.aedev.flow"
@@ -66,20 +67,27 @@ private data class AppIconOption(
     val nameRes: Int,
     val previewBackground: Color,
     val foregroundRes: Int,
-    val usesThemeColors: Boolean = false
+    val usesThemeColors: Boolean = false,
 )
 
-private val ALL_ICONS = listOf(
-    AppIconOption(".IconFlowRed", R.string.icon_name_flow_red, Color(0xFF0F0F0F), R.drawable.ic_launcher_foreground),
-    AppIconOption(".IconFlowLight", R.string.icon_name_flow_light, Color(0xFFFFFFFF), R.drawable.ic_launcher_foreground),
-    AppIconOption(".IconFlowPlay", R.string.icon_name_flow_play, Color(0xFFFFFFFF), R.drawable.ic_fg_flow_play),
-    AppIconOption(".IconAmoled", R.string.icon_name_amoled, Color(0xFF000000), R.drawable.ic_fg_amoled),
-    AppIconOption(".IconMonochrome", R.string.icon_name_monochrome, Color(0xFFFFFFFF), R.drawable.ic_fg_monochrome),
-    AppIconOption(".IconGhost", R.string.icon_name_ghost, Color(0xFF121212), R.drawable.ic_fg_ghost),
-    AppIconOption(".IconDynamic", R.string.icon_name_dynamic, Color.Unspecified, R.drawable.ic_launcher_dynamic_foreground, usesThemeColors = true),
-    AppIconOption(".IconMaterialSky", R.string.icon_name_material_sky, Color(0xFFD7E3FF), R.drawable.ic_launcher_foreground),
-    AppIconOption(".IconMaterialMint", R.string.icon_name_material_mint, Color(0xFFC7E8D4), R.drawable.ic_launcher_foreground)
-)
+private val ALL_ICONS =
+    listOf(
+        AppIconOption(".IconFlowRed", R.string.icon_name_flow_red, Color(0xFF0F0F0F), R.drawable.ic_launcher_foreground),
+        AppIconOption(".IconFlowLight", R.string.icon_name_flow_light, Color(0xFFFFFFFF), R.drawable.ic_launcher_foreground),
+        AppIconOption(".IconFlowPlay", R.string.icon_name_flow_play, Color(0xFFFFFFFF), R.drawable.ic_fg_flow_play),
+        AppIconOption(".IconAmoled", R.string.icon_name_amoled, Color(0xFF000000), R.drawable.ic_fg_amoled),
+        AppIconOption(".IconMonochrome", R.string.icon_name_monochrome, Color(0xFFFFFFFF), R.drawable.ic_fg_monochrome),
+        AppIconOption(".IconGhost", R.string.icon_name_ghost, Color(0xFF121212), R.drawable.ic_fg_ghost),
+        AppIconOption(
+            ".IconDynamic",
+            R.string.icon_name_dynamic,
+            Color.Unspecified,
+            R.drawable.ic_launcher_dynamic_foreground,
+            usesThemeColors = true,
+        ),
+        AppIconOption(".IconMaterialSky", R.string.icon_name_material_sky, Color(0xFFD7E3FF), R.drawable.ic_launcher_foreground),
+        AppIconOption(".IconMaterialMint", R.string.icon_name_material_mint, Color(0xFFC7E8D4), R.drawable.ic_launcher_foreground),
+    )
 
 private fun getActiveIconSuffix(context: Context): String {
     val pm = context.packageManager
@@ -94,17 +102,21 @@ private fun getActiveIconSuffix(context: Context): String {
     return ALL_ICONS.first().componentSuffix
 }
 
-private fun switchIcon(context: Context, newSuffix: String) {
+private fun switchIcon(
+    context: Context,
+    newSuffix: String,
+) {
     val pm = context.packageManager
     val pkg = context.packageName
 
     for (icon in ALL_ICONS) {
         val cn = ComponentName(pkg, "$ICON_NAMESPACE${icon.componentSuffix}")
-        val want = if (icon.componentSuffix == newSuffix) {
-            PackageManager.COMPONENT_ENABLED_STATE_ENABLED
-        } else {
-            PackageManager.COMPONENT_ENABLED_STATE_DISABLED
-        }
+        val want =
+            if (icon.componentSuffix == newSuffix) {
+                PackageManager.COMPONENT_ENABLED_STATE_ENABLED
+            } else {
+                PackageManager.COMPONENT_ENABLED_STATE_DISABLED
+            }
         pm.setComponentEnabledSetting(cn, want, PackageManager.DONT_KILL_APP)
     }
 }
@@ -123,50 +135,23 @@ fun AppIconPickerScreen(onNavigateBack: () -> Unit) {
     Scaffold(
         contentWindowInsets = WindowInsets(0.dp),
         topBar = {
-            Surface(
-                modifier = Modifier.fillMaxWidth(),
-                color = MaterialTheme.colorScheme.background
-            ) {
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 4.dp, vertical = 8.dp),
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    IconButton(onClick = onNavigateBack) {
-                        Icon(
-                            imageVector = Icons.Default.ArrowBack,
-                            contentDescription = stringResource(R.string.btn_back)
-                        )
-                    }
-                    Column(modifier = Modifier.weight(1f)) {
-                        Text(
-                            text = stringResource(R.string.settings_item_app_icon),
-                            style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis
-                        )
-                        Text(
-                            text = stringResource(R.string.app_icon_picker_subtitle),
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis
-                        )
-                    }
-                }
-            }
+            FlowTopBar(
+                title = stringResource(R.string.settings_item_app_icon),
+                subtitle = stringResource(R.string.app_icon_picker_subtitle),
+                onBack = onNavigateBack,
+            )
         },
-        containerColor = MaterialTheme.colorScheme.background
+        containerColor = MaterialTheme.colorScheme.background,
     ) { paddingValues ->
         LazyVerticalGrid(
             columns = GridCells.Adaptive(minSize = 152.dp),
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(paddingValues),
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .padding(paddingValues),
             contentPadding = PaddingValues(horizontal = 16.dp, vertical = 12.dp),
             horizontalArrangement = Arrangement.spacedBy(12.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp)
+            verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {
             item(span = { GridItemSpan(maxLineSpan) }) {
                 AppIconWarningCard()
@@ -183,13 +168,14 @@ fun AppIconPickerScreen(onNavigateBack: () -> Unit) {
                             coroutineScope.launch {
                                 preferences.setSelectedAppIcon(icon.componentSuffix)
                             }
-                            Toast.makeText(
-                                context,
-                                context.getString(R.string.app_icon_apply_toast),
-                                Toast.LENGTH_SHORT
-                            ).show()
+                            Toast
+                                .makeText(
+                                    context,
+                                    context.getString(R.string.app_icon_apply_toast),
+                                    Toast.LENGTH_SHORT,
+                                ).show()
                         }
-                    }
+                    },
                 )
             }
         }
@@ -201,13 +187,13 @@ private fun AppIconWarningCard() {
     Surface(
         modifier = Modifier.fillMaxWidth(),
         shape = RoundedCornerShape(8.dp),
-        color = MaterialTheme.colorScheme.errorContainer.copy(alpha = 0.55f)
+        color = MaterialTheme.colorScheme.errorContainer.copy(alpha = 0.55f),
     ) {
         Text(
             text = stringResource(R.string.app_icon_picker_warning),
             style = MaterialTheme.typography.bodySmall,
             color = MaterialTheme.colorScheme.onErrorContainer,
-            modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp)
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp),
         )
     }
 }
@@ -216,68 +202,75 @@ private fun AppIconWarningCard() {
 private fun IconOptionCard(
     option: AppIconOption,
     isSelected: Boolean,
-    onClick: () -> Unit
+    onClick: () -> Unit,
 ) {
     val cardShape = RoundedCornerShape(8.dp)
-    val previewBackground = if (option.usesThemeColors) {
-        MaterialTheme.colorScheme.secondaryContainer
-    } else {
-        option.previewBackground
-    }
-    val imageTint = if (option.usesThemeColors) {
-        ColorFilter.tint(MaterialTheme.colorScheme.onSecondaryContainer)
-    } else {
-        null
-    }
-    val borderColor = if (isSelected) {
-        MaterialTheme.colorScheme.primary
-    } else {
-        MaterialTheme.colorScheme.outlineVariant
-    }
+    val previewBackground =
+        if (option.usesThemeColors) {
+            MaterialTheme.colorScheme.secondaryContainer
+        } else {
+            option.previewBackground
+        }
+    val imageTint =
+        if (option.usesThemeColors) {
+            ColorFilter.tint(MaterialTheme.colorScheme.onSecondaryContainer)
+        } else {
+            null
+        }
+    val borderColor =
+        if (isSelected) {
+            MaterialTheme.colorScheme.primary
+        } else {
+            MaterialTheme.colorScheme.outlineVariant
+        }
 
     Card(
-        modifier = Modifier
-            .fillMaxWidth()
-            .aspectRatio(0.92f)
-            .border(
-                width = if (isSelected) 2.dp else 1.dp,
-                color = borderColor,
-                shape = cardShape
-            )
-            .clip(cardShape)
-            .clickable(onClick = onClick),
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .aspectRatio(0.92f)
+                .border(
+                    width = if (isSelected) 2.dp else 1.dp,
+                    color = borderColor,
+                    shape = cardShape,
+                ).clip(cardShape)
+                .clickable(onClick = onClick),
         shape = cardShape,
-        colors = CardDefaults.cardColors(
-            containerColor = if (isSelected) {
-                MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.26f)
-            } else {
-                MaterialTheme.colorScheme.surface
-            }
-        ),
-        elevation = CardDefaults.cardElevation(defaultElevation = 0.dp)
+        colors =
+            CardDefaults.cardColors(
+                containerColor =
+                    if (isSelected) {
+                        MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.26f)
+                    } else {
+                        MaterialTheme.colorScheme.surface
+                    },
+            ),
+        elevation = CardDefaults.cardElevation(defaultElevation = 0.dp),
     ) {
         Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(12.dp)
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .padding(12.dp),
         ) {
             Column(
                 modifier = Modifier.fillMaxSize(),
                 horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.Center
+                verticalArrangement = Arrangement.Center,
             ) {
                 Box(
-                    modifier = Modifier
-                        .size(78.dp)
-                        .clip(RoundedCornerShape(22.dp))
-                        .background(previewBackground),
-                    contentAlignment = Alignment.Center
+                    modifier =
+                        Modifier
+                            .size(78.dp)
+                            .clip(RoundedCornerShape(22.dp))
+                            .background(previewBackground),
+                    contentAlignment = Alignment.Center,
                 ) {
                     Image(
                         painter = painterResource(option.foregroundRes),
                         contentDescription = null,
                         colorFilter = imageTint,
-                        modifier = Modifier.fillMaxSize()
+                        modifier = Modifier.fillMaxSize(),
                     )
                 }
 
@@ -288,24 +281,25 @@ private fun IconOptionCard(
                     style = MaterialTheme.typography.labelLarge.copy(fontWeight = FontWeight.SemiBold),
                     color = MaterialTheme.colorScheme.onSurface,
                     maxLines = 1,
-                    overflow = TextOverflow.Ellipsis
+                    overflow = TextOverflow.Ellipsis,
                 )
             }
 
             if (isSelected) {
                 Box(
-                    modifier = Modifier
-                        .align(Alignment.TopEnd)
-                        .size(24.dp)
-                        .clip(RoundedCornerShape(50))
-                        .background(MaterialTheme.colorScheme.primary),
-                    contentAlignment = Alignment.Center
+                    modifier =
+                        Modifier
+                            .align(Alignment.TopEnd)
+                            .size(24.dp)
+                            .clip(RoundedCornerShape(50))
+                            .background(MaterialTheme.colorScheme.primary),
+                    contentAlignment = Alignment.Center,
                 ) {
                     Icon(
                         imageVector = Icons.Default.Check,
                         contentDescription = null,
                         tint = MaterialTheme.colorScheme.onPrimary,
-                        modifier = Modifier.size(16.dp)
+                        modifier = Modifier.size(16.dp),
                     )
                 }
             }

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/settings/AppearanceScreen.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/settings/AppearanceScreen.kt
@@ -23,11 +23,11 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.GridItemSpan
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
@@ -72,14 +72,16 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
-import io.github.aedev.flow.R
-import io.github.aedev.flow.ui.theme.*
 import androidx.core.graphics.ColorUtils
+import io.github.aedev.flow.R
+import io.github.aedev.flow.ui.components.layout.topbar.FlowTopBar
+import io.github.aedev.flow.ui.theme.*
 import kotlin.math.roundToInt
 
 private data class ThemeInfo(
@@ -92,113 +94,135 @@ private data class ThemeInfo(
     val surfaceColor: Color,
     val onSurfaceColor: Color,
     val accentColor: Color = Color.Unspecified,
-    val surfaceVariantColor: Color = Color.Unspecified
+    val surfaceVariantColor: Color = Color.Unspecified,
 )
 
 private enum class ThemeCategory(
     @StringRes val labelRes: Int,
-    val icon: ImageVector
+    val icon: ImageVector,
 ) {
     LIGHT(R.string.appearance_category_light, Icons.Outlined.LightMode),
     DARK(R.string.appearance_category_dark, Icons.Outlined.DarkMode),
-    CUSTOM(R.string.appearance_category_custom, Icons.Outlined.AutoAwesome)
+    CUSTOM(R.string.appearance_category_custom, Icons.Outlined.AutoAwesome),
 }
 
 private enum class SystemThemeSlot {
-    LIGHT, DARK
+    LIGHT,
+    DARK,
 }
 
 private data class CustomRoleField(
     val role: CustomColorRole,
-    @StringRes val labelRes: Int
+    @StringRes val labelRes: Int,
 )
 
-private val CUSTOM_ROLE_FIELDS = listOf(
-    CustomRoleField(CustomColorRole.PRIMARY, R.string.appearance_role_primary),
-    CustomRoleField(CustomColorRole.ON_PRIMARY, R.string.appearance_role_on_primary),
-    CustomRoleField(CustomColorRole.PRIMARY_CONTAINER, R.string.appearance_role_primary_container),
-    CustomRoleField(CustomColorRole.ON_PRIMARY_CONTAINER, R.string.appearance_role_on_primary_container),
-    CustomRoleField(CustomColorRole.INVERSE_PRIMARY, R.string.appearance_role_inverse_primary),
-    CustomRoleField(CustomColorRole.SECONDARY, R.string.appearance_role_secondary),
-    CustomRoleField(CustomColorRole.ON_SECONDARY, R.string.appearance_role_on_secondary),
-    CustomRoleField(CustomColorRole.SECONDARY_CONTAINER, R.string.appearance_role_secondary_container),
-    CustomRoleField(CustomColorRole.ON_SECONDARY_CONTAINER, R.string.appearance_role_on_secondary_container),
-    CustomRoleField(CustomColorRole.TERTIARY, R.string.appearance_role_tertiary),
-    CustomRoleField(CustomColorRole.ON_TERTIARY, R.string.appearance_role_on_tertiary),
-    CustomRoleField(CustomColorRole.TERTIARY_CONTAINER, R.string.appearance_role_tertiary_container),
-    CustomRoleField(CustomColorRole.ON_TERTIARY_CONTAINER, R.string.appearance_role_on_tertiary_container),
-    CustomRoleField(CustomColorRole.BACKGROUND, R.string.appearance_role_background),
-    CustomRoleField(CustomColorRole.ON_BACKGROUND, R.string.appearance_role_on_background),
-    CustomRoleField(CustomColorRole.SURFACE, R.string.appearance_role_surface),
-    CustomRoleField(CustomColorRole.ON_SURFACE, R.string.appearance_role_on_surface),
-    CustomRoleField(CustomColorRole.SURFACE_VARIANT, R.string.appearance_role_surface_variant),
-    CustomRoleField(CustomColorRole.ON_SURFACE_VARIANT, R.string.appearance_role_on_surface_variant),
-    CustomRoleField(CustomColorRole.SURFACE_TINT, R.string.appearance_role_surface_tint),
-    CustomRoleField(CustomColorRole.INVERSE_SURFACE, R.string.appearance_role_inverse_surface),
-    CustomRoleField(CustomColorRole.INVERSE_ON_SURFACE, R.string.appearance_role_inverse_on_surface),
-    CustomRoleField(CustomColorRole.ERROR, R.string.appearance_role_error),
-    CustomRoleField(CustomColorRole.ON_ERROR, R.string.appearance_role_on_error),
-    CustomRoleField(CustomColorRole.ERROR_CONTAINER, R.string.appearance_role_error_container),
-    CustomRoleField(CustomColorRole.ON_ERROR_CONTAINER, R.string.appearance_role_on_error_container),
-    CustomRoleField(CustomColorRole.OUTLINE, R.string.appearance_role_outline),
-    CustomRoleField(CustomColorRole.OUTLINE_VARIANT, R.string.appearance_role_outline_variant),
-    CustomRoleField(CustomColorRole.SCRIM, R.string.appearance_role_scrim),
-    CustomRoleField(CustomColorRole.SURFACE_BRIGHT, R.string.appearance_role_surface_bright),
-    CustomRoleField(CustomColorRole.SURFACE_DIM, R.string.appearance_role_surface_dim),
-    CustomRoleField(CustomColorRole.SURFACE_CONTAINER_LOWEST, R.string.appearance_role_surface_container_lowest),
-    CustomRoleField(CustomColorRole.SURFACE_CONTAINER_LOW, R.string.appearance_role_surface_container_low),
-    CustomRoleField(CustomColorRole.SURFACE_CONTAINER, R.string.appearance_role_surface_container),
-    CustomRoleField(CustomColorRole.SURFACE_CONTAINER_HIGH, R.string.appearance_role_surface_container_high),
-    CustomRoleField(CustomColorRole.SURFACE_CONTAINER_HIGHEST, R.string.appearance_role_surface_container_highest)
-)
+private val CUSTOM_ROLE_FIELDS =
+    listOf(
+        CustomRoleField(CustomColorRole.PRIMARY, R.string.appearance_role_primary),
+        CustomRoleField(CustomColorRole.ON_PRIMARY, R.string.appearance_role_on_primary),
+        CustomRoleField(CustomColorRole.PRIMARY_CONTAINER, R.string.appearance_role_primary_container),
+        CustomRoleField(CustomColorRole.ON_PRIMARY_CONTAINER, R.string.appearance_role_on_primary_container),
+        CustomRoleField(CustomColorRole.INVERSE_PRIMARY, R.string.appearance_role_inverse_primary),
+        CustomRoleField(CustomColorRole.SECONDARY, R.string.appearance_role_secondary),
+        CustomRoleField(CustomColorRole.ON_SECONDARY, R.string.appearance_role_on_secondary),
+        CustomRoleField(CustomColorRole.SECONDARY_CONTAINER, R.string.appearance_role_secondary_container),
+        CustomRoleField(CustomColorRole.ON_SECONDARY_CONTAINER, R.string.appearance_role_on_secondary_container),
+        CustomRoleField(CustomColorRole.TERTIARY, R.string.appearance_role_tertiary),
+        CustomRoleField(CustomColorRole.ON_TERTIARY, R.string.appearance_role_on_tertiary),
+        CustomRoleField(CustomColorRole.TERTIARY_CONTAINER, R.string.appearance_role_tertiary_container),
+        CustomRoleField(CustomColorRole.ON_TERTIARY_CONTAINER, R.string.appearance_role_on_tertiary_container),
+        CustomRoleField(CustomColorRole.BACKGROUND, R.string.appearance_role_background),
+        CustomRoleField(CustomColorRole.ON_BACKGROUND, R.string.appearance_role_on_background),
+        CustomRoleField(CustomColorRole.SURFACE, R.string.appearance_role_surface),
+        CustomRoleField(CustomColorRole.ON_SURFACE, R.string.appearance_role_on_surface),
+        CustomRoleField(CustomColorRole.SURFACE_VARIANT, R.string.appearance_role_surface_variant),
+        CustomRoleField(CustomColorRole.ON_SURFACE_VARIANT, R.string.appearance_role_on_surface_variant),
+        CustomRoleField(CustomColorRole.SURFACE_TINT, R.string.appearance_role_surface_tint),
+        CustomRoleField(CustomColorRole.INVERSE_SURFACE, R.string.appearance_role_inverse_surface),
+        CustomRoleField(CustomColorRole.INVERSE_ON_SURFACE, R.string.appearance_role_inverse_on_surface),
+        CustomRoleField(CustomColorRole.ERROR, R.string.appearance_role_error),
+        CustomRoleField(CustomColorRole.ON_ERROR, R.string.appearance_role_on_error),
+        CustomRoleField(CustomColorRole.ERROR_CONTAINER, R.string.appearance_role_error_container),
+        CustomRoleField(CustomColorRole.ON_ERROR_CONTAINER, R.string.appearance_role_on_error_container),
+        CustomRoleField(CustomColorRole.OUTLINE, R.string.appearance_role_outline),
+        CustomRoleField(CustomColorRole.OUTLINE_VARIANT, R.string.appearance_role_outline_variant),
+        CustomRoleField(CustomColorRole.SCRIM, R.string.appearance_role_scrim),
+        CustomRoleField(CustomColorRole.SURFACE_BRIGHT, R.string.appearance_role_surface_bright),
+        CustomRoleField(CustomColorRole.SURFACE_DIM, R.string.appearance_role_surface_dim),
+        CustomRoleField(CustomColorRole.SURFACE_CONTAINER_LOWEST, R.string.appearance_role_surface_container_lowest),
+        CustomRoleField(CustomColorRole.SURFACE_CONTAINER_LOW, R.string.appearance_role_surface_container_low),
+        CustomRoleField(CustomColorRole.SURFACE_CONTAINER, R.string.appearance_role_surface_container),
+        CustomRoleField(CustomColorRole.SURFACE_CONTAINER_HIGH, R.string.appearance_role_surface_container_high),
+        CustomRoleField(CustomColorRole.SURFACE_CONTAINER_HIGHEST, R.string.appearance_role_surface_container_highest),
+    )
 
 private fun ThemeInfo.forVariant(variant: ThemeVariant): ThemeInfo {
     if (mode == ThemeMode.CUSTOM) return this
     if (mode == ThemeMode.DARK) {
         return when (variant) {
-            ThemeVariant.LIGHT -> copy(
-                backgroundColor = LightThemeColors.Background,
-                surfaceColor = LightThemeColors.Surface,
-                onSurfaceColor = LightThemeColors.Text,
-                accentColor = LightThemeColors.Secondary,
-                surfaceVariantColor = LightThemeColors.Border
-            )
-            ThemeVariant.DARK -> this
-            ThemeVariant.AMOLED -> copy(
-                backgroundColor = OLEDThemeColors.Background,
-                surfaceColor = OLEDThemeColors.Surface,
-                onSurfaceColor = OLEDThemeColors.Text,
-                accentColor = OLEDThemeColors.Secondary,
-                surfaceVariantColor = OLEDThemeColors.Border
-            )
+            ThemeVariant.LIGHT -> {
+                copy(
+                    backgroundColor = LightThemeColors.Background,
+                    surfaceColor = LightThemeColors.Surface,
+                    onSurfaceColor = LightThemeColors.Text,
+                    accentColor = LightThemeColors.Secondary,
+                    surfaceVariantColor = LightThemeColors.Border,
+                )
+            }
+
+            ThemeVariant.DARK -> {
+                this
+            }
+
+            ThemeVariant.AMOLED -> {
+                copy(
+                    backgroundColor = OLEDThemeColors.Background,
+                    surfaceColor = OLEDThemeColors.Surface,
+                    onSurfaceColor = OLEDThemeColors.Text,
+                    accentColor = OLEDThemeColors.Secondary,
+                    surfaceVariantColor = OLEDThemeColors.Border,
+                )
+            }
         }
     }
-    fun blend(first: Color, second: Color, ratio: Float): Color =
-        Color(ColorUtils.blendARGB(first.toArgb(), second.toArgb(), ratio))
+
+    fun blend(
+        first: Color,
+        second: Color,
+        ratio: Float,
+    ): Color = Color(ColorUtils.blendARGB(first.toArgb(), second.toArgb(), ratio))
 
     return when (variant) {
-        ThemeVariant.LIGHT -> if (category == ThemeCategory.LIGHT) {
-            this
-        } else {
+        ThemeVariant.LIGHT -> {
+            if (category == ThemeCategory.LIGHT) {
+                this
+            } else {
+                copy(
+                    backgroundColor = blend(primaryColor, Color.White, 0.88f),
+                    surfaceColor = blend(primaryColor, Color.White, 0.80f),
+                    onSurfaceColor = blend(primaryColor, Color.Black, 0.82f),
+                    surfaceVariantColor = blend(primaryColor, Color.White, 0.70f),
+                )
+            }
+        }
+
+        ThemeVariant.DARK -> {
             copy(
-                backgroundColor = blend(primaryColor, Color.White, 0.88f),
-                surfaceColor = blend(primaryColor, Color.White, 0.80f),
-                onSurfaceColor = blend(primaryColor, Color.Black, 0.82f),
-                surfaceVariantColor = blend(primaryColor, Color.White, 0.70f)
+                backgroundColor = blend(primaryColor, Color.Black, 0.92f),
+                surfaceColor = blend(primaryColor, Color.Black, 0.86f),
+                onSurfaceColor = blend(primaryColor, Color.White, 0.88f),
+                surfaceVariantColor = blend(primaryColor, Color.Black, 0.76f),
             )
         }
-        ThemeVariant.DARK -> copy(
-            backgroundColor = blend(primaryColor, Color.Black, 0.92f),
-            surfaceColor = blend(primaryColor, Color.Black, 0.86f),
-            onSurfaceColor = blend(primaryColor, Color.White, 0.88f),
-            surfaceVariantColor = blend(primaryColor, Color.Black, 0.76f)
-        )
-        ThemeVariant.AMOLED -> copy(
-            backgroundColor = Color.Black,
-            surfaceColor = Color.Black,
-            onSurfaceColor = Color.White,
-            surfaceVariantColor = blend(primaryColor, Color.Black, 0.88f)
-        )
+
+        ThemeVariant.AMOLED -> {
+            copy(
+                backgroundColor = Color.Black,
+                surfaceColor = Color.Black,
+                onSurfaceColor = Color.White,
+                surfaceVariantColor = blend(primaryColor, Color.Black, 0.88f),
+            )
+        }
     }
 }
 
@@ -216,7 +240,7 @@ fun AppearanceScreen(
     onSystemLightThemeChange: (ThemeMode) -> Unit,
     onSystemDarkThemeChange: (ThemeMode) -> Unit,
     onSystemDarkThemeVariantChange: (ThemeVariant) -> Unit,
-    onNavigateBack: () -> Unit
+    onNavigateBack: () -> Unit,
 ) {
     val haptic = LocalHapticFeedback.current
     val context = LocalContext.current
@@ -229,28 +253,34 @@ fun AppearanceScreen(
     var lastAppliedTheme by remember { mutableStateOf("") }
 
     val activeCustomColors = customThemePalettes.forVariant(themeVariant)
-    val allThemes = remember(activeCustomColors, themeVariant) {
-        buildThemeCatalog(activeCustomColors).map { it.forVariant(themeVariant) }
-    }
-    val systemLightThemes = remember(customThemePalettes.light) {
-        buildThemeCatalog(customThemePalettes.light)
-            .filterNot { it.mode == ThemeMode.SYSTEM }
-            .map { it.forVariant(ThemeVariant.LIGHT) }
-    }
-    val systemDarkThemes = remember(customThemePalettes, systemDarkThemeVariant) {
-        buildThemeCatalog(customThemePalettes.forVariant(systemDarkThemeVariant))
-            .filterNot { it.mode == ThemeMode.SYSTEM }
-            .map { it.forVariant(systemDarkThemeVariant) }
-    }
-    val currentThemeInfo = remember(currentTheme, allThemes) {
-        allThemes.firstOrNull { it.mode == currentTheme } ?: allThemes.first()
-    }
-    val systemLightThemeInfo = remember(systemLightThemeMode, systemLightThemes) {
-        systemLightThemes.firstOrNull { it.mode == systemLightThemeMode } ?: systemLightThemes.first()
-    }
-    val systemDarkThemeInfo = remember(systemDarkThemeMode, systemDarkThemes) {
-        systemDarkThemes.firstOrNull { it.mode == systemDarkThemeMode } ?: systemDarkThemes.first()
-    }
+    val allThemes =
+        remember(activeCustomColors, themeVariant) {
+            buildThemeCatalog(activeCustomColors).map { it.forVariant(themeVariant) }
+        }
+    val systemLightThemes =
+        remember(customThemePalettes.light) {
+            buildThemeCatalog(customThemePalettes.light)
+                .filterNot { it.mode == ThemeMode.SYSTEM }
+                .map { it.forVariant(ThemeVariant.LIGHT) }
+        }
+    val systemDarkThemes =
+        remember(customThemePalettes, systemDarkThemeVariant) {
+            buildThemeCatalog(customThemePalettes.forVariant(systemDarkThemeVariant))
+                .filterNot { it.mode == ThemeMode.SYSTEM }
+                .map { it.forVariant(systemDarkThemeVariant) }
+        }
+    val currentThemeInfo =
+        remember(currentTheme, allThemes) {
+            allThemes.firstOrNull { it.mode == currentTheme } ?: allThemes.first()
+        }
+    val systemLightThemeInfo =
+        remember(systemLightThemeMode, systemLightThemes) {
+            systemLightThemes.firstOrNull { it.mode == systemLightThemeMode } ?: systemLightThemes.first()
+        }
+    val systemDarkThemeInfo =
+        remember(systemDarkThemeMode, systemDarkThemes) {
+            systemDarkThemes.firstOrNull { it.mode == systemDarkThemeMode } ?: systemDarkThemes.first()
+        }
 
     val snackbarHostState = remember { SnackbarHostState() }
 
@@ -258,7 +288,7 @@ fun AppearanceScreen(
         if (showAppliedSnackbar) {
             snackbarHostState.showSnackbar(
                 message = context.getString(R.string.appearance_applied_toast, lastAppliedTheme),
-                duration = SnackbarDuration.Short
+                duration = SnackbarDuration.Short,
             )
             showAppliedSnackbar = false
         }
@@ -278,24 +308,26 @@ fun AppearanceScreen(
                 lastAppliedTheme = context.getString(R.string.theme_name_custom)
                 showAppliedSnackbar = true
                 showCustomizer = false
-            }
+            },
         )
     }
 
     val activeSystemThemeSlot = systemThemeSlot
     if (activeSystemThemeSlot != null) {
         SystemThemePickerDialog(
-            titleRes = if (activeSystemThemeSlot == SystemThemeSlot.LIGHT) {
-                R.string.appearance_system_light_theme
-            } else {
-                R.string.appearance_system_dark_theme
-            },
+            titleRes =
+                if (activeSystemThemeSlot == SystemThemeSlot.LIGHT) {
+                    R.string.appearance_system_light_theme
+                } else {
+                    R.string.appearance_system_dark_theme
+                },
             themes = if (activeSystemThemeSlot == SystemThemeSlot.LIGHT) systemLightThemes else systemDarkThemes,
-            selectedMode = if (activeSystemThemeSlot == SystemThemeSlot.LIGHT) {
-                systemLightThemeInfo.mode
-            } else {
-                systemDarkThemeInfo.mode
-            },
+            selectedMode =
+                if (activeSystemThemeSlot == SystemThemeSlot.LIGHT) {
+                    systemLightThemeInfo.mode
+                } else {
+                    systemDarkThemeInfo.mode
+                },
             onDismiss = { systemThemeSlot = null },
             onSelect = { mode ->
                 if (activeSystemThemeSlot == SystemThemeSlot.LIGHT) {
@@ -304,44 +336,18 @@ fun AppearanceScreen(
                     onSystemDarkThemeChange(mode)
                 }
                 systemThemeSlot = null
-            }
+            },
         )
     }
 
     Scaffold(
         contentWindowInsets = WindowInsets(0.dp),
         topBar = {
-            Surface(
-                modifier = Modifier.fillMaxWidth(),
-                color = MaterialTheme.colorScheme.background
-            ) {
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 4.dp, vertical = 8.dp),
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    IconButton(onClick = onNavigateBack) {
-                        Icon(
-                            Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = androidx.compose.ui.res.stringResource(R.string.appearance_navigate_back)
-                        )
-                    }
-                    Column(modifier = Modifier.weight(1f)) {
-                        Text(
-                            text = androidx.compose.ui.res.stringResource(R.string.appearance_title),
-                            style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis
-                        )
-                        Text(
-                            text = androidx.compose.ui.res.stringResource(R.string.appearance_subtitle),
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis
-                        )
-                    }
+            FlowTopBar(
+                title = stringResource(R.string.appearance_title),
+                subtitle = stringResource(R.string.appearance_subtitle),
+                onBack = onNavigateBack,
+                actions = {
                     IconButton(onClick = {
                         customizerVariant = themeVariant
                         applyCustomAsCurrent = true
@@ -349,39 +355,47 @@ fun AppearanceScreen(
                     }) {
                         Icon(
                             Icons.Outlined.Palette,
-                            contentDescription = androidx.compose.ui.res.stringResource(R.string.appearance_customize_theme)
+                            contentDescription = stringResource(R.string.appearance_customize_theme),
                         )
                     }
-                }
-            }
+                },
+            )
         },
         snackbarHost = { SnackbarHost(snackbarHostState) },
-        containerColor = MaterialTheme.colorScheme.background
+        containerColor = MaterialTheme.colorScheme.background,
     ) { padding ->
         LazyVerticalGrid(
             columns = GridCells.Adaptive(minSize = 176.dp),
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(padding),
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .padding(padding),
             contentPadding = PaddingValues(horizontal = 16.dp, vertical = 12.dp),
             horizontalArrangement = Arrangement.spacedBy(14.dp),
-            verticalArrangement = Arrangement.spacedBy(14.dp)
+            verticalArrangement = Arrangement.spacedBy(14.dp),
         ) {
             item(span = { GridItemSpan(maxLineSpan) }) {
                 ThemeVariantSelector(
                     selected = themeVariant,
-                    onSelect = onThemeVariantChange
+                    onSelect = onThemeVariantChange,
                 )
             }
 
             item(span = { GridItemSpan(maxLineSpan) }) {
                 CurrentThemeHero(
                     themeInfo = currentThemeInfo,
-                    onCustomize = if (currentThemeInfo.mode == ThemeMode.CUSTOM) ({
-                        customizerVariant = themeVariant
-                        applyCustomAsCurrent = true
-                        showCustomizer = true
-                    }) else null
+                    onCustomize =
+                        if (currentThemeInfo.mode == ThemeMode.CUSTOM) {
+                            (
+                                {
+                                    customizerVariant = themeVariant
+                                    applyCustomAsCurrent = true
+                                    showCustomizer = true
+                                }
+                            )
+                        } else {
+                            null
+                        },
                 )
             }
 
@@ -402,7 +416,7 @@ fun AppearanceScreen(
                         customizerVariant = systemDarkThemeVariant
                         applyCustomAsCurrent = false
                         showCustomizer = true
-                    }
+                    },
                 )
             }
 
@@ -413,13 +427,13 @@ fun AppearanceScreen(
                     style = MaterialTheme.typography.labelLarge,
                     color = MaterialTheme.colorScheme.primary,
                     fontWeight = FontWeight.Medium,
-                    modifier = Modifier.padding(top = 4.dp)
+                    modifier = Modifier.padding(top = 4.dp),
                 )
             }
 
             items(
                 items = allThemes,
-                key = { it.mode.name }
+                key = { it.mode.name },
             ) { themeInfo ->
                 ThemeCard(
                     themeInfo = themeInfo,
@@ -430,11 +444,18 @@ fun AppearanceScreen(
                         lastAppliedTheme = context.getString(themeInfo.displayNameRes)
                         showAppliedSnackbar = true
                     },
-                    onCustomize = if (themeInfo.mode == ThemeMode.CUSTOM) ({
-                        customizerVariant = themeVariant
-                        applyCustomAsCurrent = true
-                        showCustomizer = true
-                    }) else null
+                    onCustomize =
+                        if (themeInfo.mode == ThemeMode.CUSTOM) {
+                            (
+                                {
+                                    customizerVariant = themeVariant
+                                    applyCustomAsCurrent = true
+                                    showCustomizer = true
+                                }
+                            )
+                        } else {
+                            null
+                        },
                 )
             }
 
@@ -448,13 +469,15 @@ fun AppearanceScreen(
 @Composable
 private fun ThemeVariantSelector(
     selected: ThemeVariant,
-    onSelect: (ThemeVariant) -> Unit
+    onSelect: (ThemeVariant) -> Unit,
 ) {
     Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
         Text(
-            text = androidx.compose.ui.res.stringResource(R.string.appearance_variant_title),
+            text =
+                androidx.compose.ui.res
+                    .stringResource(R.string.appearance_variant_title),
             style = MaterialTheme.typography.titleMedium,
-            color = MaterialTheme.colorScheme.onSurface
+            color = MaterialTheme.colorScheme.onSurface,
         )
         SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
             ThemeVariant.entries.forEachIndexed { index, variant ->
@@ -464,15 +487,16 @@ private fun ThemeVariantSelector(
                     shape = SegmentedButtonDefaults.itemShape(index, ThemeVariant.entries.size),
                     label = {
                         Text(
-                            text = androidx.compose.ui.res.stringResource(
-                                when (variant) {
-                                    ThemeVariant.LIGHT -> R.string.appearance_variant_light
-                                    ThemeVariant.DARK -> R.string.appearance_variant_dark
-                                    ThemeVariant.AMOLED -> R.string.appearance_variant_amoled
-                                }
-                            )
+                            text =
+                                androidx.compose.ui.res.stringResource(
+                                    when (variant) {
+                                        ThemeVariant.LIGHT -> R.string.appearance_variant_light
+                                        ThemeVariant.DARK -> R.string.appearance_variant_dark
+                                        ThemeVariant.AMOLED -> R.string.appearance_variant_amoled
+                                    },
+                                ),
                         )
-                    }
+                    },
                 )
             }
         }
@@ -482,34 +506,37 @@ private fun ThemeVariantSelector(
 @Composable
 private fun CurrentThemeHero(
     themeInfo: ThemeInfo,
-    onCustomize: (() -> Unit)?
+    onCustomize: (() -> Unit)?,
 ) {
     Card(
         modifier = Modifier.fillMaxWidth(),
         shape = MaterialTheme.shapes.extraLarge,
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
-        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant)
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),
     ) {
         Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(18.dp)
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(18.dp),
         ) {
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.SpaceBetween
+                horizontalArrangement = Arrangement.SpaceBetween,
             ) {
                 Surface(
                     color = themeInfo.primaryColor.copy(alpha = 0.16f),
-                    shape = MaterialTheme.shapes.small
+                    shape = MaterialTheme.shapes.small,
                 ) {
                     Text(
-                        text = androidx.compose.ui.res.stringResource(R.string.appearance_current_theme),
+                        text =
+                            androidx.compose.ui.res
+                                .stringResource(R.string.appearance_current_theme),
                         style = MaterialTheme.typography.labelSmall,
                         fontWeight = FontWeight.Bold,
                         color = themeInfo.primaryColor,
-                        modifier = Modifier.padding(horizontal = 10.dp, vertical = 5.dp)
+                        modifier = Modifier.padding(horizontal = 10.dp, vertical = 5.dp),
                     )
                 }
 
@@ -517,7 +544,11 @@ private fun CurrentThemeHero(
                     TextButton(onClick = onCustomize) {
                         Icon(Icons.Default.Edit, contentDescription = null, modifier = Modifier.size(16.dp))
                         Spacer(modifier = Modifier.width(4.dp))
-                        Text(text = androidx.compose.ui.res.stringResource(R.string.appearance_customize_theme))
+                        Text(
+                            text =
+                                androidx.compose.ui.res
+                                    .stringResource(R.string.appearance_customize_theme),
+                        )
                     }
                 }
             }
@@ -525,15 +556,19 @@ private fun CurrentThemeHero(
             Spacer(modifier = Modifier.height(12.dp))
 
             Text(
-                text = androidx.compose.ui.res.stringResource(themeInfo.displayNameRes),
+                text =
+                    androidx.compose.ui.res
+                        .stringResource(themeInfo.displayNameRes),
                 style = MaterialTheme.typography.headlineSmall,
                 fontWeight = FontWeight.Bold,
-                color = MaterialTheme.colorScheme.onSurface
+                color = MaterialTheme.colorScheme.onSurface,
             )
             Text(
-                text = androidx.compose.ui.res.stringResource(themeInfo.subtitleRes),
+                text =
+                    androidx.compose.ui.res
+                        .stringResource(themeInfo.subtitleRes),
                 style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
 
             Spacer(modifier = Modifier.height(14.dp))
@@ -563,29 +598,34 @@ private fun SystemDefaultThemesCard(
     onDarkClick: () -> Unit,
     onDarkVariantChange: (ThemeVariant) -> Unit,
     onCustomizeLight: () -> Unit,
-    onCustomizeDark: () -> Unit
+    onCustomizeDark: () -> Unit,
 ) {
     Card(
         modifier = Modifier.fillMaxWidth(),
         shape = MaterialTheme.shapes.extraLarge,
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
-        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant)
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),
     ) {
         Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(16.dp)
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(16.dp),
         ) {
             Text(
-                text = androidx.compose.ui.res.stringResource(R.string.appearance_system_defaults_title),
+                text =
+                    androidx.compose.ui.res
+                        .stringResource(R.string.appearance_system_defaults_title),
                 style = MaterialTheme.typography.titleMedium,
                 fontWeight = FontWeight.Bold,
-                color = MaterialTheme.colorScheme.onSurface
+                color = MaterialTheme.colorScheme.onSurface,
             )
             Text(
-                text = androidx.compose.ui.res.stringResource(R.string.appearance_system_defaults_subtitle),
+                text =
+                    androidx.compose.ui.res
+                        .stringResource(R.string.appearance_system_defaults_subtitle),
                 style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
 
             Spacer(modifier = Modifier.height(12.dp))
@@ -595,7 +635,7 @@ private fun SystemDefaultThemesCard(
                 labelRes = R.string.appearance_system_light_theme,
                 themeInfo = lightThemeInfo,
                 onClick = onLightClick,
-                onCustomize = onCustomizeLight
+                onCustomize = onCustomizeLight,
             )
             Spacer(modifier = Modifier.height(8.dp))
             SystemThemeChoiceRow(
@@ -603,19 +643,22 @@ private fun SystemDefaultThemesCard(
                 labelRes = R.string.appearance_system_dark_theme,
                 themeInfo = darkThemeInfo,
                 onClick = onDarkClick,
-                onCustomize = onCustomizeDark
+                onCustomize = onCustomizeDark,
             )
 
             Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(top = 12.dp),
-                verticalAlignment = Alignment.CenterVertically
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(top = 12.dp),
+                verticalAlignment = Alignment.CenterVertically,
             ) {
                 Text(
-                    text = androidx.compose.ui.res.stringResource(R.string.appearance_system_dark_surface),
+                    text =
+                        androidx.compose.ui.res
+                            .stringResource(R.string.appearance_system_dark_surface),
                     style = MaterialTheme.typography.bodyMedium,
-                    modifier = Modifier.weight(1f)
+                    modifier = Modifier.weight(1f),
                 )
                 SingleChoiceSegmentedButtonRow {
                     listOf(ThemeVariant.DARK, ThemeVariant.AMOLED).forEachIndexed { index, variant ->
@@ -626,11 +669,14 @@ private fun SystemDefaultThemesCard(
                             label = {
                                 Text(
                                     androidx.compose.ui.res.stringResource(
-                                        if (variant == ThemeVariant.DARK) R.string.appearance_variant_dark
-                                        else R.string.appearance_variant_amoled
-                                    )
+                                        if (variant == ThemeVariant.DARK) {
+                                            R.string.appearance_variant_dark
+                                        } else {
+                                            R.string.appearance_variant_amoled
+                                        },
+                                    ),
                                 )
-                            }
+                            },
                         )
                     }
                 }
@@ -645,37 +691,42 @@ private fun SystemThemeChoiceRow(
     @StringRes labelRes: Int,
     themeInfo: ThemeInfo,
     onClick: () -> Unit,
-    onCustomize: () -> Unit
+    onCustomize: () -> Unit,
 ) {
     Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .clip(MaterialTheme.shapes.large)
-            .clickable(onClick = onClick)
-            .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.28f))
-            .padding(horizontal = 12.dp, vertical = 10.dp),
-        verticalAlignment = Alignment.CenterVertically
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .clip(MaterialTheme.shapes.large)
+                .clickable(onClick = onClick)
+                .background(MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.28f))
+                .padding(horizontal = 12.dp, vertical = 10.dp),
+        verticalAlignment = Alignment.CenterVertically,
     ) {
         Icon(
             imageVector = icon,
             contentDescription = null,
             tint = MaterialTheme.colorScheme.primary,
-            modifier = Modifier.size(22.dp)
+            modifier = Modifier.size(22.dp),
         )
         Spacer(modifier = Modifier.width(12.dp))
         Column(modifier = Modifier.weight(1f)) {
             Text(
-                text = androidx.compose.ui.res.stringResource(labelRes),
+                text =
+                    androidx.compose.ui.res
+                        .stringResource(labelRes),
                 style = MaterialTheme.typography.labelMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
             Text(
-                text = androidx.compose.ui.res.stringResource(themeInfo.displayNameRes),
+                text =
+                    androidx.compose.ui.res
+                        .stringResource(themeInfo.displayNameRes),
                 style = MaterialTheme.typography.bodyLarge,
                 fontWeight = FontWeight.SemiBold,
                 color = MaterialTheme.colorScheme.onSurface,
                 maxLines = 1,
-                overflow = TextOverflow.Ellipsis
+                overflow = TextOverflow.Ellipsis,
             )
         }
         ColorDot(themeInfo.primaryColor)
@@ -684,7 +735,9 @@ private fun SystemThemeChoiceRow(
         IconButton(onClick = onCustomize) {
             Icon(
                 imageVector = Icons.Default.Edit,
-                contentDescription = androidx.compose.ui.res.stringResource(R.string.appearance_customize_theme)
+                contentDescription =
+                    androidx.compose.ui.res
+                        .stringResource(R.string.appearance_customize_theme),
             )
         }
     }
@@ -696,51 +749,59 @@ private fun SystemThemePickerDialog(
     themes: List<ThemeInfo>,
     selectedMode: ThemeMode,
     onDismiss: () -> Unit,
-    onSelect: (ThemeMode) -> Unit
+    onSelect: (ThemeMode) -> Unit,
 ) {
     Dialog(onDismissRequest = onDismiss) {
         Surface(
             shape = MaterialTheme.shapes.extraLarge,
             tonalElevation = 6.dp,
-            modifier = Modifier.fillMaxWidth()
+            modifier = Modifier.fillMaxWidth(),
         ) {
             Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(16.dp)
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(16.dp),
             ) {
                 Text(
-                    text = androidx.compose.ui.res.stringResource(titleRes),
+                    text =
+                        androidx.compose.ui.res
+                            .stringResource(titleRes),
                     style = MaterialTheme.typography.titleLarge,
                     fontWeight = FontWeight.Bold,
-                    color = MaterialTheme.colorScheme.onSurface
+                    color = MaterialTheme.colorScheme.onSurface,
                 )
                 Spacer(modifier = Modifier.height(12.dp))
 
                 LazyColumn(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .heightIn(max = 420.dp),
-                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .heightIn(max = 420.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp),
                 ) {
                     items(
                         items = themes,
-                        key = { it.mode.name }
+                        key = { it.mode.name },
                     ) { themeInfo ->
                         ThemePickerRow(
                             themeInfo = themeInfo,
                             isSelected = themeInfo.mode == selectedMode,
-                            onClick = { onSelect(themeInfo.mode) }
+                            onClick = { onSelect(themeInfo.mode) },
                         )
                     }
                 }
 
                 Row(
                     modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.End
+                    horizontalArrangement = Arrangement.End,
                 ) {
                     TextButton(onClick = onDismiss) {
-                        Text(text = androidx.compose.ui.res.stringResource(android.R.string.cancel))
+                        Text(
+                            text =
+                                androidx.compose.ui.res
+                                    .stringResource(android.R.string.cancel),
+                        )
                     }
                 }
             }
@@ -752,24 +813,26 @@ private fun SystemThemePickerDialog(
 private fun ThemePickerRow(
     themeInfo: ThemeInfo,
     isSelected: Boolean,
-    onClick: () -> Unit
+    onClick: () -> Unit,
 ) {
     Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .clip(MaterialTheme.shapes.large)
-            .clickable(onClick = onClick)
-            .background(
-                if (isSelected) themeInfo.primaryColor.copy(alpha = 0.22f)
-                else MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.26f)
-            )
-            .border(
-                width = if (isSelected) 2.dp else 1.dp,
-                color = MaterialTheme.colorScheme.outlineVariant,
-                shape = MaterialTheme.shapes.large
-            )
-            .padding(12.dp),
-        verticalAlignment = Alignment.CenterVertically
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .clip(MaterialTheme.shapes.large)
+                .clickable(onClick = onClick)
+                .background(
+                    if (isSelected) {
+                        themeInfo.primaryColor.copy(alpha = 0.22f)
+                    } else {
+                        MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.26f)
+                    },
+                ).border(
+                    width = if (isSelected) 2.dp else 1.dp,
+                    color = MaterialTheme.colorScheme.outlineVariant,
+                    shape = MaterialTheme.shapes.large,
+                ).padding(12.dp),
+        verticalAlignment = Alignment.CenterVertically,
     ) {
         ColorDot(themeInfo.primaryColor)
         Spacer(modifier = Modifier.width(8.dp))
@@ -777,27 +840,33 @@ private fun ThemePickerRow(
         Spacer(modifier = Modifier.width(12.dp))
         Column(modifier = Modifier.weight(1f)) {
             Text(
-                text = androidx.compose.ui.res.stringResource(themeInfo.displayNameRes),
+                text =
+                    androidx.compose.ui.res
+                        .stringResource(themeInfo.displayNameRes),
                 style = MaterialTheme.typography.bodyLarge,
                 fontWeight = FontWeight.SemiBold,
                 color = MaterialTheme.colorScheme.onSurface,
                 maxLines = 1,
-                overflow = TextOverflow.Ellipsis
+                overflow = TextOverflow.Ellipsis,
             )
             Text(
-                text = androidx.compose.ui.res.stringResource(themeInfo.subtitleRes),
+                text =
+                    androidx.compose.ui.res
+                        .stringResource(themeInfo.subtitleRes),
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 maxLines = 1,
-                overflow = TextOverflow.Ellipsis
+                overflow = TextOverflow.Ellipsis,
             )
         }
         if (isSelected) {
             Icon(
                 imageVector = Icons.Default.Check,
-                contentDescription = androidx.compose.ui.res.stringResource(R.string.appearance_selected),
+                contentDescription =
+                    androidx.compose.ui.res
+                        .stringResource(R.string.appearance_selected),
                 tint = themeInfo.primaryColor,
-                modifier = Modifier.size(20.dp)
+                modifier = Modifier.size(20.dp),
             )
         }
     }
@@ -805,53 +874,59 @@ private fun ThemePickerRow(
 
 @Composable
 private fun MiniThemePreview(themeInfo: ThemeInfo) {
-    val surfaceVariant = if (themeInfo.surfaceVariantColor != Color.Unspecified) {
-        themeInfo.surfaceVariantColor
-    } else {
-        themeInfo.surfaceColor.copy(alpha = 0.9f)
-    }
+    val surfaceVariant =
+        if (themeInfo.surfaceVariantColor != Color.Unspecified) {
+            themeInfo.surfaceVariantColor
+        } else {
+            themeInfo.surfaceColor.copy(alpha = 0.9f)
+        }
 
     Box(
-        modifier = Modifier
-            .fillMaxWidth()
-            .height(84.dp)
-            .clip(MaterialTheme.shapes.large)
-            .background(themeInfo.backgroundColor)
-            .border(1.dp, themeInfo.onSurfaceColor.copy(alpha = 0.16f), MaterialTheme.shapes.large)
-            .padding(10.dp)
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .height(84.dp)
+                .clip(MaterialTheme.shapes.large)
+                .background(themeInfo.backgroundColor)
+                .border(1.dp, themeInfo.onSurfaceColor.copy(alpha = 0.16f), MaterialTheme.shapes.large)
+                .padding(10.dp),
     ) {
         Column(modifier = Modifier.fillMaxSize()) {
             Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(11.dp)
-                    .clip(MaterialTheme.shapes.small)
-                    .background(themeInfo.surfaceColor)
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .height(11.dp)
+                        .clip(MaterialTheme.shapes.small)
+                        .background(themeInfo.surfaceColor),
             )
             Spacer(modifier = Modifier.height(8.dp))
             Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(22.dp)
-                    .clip(MaterialTheme.shapes.small)
-                    .background(surfaceVariant)
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .height(22.dp)
+                        .clip(MaterialTheme.shapes.small)
+                        .background(surfaceVariant),
             )
             Spacer(modifier = Modifier.height(6.dp))
             Box(
-                modifier = Modifier
-                    .fillMaxWidth(0.65f)
-                    .height(7.dp)
-                    .clip(MaterialTheme.shapes.extraSmall)
-                    .background(themeInfo.onSurfaceColor.copy(alpha = 0.24f))
+                modifier =
+                    Modifier
+                        .fillMaxWidth(0.65f)
+                        .height(7.dp)
+                        .clip(MaterialTheme.shapes.extraSmall)
+                        .background(themeInfo.onSurfaceColor.copy(alpha = 0.24f)),
             )
         }
 
         Box(
-            modifier = Modifier
-                .align(Alignment.BottomEnd)
-                .size(14.dp)
-                .clip(CircleShape)
-                .background(themeInfo.primaryColor)
+            modifier =
+                Modifier
+                    .align(Alignment.BottomEnd)
+                    .size(14.dp)
+                    .clip(CircleShape)
+                    .background(themeInfo.primaryColor),
         )
     }
 }
@@ -859,11 +934,12 @@ private fun MiniThemePreview(themeInfo: ThemeInfo) {
 @Composable
 private fun ColorDot(color: Color) {
     Box(
-        modifier = Modifier
-            .size(22.dp)
-            .clip(CircleShape)
-            .background(color)
-            .border(1.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.6f), CircleShape)
+        modifier =
+            Modifier
+                .size(22.dp)
+                .clip(CircleShape)
+                .background(color)
+                .border(1.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.6f), CircleShape),
     )
 }
 
@@ -872,30 +948,39 @@ private fun ThemeCard(
     themeInfo: ThemeInfo,
     isSelected: Boolean,
     onClick: () -> Unit,
-    onCustomize: (() -> Unit)?
+    onCustomize: (() -> Unit)?,
 ) {
     Card(
-        modifier = Modifier
-            .fillMaxWidth()
-            .clickable(onClick = onClick),
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .clickable(onClick = onClick),
         shape = MaterialTheme.shapes.large,
-        colors = CardDefaults.cardColors(
-            containerColor = if (isSelected) MaterialTheme.colorScheme.primaryContainer else MaterialTheme.colorScheme.surfaceContainerLow
-        ),
-        border = BorderStroke(
-            width = if (isSelected) 2.dp else 1.dp,
-            color = MaterialTheme.colorScheme.outlineVariant
-        )
+        colors =
+            CardDefaults.cardColors(
+                containerColor =
+                    if (isSelected) {
+                        MaterialTheme.colorScheme.primaryContainer
+                    } else {
+                        MaterialTheme.colorScheme.surfaceContainerLow
+                    },
+            ),
+        border =
+            BorderStroke(
+                width = if (isSelected) 2.dp else 1.dp,
+                color = MaterialTheme.colorScheme.outlineVariant,
+            ),
     ) {
         Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(14.dp)
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(14.dp),
         ) {
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically
+                verticalAlignment = Alignment.CenterVertically,
             ) {
                 Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
                     ColorDot(themeInfo.primaryColor)
@@ -904,9 +989,11 @@ private fun ThemeCard(
                 if (isSelected) {
                     Icon(
                         imageVector = Icons.Default.Check,
-                        contentDescription = androidx.compose.ui.res.stringResource(R.string.appearance_selected),
+                        contentDescription =
+                            androidx.compose.ui.res
+                                .stringResource(R.string.appearance_selected),
                         tint = MaterialTheme.colorScheme.onPrimaryContainer,
-                        modifier = Modifier.size(18.dp)
+                        modifier = Modifier.size(18.dp),
                     )
                 }
             }
@@ -916,30 +1003,38 @@ private fun ThemeCard(
             Spacer(modifier = Modifier.height(10.dp))
 
             Text(
-                text = androidx.compose.ui.res.stringResource(themeInfo.displayNameRes),
+                text =
+                    androidx.compose.ui.res
+                        .stringResource(themeInfo.displayNameRes),
                 style = MaterialTheme.typography.titleMedium,
                 fontWeight = FontWeight.SemiBold,
                 color = MaterialTheme.colorScheme.onSurface,
                 maxLines = 1,
-                overflow = TextOverflow.Ellipsis
+                overflow = TextOverflow.Ellipsis,
             )
             Text(
-                text = androidx.compose.ui.res.stringResource(themeInfo.subtitleRes),
+                text =
+                    androidx.compose.ui.res
+                        .stringResource(themeInfo.subtitleRes),
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
                 maxLines = 1,
-                overflow = TextOverflow.Ellipsis
+                overflow = TextOverflow.Ellipsis,
             )
 
             if (onCustomize != null) {
                 Spacer(modifier = Modifier.height(8.dp))
                 TextButton(
                     onClick = onCustomize,
-                    contentPadding = PaddingValues(horizontal = 2.dp, vertical = 0.dp)
+                    contentPadding = PaddingValues(horizontal = 2.dp, vertical = 0.dp),
                 ) {
                     Icon(Icons.Default.Edit, contentDescription = null, modifier = Modifier.size(16.dp))
                     Spacer(modifier = Modifier.width(4.dp))
-                    Text(text = androidx.compose.ui.res.stringResource(R.string.appearance_customize_theme))
+                    Text(
+                        text =
+                            androidx.compose.ui.res
+                                .stringResource(R.string.appearance_customize_theme),
+                    )
                 }
             }
         }
@@ -951,68 +1046,77 @@ private fun CustomThemeEditorDialog(
     initialColors: CustomThemeColors,
     variant: ThemeVariant,
     onDismiss: () -> Unit,
-    onSave: (CustomThemeColors) -> Unit
+    onSave: (CustomThemeColors) -> Unit,
 ) {
     var draft by remember(initialColors) { mutableStateOf(initialColors) }
     var activePickerRole by remember { mutableStateOf<CustomColorRole?>(null) }
-    val hexInputs = remember(initialColors) {
-        mutableStateMapOf<CustomColorRole, String>().apply {
-            CUSTOM_ROLE_FIELDS.forEach { field ->
-                this[field.role] = draft.colorOf(field.role).toHexArgbString()
+    val hexInputs =
+        remember(initialColors) {
+            mutableStateMapOf<CustomColorRole, String>().apply {
+                CUSTOM_ROLE_FIELDS.forEach { field ->
+                    this[field.role] = draft.colorOf(field.role).toHexArgbString()
+                }
             }
         }
-    }
 
-    val activePickerField = activePickerRole?.let { role ->
-        CUSTOM_ROLE_FIELDS.firstOrNull { it.role == role }
-    }
+    val activePickerField =
+        activePickerRole?.let { role ->
+            CUSTOM_ROLE_FIELDS.firstOrNull { it.role == role }
+        }
 
     if (activePickerField != null) {
         ColorPickerDialog(
-            title = androidx.compose.ui.res.stringResource(activePickerField.labelRes),
+            title =
+                androidx.compose.ui.res
+                    .stringResource(activePickerField.labelRes),
             initialArgb = draft.colorOf(activePickerField.role),
             onDismiss = { activePickerRole = null },
             onApply = { argb ->
                 draft = draft.withColor(activePickerField.role, argb)
                 hexInputs[activePickerField.role] = argb.toHexArgbString()
                 activePickerRole = null
-            }
+            },
         )
     }
 
-    val allValid = CUSTOM_ROLE_FIELDS.all { field ->
-        parseHexColorToArgbLong(hexInputs[field.role].orEmpty()) != null
-    }
+    val allValid =
+        CUSTOM_ROLE_FIELDS.all { field ->
+            parseHexColorToArgbLong(hexInputs[field.role].orEmpty()) != null
+        }
 
     Dialog(onDismissRequest = onDismiss) {
         Surface(
             shape = MaterialTheme.shapes.extraLarge,
             tonalElevation = 6.dp,
-            modifier = Modifier.fillMaxWidth()
+            modifier = Modifier.fillMaxWidth(),
         ) {
             Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(16.dp)
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(16.dp),
             ) {
                 Text(
-                    text = androidx.compose.ui.res.stringResource(
-                        R.string.appearance_customizer_variant_title,
+                    text =
                         androidx.compose.ui.res.stringResource(
-                            when (variant) {
-                                ThemeVariant.LIGHT -> R.string.appearance_variant_light
-                                ThemeVariant.DARK -> R.string.appearance_variant_dark
-                                ThemeVariant.AMOLED -> R.string.appearance_variant_amoled
-                            }
-                        )
-                    ),
+                            R.string.appearance_customizer_variant_title,
+                            androidx.compose.ui.res.stringResource(
+                                when (variant) {
+                                    ThemeVariant.LIGHT -> R.string.appearance_variant_light
+                                    ThemeVariant.DARK -> R.string.appearance_variant_dark
+                                    ThemeVariant.AMOLED -> R.string.appearance_variant_amoled
+                                },
+                            ),
+                        ),
                     style = MaterialTheme.typography.titleLarge,
-                    fontWeight = FontWeight.Bold
+                    fontWeight = FontWeight.Bold,
                 )
                 Text(
-                    text = androidx.compose.ui.res.stringResource(R.string.appearance_customizer_subtitle),
+                    text =
+                        androidx.compose.ui.res
+                            .stringResource(R.string.appearance_customizer_subtitle),
                     style = MaterialTheme.typography.bodySmall,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
 
                 Spacer(modifier = Modifier.height(12.dp))
@@ -1022,10 +1126,11 @@ private fun CustomThemeEditorDialog(
                 Spacer(modifier = Modifier.height(12.dp))
 
                 LazyColumn(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(360.dp),
-                    verticalArrangement = Arrangement.spacedBy(10.dp)
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .height(360.dp),
+                    verticalArrangement = Arrangement.spacedBy(10.dp),
                 ) {
                     items(CUSTOM_ROLE_FIELDS.size) { index ->
                         val field = CUSTOM_ROLE_FIELDS[index]
@@ -1044,27 +1149,36 @@ private fun CustomThemeEditorDialog(
                             },
                             singleLine = true,
                             isError = hasError,
-                            label = { Text(androidx.compose.ui.res.stringResource(field.labelRes)) },
+                            label = {
+                                Text(
+                                    androidx.compose.ui.res
+                                        .stringResource(field.labelRes),
+                                )
+                            },
                             trailingIcon = {
                                 val previewColor = parsedColor?.let { Color(it) } ?: Color.Transparent
                                 Box(
-                                    modifier = Modifier
-                                        .size(20.dp)
-                                        .clip(CircleShape)
-                                        .border(1.dp, MaterialTheme.colorScheme.outlineVariant, CircleShape)
-                                        .background(previewColor, CircleShape)
-                                        .clickable {
-                                            activePickerRole = field.role
-                                        }
+                                    modifier =
+                                        Modifier
+                                            .size(20.dp)
+                                            .clip(CircleShape)
+                                            .border(1.dp, MaterialTheme.colorScheme.outlineVariant, CircleShape)
+                                            .background(previewColor, CircleShape)
+                                            .clickable {
+                                                activePickerRole = field.role
+                                            },
                                 )
                             },
                             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Ascii),
                             supportingText = {
                                 if (index == 0) {
-                                    Text(androidx.compose.ui.res.stringResource(R.string.appearance_customizer_format_hint))
+                                    Text(
+                                        androidx.compose.ui.res
+                                            .stringResource(R.string.appearance_customizer_format_hint),
+                                    )
                                 }
                             },
-                            modifier = Modifier.fillMaxWidth()
+                            modifier = Modifier.fillMaxWidth(),
                         )
                     }
                 }
@@ -1073,7 +1187,7 @@ private fun CustomThemeEditorDialog(
 
                 Row(
                     modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                    horizontalArrangement = Arrangement.spacedBy(8.dp),
                 ) {
                     TextButton(
                         onClick = {
@@ -1082,21 +1196,33 @@ private fun CustomThemeEditorDialog(
                             CUSTOM_ROLE_FIELDS.forEach { field ->
                                 hexInputs[field.role] = reset.colorOf(field.role).toHexArgbString()
                             }
-                        }
+                        },
                     ) {
-                        Text(text = androidx.compose.ui.res.stringResource(R.string.appearance_customizer_reset))
+                        Text(
+                            text =
+                                androidx.compose.ui.res
+                                    .stringResource(R.string.appearance_customizer_reset),
+                        )
                     }
 
                     Spacer(modifier = Modifier.weight(1f))
 
                     TextButton(onClick = onDismiss) {
-                        Text(text = androidx.compose.ui.res.stringResource(android.R.string.cancel))
+                        Text(
+                            text =
+                                androidx.compose.ui.res
+                                    .stringResource(android.R.string.cancel),
+                        )
                     }
                     Button(
                         onClick = { onSave(draft) },
-                        enabled = allValid
+                        enabled = allValid,
                     ) {
-                        Text(text = androidx.compose.ui.res.stringResource(R.string.appearance_customizer_save))
+                        Text(
+                            text =
+                                androidx.compose.ui.res
+                                    .stringResource(R.string.appearance_customizer_save),
+                        )
                     }
                 }
             }
@@ -1109,14 +1235,15 @@ private fun ColorPickerDialog(
     title: String,
     initialArgb: Long,
     onDismiss: () -> Unit,
-    onApply: (Long) -> Unit
+    onApply: (Long) -> Unit,
 ) {
     val initialColorInt = ((initialArgb and 0xFFFFFFFFL).toInt())
-    val initialHsv = remember(initialArgb) {
-        FloatArray(3).also { hsv ->
-            android.graphics.Color.colorToHSV(initialColorInt, hsv)
+    val initialHsv =
+        remember(initialArgb) {
+            FloatArray(3).also { hsv ->
+                android.graphics.Color.colorToHSV(initialColorInt, hsv)
+            }
         }
-    }
 
     var hue by remember(initialArgb) { mutableStateOf(initialHsv[0]) }
     var saturation by remember(initialArgb) { mutableStateOf(initialHsv[1]) }
@@ -1125,73 +1252,104 @@ private fun ColorPickerDialog(
         mutableStateOf(android.graphics.Color.alpha(initialColorInt) / 255f)
     }
 
-    val previewArgb = hsvaToArgbLong(
-        hue = hue,
-        saturation = saturation,
-        value = value,
-        alpha = alpha
-    )
+    val previewArgb =
+        hsvaToArgbLong(
+            hue = hue,
+            saturation = saturation,
+            value = value,
+            alpha = alpha,
+        )
 
     Dialog(onDismissRequest = onDismiss) {
         Surface(
             shape = MaterialTheme.shapes.extraLarge,
             tonalElevation = 8.dp,
-            modifier = Modifier.fillMaxWidth()
+            modifier = Modifier.fillMaxWidth(),
         ) {
             Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(16.dp)
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(16.dp),
             ) {
                 Text(
                     text = title,
                     style = MaterialTheme.typography.titleMedium,
-                    fontWeight = FontWeight.SemiBold
+                    fontWeight = FontWeight.SemiBold,
                 )
                 Spacer(modifier = Modifier.height(12.dp))
 
                 Box(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(52.dp)
-                        .clip(MaterialTheme.shapes.medium)
-                        .background(Color(previewArgb))
-                        .border(1.dp, MaterialTheme.colorScheme.outlineVariant, MaterialTheme.shapes.medium),
-                    contentAlignment = Alignment.Center
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .height(52.dp)
+                            .clip(MaterialTheme.shapes.medium)
+                            .background(Color(previewArgb))
+                            .border(1.dp, MaterialTheme.colorScheme.outlineVariant, MaterialTheme.shapes.medium),
+                    contentAlignment = Alignment.Center,
                 ) {
                     Text(
                         text = previewArgb.toHexArgbString(),
                         color = MaterialTheme.colorScheme.onSurface,
                         style = MaterialTheme.typography.labelLarge,
-                        fontWeight = FontWeight.Bold
+                        fontWeight = FontWeight.Bold,
                     )
                 }
 
                 Spacer(modifier = Modifier.height(12.dp))
 
-                Text(text = androidx.compose.ui.res.stringResource(R.string.appearance_color_hue), style = MaterialTheme.typography.labelMedium)
+                Text(
+                    text =
+                        androidx.compose.ui.res
+                            .stringResource(R.string.appearance_color_hue),
+                    style = MaterialTheme.typography.labelMedium,
+                )
                 Slider(value = hue, onValueChange = { hue = it }, valueRange = 0f..360f)
 
-                Text(text = androidx.compose.ui.res.stringResource(R.string.appearance_color_saturation), style = MaterialTheme.typography.labelMedium)
+                Text(
+                    text =
+                        androidx.compose.ui.res
+                            .stringResource(R.string.appearance_color_saturation),
+                    style = MaterialTheme.typography.labelMedium,
+                )
                 Slider(value = saturation, onValueChange = { saturation = it }, valueRange = 0f..1f)
 
-                Text(text = androidx.compose.ui.res.stringResource(R.string.appearance_color_brightness), style = MaterialTheme.typography.labelMedium)
+                Text(
+                    text =
+                        androidx.compose.ui.res
+                            .stringResource(R.string.appearance_color_brightness),
+                    style = MaterialTheme.typography.labelMedium,
+                )
                 Slider(value = value, onValueChange = { value = it }, valueRange = 0f..1f)
 
-                Text(text = androidx.compose.ui.res.stringResource(R.string.appearance_color_alpha), style = MaterialTheme.typography.labelMedium)
+                Text(
+                    text =
+                        androidx.compose.ui.res
+                            .stringResource(R.string.appearance_color_alpha),
+                    style = MaterialTheme.typography.labelMedium,
+                )
                 Slider(value = alpha, onValueChange = { alpha = it }, valueRange = 0f..1f)
 
                 Spacer(modifier = Modifier.height(8.dp))
 
                 Row(
                     modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.End
+                    horizontalArrangement = Arrangement.End,
                 ) {
                     TextButton(onClick = onDismiss) {
-                        Text(text = androidx.compose.ui.res.stringResource(android.R.string.cancel))
+                        Text(
+                            text =
+                                androidx.compose.ui.res
+                                    .stringResource(android.R.string.cancel),
+                        )
                     }
                     Button(onClick = { onApply(previewArgb) }) {
-                        Text(text = androidx.compose.ui.res.stringResource(R.string.appearance_customizer_save))
+                        Text(
+                            text =
+                                androidx.compose.ui.res
+                                    .stringResource(R.string.appearance_customizer_save),
+                        )
                     }
                 }
             }
@@ -1201,30 +1359,33 @@ private fun ColorPickerDialog(
 
 @Composable
 private fun CustomThemePreviewCard(colors: CustomThemeColors) {
-    val previewTheme = ThemeInfo(
-        mode = ThemeMode.CUSTOM,
-        displayNameRes = R.string.theme_name_custom,
-        subtitleRes = R.string.theme_desc_custom,
-        category = ThemeCategory.CUSTOM,
-        primaryColor = Color(colors.primary),
-        backgroundColor = Color(colors.background),
-        surfaceColor = Color(colors.surface),
-        onSurfaceColor = Color(colors.onSurface),
-        accentColor = Color(colors.secondary),
-        surfaceVariantColor = Color(colors.surfaceVariant)
-    )
+    val previewTheme =
+        ThemeInfo(
+            mode = ThemeMode.CUSTOM,
+            displayNameRes = R.string.theme_name_custom,
+            subtitleRes = R.string.theme_desc_custom,
+            category = ThemeCategory.CUSTOM,
+            primaryColor = Color(colors.primary),
+            backgroundColor = Color(colors.background),
+            surfaceColor = Color(colors.surface),
+            onSurfaceColor = Color(colors.onSurface),
+            accentColor = Color(colors.secondary),
+            surfaceVariantColor = Color(colors.surfaceVariant),
+        )
 
     Card(
         modifier = Modifier.fillMaxWidth(),
         shape = MaterialTheme.shapes.large,
         colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f)),
-        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant)
+        border = BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant),
     ) {
         Column(modifier = Modifier.padding(12.dp)) {
             Text(
-                text = androidx.compose.ui.res.stringResource(R.string.appearance_customize_theme),
+                text =
+                    androidx.compose.ui.res
+                        .stringResource(R.string.appearance_customize_theme),
                 style = MaterialTheme.typography.labelMedium,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
             Spacer(modifier = Modifier.height(8.dp))
             MiniThemePreview(previewTheme)
@@ -1232,8 +1393,8 @@ private fun CustomThemePreviewCard(colors: CustomThemeColors) {
     }
 }
 
-private fun buildThemeCatalog(customThemeColors: CustomThemeColors): List<ThemeInfo> {
-    return listOf(
+private fun buildThemeCatalog(customThemeColors: CustomThemeColors): List<ThemeInfo> =
+    listOf(
         ThemeInfo(
             mode = ThemeMode.SYSTEM,
             displayNameRes = R.string.theme_name_system_default,
@@ -1243,7 +1404,7 @@ private fun buildThemeCatalog(customThemeColors: CustomThemeColors): List<ThemeI
             backgroundColor = Color(0xFF1C1C1C),
             surfaceColor = Color(0xFF252525),
             onSurfaceColor = Color.White,
-            surfaceVariantColor = Color(0xFF333333)
+            surfaceVariantColor = Color(0xFF333333),
         ),
         ThemeInfo(
             mode = ThemeMode.MATERIAL_YOU,
@@ -1255,7 +1416,7 @@ private fun buildThemeCatalog(customThemeColors: CustomThemeColors): List<ThemeI
             surfaceColor = Color(0xFFFFFBFE),
             onSurfaceColor = Color(0xFF1C1B1F),
             accentColor = Color(0xFF625B71),
-            surfaceVariantColor = Color(0xFFE7E0EC)
+            surfaceVariantColor = Color(0xFFE7E0EC),
         ),
         ThemeInfo(
             mode = ThemeMode.CUSTOM,
@@ -1267,9 +1428,8 @@ private fun buildThemeCatalog(customThemeColors: CustomThemeColors): List<ThemeI
             surfaceColor = Color(customThemeColors.surface),
             onSurfaceColor = Color(customThemeColors.onSurface),
             accentColor = Color(customThemeColors.secondary),
-            surfaceVariantColor = Color(customThemeColors.surfaceVariant)
+            surfaceVariantColor = Color(customThemeColors.surfaceVariant),
         ),
-
         ThemeInfo(
             mode = ThemeMode.MINT_LIGHT,
             displayNameRes = R.string.theme_name_mint_fresh,
@@ -1280,7 +1440,7 @@ private fun buildThemeCatalog(customThemeColors: CustomThemeColors): List<ThemeI
             surfaceColor = MintLightThemeColors.Surface,
             onSurfaceColor = MintLightThemeColors.Text,
             accentColor = MintLightThemeColors.Secondary,
-            surfaceVariantColor = MintLightThemeColors.Border
+            surfaceVariantColor = MintLightThemeColors.Border,
         ),
         ThemeInfo(
             mode = ThemeMode.ROSE_LIGHT,
@@ -1292,7 +1452,7 @@ private fun buildThemeCatalog(customThemeColors: CustomThemeColors): List<ThemeI
             surfaceColor = RoseLightThemeColors.Surface,
             onSurfaceColor = RoseLightThemeColors.Text,
             accentColor = RoseLightThemeColors.Secondary,
-            surfaceVariantColor = RoseLightThemeColors.Border
+            surfaceVariantColor = RoseLightThemeColors.Border,
         ),
         ThemeInfo(
             mode = ThemeMode.SKY_LIGHT,
@@ -1304,7 +1464,7 @@ private fun buildThemeCatalog(customThemeColors: CustomThemeColors): List<ThemeI
             surfaceColor = SkyLightThemeColors.Surface,
             onSurfaceColor = SkyLightThemeColors.Text,
             accentColor = SkyLightThemeColors.Secondary,
-            surfaceVariantColor = SkyLightThemeColors.Border
+            surfaceVariantColor = SkyLightThemeColors.Border,
         ),
         ThemeInfo(
             mode = ThemeMode.CREAM_LIGHT,
@@ -1316,9 +1476,8 @@ private fun buildThemeCatalog(customThemeColors: CustomThemeColors): List<ThemeI
             surfaceColor = CreamLightThemeColors.Surface,
             onSurfaceColor = CreamLightThemeColors.Text,
             accentColor = CreamLightThemeColors.Secondary,
-            surfaceVariantColor = CreamLightThemeColors.Border
+            surfaceVariantColor = CreamLightThemeColors.Border,
         ),
-
         ThemeInfo(
             mode = ThemeMode.DARK,
             displayNameRes = R.string.theme_name_classic_dark,
@@ -1328,7 +1487,7 @@ private fun buildThemeCatalog(customThemeColors: CustomThemeColors): List<ThemeI
             backgroundColor = DarkBackground,
             surfaceColor = DarkSurface,
             onSurfaceColor = TextPrimary,
-            surfaceVariantColor = DarkSurfaceVariant
+            surfaceVariantColor = DarkSurfaceVariant,
         ),
         ThemeInfo(
             mode = ThemeMode.MONOCHROME,
@@ -1340,7 +1499,7 @@ private fun buildThemeCatalog(customThemeColors: CustomThemeColors): List<ThemeI
             surfaceColor = Color.Black,
             onSurfaceColor = Color.White,
             accentColor = Color(0xFF777777),
-            surfaceVariantColor = Color(0xFF111111)
+            surfaceVariantColor = Color(0xFF111111),
         ),
         ThemeInfo(
             mode = ThemeMode.MIDNIGHT_BLACK,
@@ -1352,7 +1511,7 @@ private fun buildThemeCatalog(customThemeColors: CustomThemeColors): List<ThemeI
             surfaceColor = MidnightBlackThemeColors.Surface,
             onSurfaceColor = MidnightBlackThemeColors.Text,
             accentColor = MidnightBlackThemeColors.Secondary,
-            surfaceVariantColor = MidnightBlackThemeColors.Border
+            surfaceVariantColor = MidnightBlackThemeColors.Border,
         ),
         ThemeInfo(
             mode = ThemeMode.OCEAN_BLUE,
@@ -1364,7 +1523,7 @@ private fun buildThemeCatalog(customThemeColors: CustomThemeColors): List<ThemeI
             surfaceColor = OceanBlueThemeColors.Surface,
             onSurfaceColor = OceanBlueThemeColors.Text,
             accentColor = OceanBlueThemeColors.Secondary,
-            surfaceVariantColor = OceanBlueThemeColors.Border
+            surfaceVariantColor = OceanBlueThemeColors.Border,
         ),
         ThemeInfo(
             mode = ThemeMode.FOREST_GREEN,
@@ -1376,7 +1535,7 @@ private fun buildThemeCatalog(customThemeColors: CustomThemeColors): List<ThemeI
             surfaceColor = ForestGreenThemeColors.Surface,
             onSurfaceColor = ForestGreenThemeColors.Text,
             accentColor = ForestGreenThemeColors.Secondary,
-            surfaceVariantColor = ForestGreenThemeColors.Border
+            surfaceVariantColor = ForestGreenThemeColors.Border,
         ),
         ThemeInfo(
             mode = ThemeMode.LAVENDER_MIST,
@@ -1388,7 +1547,7 @@ private fun buildThemeCatalog(customThemeColors: CustomThemeColors): List<ThemeI
             surfaceColor = Color(0xFF1F1A2E),
             onSurfaceColor = Color(0xFFEDE7F6),
             accentColor = Color(0xFF9575CD),
-            surfaceVariantColor = Color(0xFF2A2235)
+            surfaceVariantColor = Color(0xFF2A2235),
         ),
         ThemeInfo(
             mode = ThemeMode.SUNSET_ORANGE,
@@ -1400,7 +1559,7 @@ private fun buildThemeCatalog(customThemeColors: CustomThemeColors): List<ThemeI
             surfaceColor = SunsetOrangeThemeColors.Surface,
             onSurfaceColor = SunsetOrangeThemeColors.Text,
             accentColor = SunsetOrangeThemeColors.Secondary,
-            surfaceVariantColor = SunsetOrangeThemeColors.Border
+            surfaceVariantColor = SunsetOrangeThemeColors.Border,
         ),
         ThemeInfo(
             mode = ThemeMode.PURPLE_NEBULA,
@@ -1412,7 +1571,7 @@ private fun buildThemeCatalog(customThemeColors: CustomThemeColors): List<ThemeI
             surfaceColor = PurpleNebulaThemeColors.Surface,
             onSurfaceColor = PurpleNebulaThemeColors.Text,
             accentColor = PurpleNebulaThemeColors.Secondary,
-            surfaceVariantColor = PurpleNebulaThemeColors.Border
+            surfaceVariantColor = PurpleNebulaThemeColors.Border,
         ),
         ThemeInfo(
             mode = ThemeMode.ROSE_GOLD,
@@ -1424,7 +1583,7 @@ private fun buildThemeCatalog(customThemeColors: CustomThemeColors): List<ThemeI
             surfaceColor = RoseGoldThemeColors.Surface,
             onSurfaceColor = RoseGoldThemeColors.Text,
             accentColor = RoseGoldThemeColors.Secondary,
-            surfaceVariantColor = RoseGoldThemeColors.Border
+            surfaceVariantColor = RoseGoldThemeColors.Border,
         ),
         ThemeInfo(
             mode = ThemeMode.ARCTIC_ICE,
@@ -1436,7 +1595,7 @@ private fun buildThemeCatalog(customThemeColors: CustomThemeColors): List<ThemeI
             surfaceColor = ArcticIceThemeColors.Surface,
             onSurfaceColor = ArcticIceThemeColors.Text,
             accentColor = ArcticIceThemeColors.Secondary,
-            surfaceVariantColor = ArcticIceThemeColors.Border
+            surfaceVariantColor = ArcticIceThemeColors.Border,
         ),
         ThemeInfo(
             mode = ThemeMode.MINTY_FRESH,
@@ -1448,9 +1607,8 @@ private fun buildThemeCatalog(customThemeColors: CustomThemeColors): List<ThemeI
             surfaceColor = Color(0xFF1A2E2B),
             onSurfaceColor = Color(0xFFE0F2F1),
             accentColor = Color(0xFF4DB6AC),
-            surfaceVariantColor = Color(0xFF1E302D)
+            surfaceVariantColor = Color(0xFF1E302D),
         ),
-
         ThemeInfo(
             mode = ThemeMode.CRIMSON_RED,
             displayNameRes = R.string.theme_name_crimson,
@@ -1461,7 +1619,7 @@ private fun buildThemeCatalog(customThemeColors: CustomThemeColors): List<ThemeI
             surfaceColor = CrimsonRedThemeColors.Surface,
             onSurfaceColor = CrimsonRedThemeColors.Text,
             accentColor = CrimsonRedThemeColors.Secondary,
-            surfaceVariantColor = CrimsonRedThemeColors.Border
+            surfaceVariantColor = CrimsonRedThemeColors.Border,
         ),
         ThemeInfo(
             mode = ThemeMode.COSMIC_VOID,
@@ -1473,7 +1631,7 @@ private fun buildThemeCatalog(customThemeColors: CustomThemeColors): List<ThemeI
             surfaceColor = Color(0xFF121212),
             onSurfaceColor = Color(0xFFE0E0E0),
             accentColor = Color(0xFF651FFF),
-            surfaceVariantColor = Color(0xFF1A1225)
+            surfaceVariantColor = Color(0xFF1A1225),
         ),
         ThemeInfo(
             mode = ThemeMode.SOLAR_FLARE,
@@ -1485,7 +1643,7 @@ private fun buildThemeCatalog(customThemeColors: CustomThemeColors): List<ThemeI
             surfaceColor = Color(0xFF2E2600),
             onSurfaceColor = Color(0xFFFFFDE7),
             accentColor = Color(0xFFFFAB00),
-            surfaceVariantColor = Color(0xFF352A10)
+            surfaceVariantColor = Color(0xFF352A10),
         ),
         ThemeInfo(
             mode = ThemeMode.CYBERPUNK,
@@ -1497,7 +1655,7 @@ private fun buildThemeCatalog(customThemeColors: CustomThemeColors): List<ThemeI
             surfaceColor = Color(0xFF1F0033),
             onSurfaceColor = Color(0xFFE0E0E0),
             accentColor = Color(0xFF00FFFF),
-            surfaceVariantColor = Color(0xFF200F35)
+            surfaceVariantColor = Color(0xFF200F35),
         ),
         ThemeInfo(
             mode = ThemeMode.ROYAL_GOLD,
@@ -1509,7 +1667,7 @@ private fun buildThemeCatalog(customThemeColors: CustomThemeColors): List<ThemeI
             surfaceColor = RoyalGoldThemeColors.Surface,
             onSurfaceColor = RoyalGoldThemeColors.Text,
             accentColor = RoyalGoldThemeColors.Secondary,
-            surfaceVariantColor = RoyalGoldThemeColors.Border
+            surfaceVariantColor = RoyalGoldThemeColors.Border,
         ),
         ThemeInfo(
             mode = ThemeMode.NORDIC_HORIZON,
@@ -1521,7 +1679,7 @@ private fun buildThemeCatalog(customThemeColors: CustomThemeColors): List<ThemeI
             surfaceColor = NordicHorizonThemeColors.Surface,
             onSurfaceColor = NordicHorizonThemeColors.Text,
             accentColor = NordicHorizonThemeColors.Secondary,
-            surfaceVariantColor = NordicHorizonThemeColors.Border
+            surfaceVariantColor = NordicHorizonThemeColors.Border,
         ),
         ThemeInfo(
             mode = ThemeMode.ESPRESSO,
@@ -1533,7 +1691,7 @@ private fun buildThemeCatalog(customThemeColors: CustomThemeColors): List<ThemeI
             surfaceColor = EspressoThemeColors.Surface,
             onSurfaceColor = EspressoThemeColors.Text,
             accentColor = EspressoThemeColors.Secondary,
-            surfaceVariantColor = EspressoThemeColors.Border
+            surfaceVariantColor = EspressoThemeColors.Border,
         ),
         ThemeInfo(
             mode = ThemeMode.GUNMETAL,
@@ -1545,10 +1703,9 @@ private fun buildThemeCatalog(customThemeColors: CustomThemeColors): List<ThemeI
             surfaceColor = GunmetalThemeColors.Surface,
             onSurfaceColor = GunmetalThemeColors.Text,
             accentColor = GunmetalThemeColors.Secondary,
-            surfaceVariantColor = GunmetalThemeColors.Border
-        )
+            surfaceVariantColor = GunmetalThemeColors.Border,
+        ),
     )
-}
 
 private fun sanitizeHexInput(raw: String): String {
     val trimmed = raw.trim().uppercase()
@@ -1559,11 +1716,12 @@ private fun sanitizeHexInput(raw: String): String {
 
 private fun parseHexColorToArgbLong(input: String): Long? {
     val body = input.trim().removePrefix("#")
-    val normalized = when (body.length) {
-        6 -> "FF$body"
-        8 -> body
-        else -> return null
-    }
+    val normalized =
+        when (body.length) {
+            6 -> "FF$body"
+            8 -> body
+            else -> return null
+        }
     return normalized.toLongOrNull(16)
 }
 
@@ -1571,15 +1729,14 @@ private fun hsvaToArgbLong(
     hue: Float,
     saturation: Float,
     value: Float,
-    alpha: Float
+    alpha: Float,
 ): Long {
-    val argbInt = android.graphics.Color.HSVToColor(
-        (alpha * 255f).roundToInt().coerceIn(0, 255),
-        floatArrayOf(hue.coerceIn(0f, 360f), saturation.coerceIn(0f, 1f), value.coerceIn(0f, 1f))
-    )
+    val argbInt =
+        android.graphics.Color.HSVToColor(
+            (alpha * 255f).roundToInt().coerceIn(0, 255),
+            floatArrayOf(hue.coerceIn(0f, 360f), saturation.coerceIn(0f, 1f), value.coerceIn(0f, 1f)),
+        )
     return argbInt.toLong() and 0xFFFFFFFFL
 }
 
-private fun Long.toHexArgbString(): String {
-    return "#%08X".format(this and 0xFFFFFFFFL)
-}
+private fun Long.toHexArgbString(): String = "#%08X".format(this and 0xFFFFFFFFL)

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/settings/AutoBackupSettingsScreen.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/settings/AutoBackupSettingsScreen.kt
@@ -25,6 +25,7 @@ import io.github.aedev.flow.data.local.BackupRepository
 import io.github.aedev.flow.data.local.LocalDataManager
 import io.github.aedev.flow.data.local.PlayerPreferences
 import io.github.aedev.flow.notification.AutoBackupWorker
+import io.github.aedev.flow.ui.components.layout.topbar.FlowTopBar
 import kotlinx.coroutines.launch
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -32,9 +33,7 @@ import java.util.Locale
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun AutoBackupSettingsScreen(
-    onNavigateBack: () -> Unit
-) {
+fun AutoBackupSettingsScreen(onNavigateBack: () -> Unit) {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
     val ldm = remember { LocalDataManager(context) }
@@ -48,83 +47,72 @@ fun AutoBackupSettingsScreen(
 
     var isRunningNow by remember { mutableStateOf(false) }
 
-    val folderPickerLauncher = rememberLauncherForActivityResult(
-        contract = ActivityResultContracts.OpenDocumentTree()
-    ) { uri ->
-        uri?.let {
-            context.contentResolver.takePersistableUriPermission(
-                it,
-                Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION
-            )
-            scope.launch { playerPrefs.setAutoBackupFolderUri(it.toString()) }
+    val folderPickerLauncher =
+        rememberLauncherForActivityResult(
+            contract = ActivityResultContracts.OpenDocumentTree(),
+        ) { uri ->
+            uri?.let {
+                context.contentResolver.takePersistableUriPermission(
+                    it,
+                    Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION,
+                )
+                scope.launch { playerPrefs.setAutoBackupFolderUri(it.toString()) }
+            }
         }
-    }
 
-    val lastRunText = if (lastRun == 0L) {
-        stringResource(R.string.auto_backup_never_run)
-    } else {
-        val sdf = SimpleDateFormat("MMM d, yyyy HH:mm", Locale.getDefault())
-        stringResource(R.string.auto_backup_last_run, sdf.format(Date(lastRun)))
-    }
+    val lastRunText =
+        if (lastRun == 0L) {
+            stringResource(R.string.auto_backup_never_run)
+        } else {
+            val sdf = SimpleDateFormat("MMM d, yyyy HH:mm", Locale.getDefault())
+            stringResource(R.string.auto_backup_last_run, sdf.format(Date(lastRun)))
+        }
 
     Scaffold(
         contentWindowInsets = WindowInsets(0.dp),
         topBar = {
-            Surface(
-                modifier = Modifier.fillMaxWidth(),
-                color = MaterialTheme.colorScheme.background
-            ) {
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 4.dp, vertical = 8.dp),
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    IconButton(onClick = onNavigateBack) {
-                        Icon(Icons.Default.ArrowBack, stringResource(R.string.btn_back))
-                    }
-                    Text(
-                        text = stringResource(R.string.auto_backup_screen_title),
-                        style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold)
-                    )
-                }
-            }
+            FlowTopBar(
+                title = stringResource(R.string.auto_backup_screen_title),
+                onBack = onNavigateBack,
+            )
         },
-        containerColor = MaterialTheme.colorScheme.background
+        containerColor = MaterialTheme.colorScheme.background,
     ) { paddingValues ->
         LazyColumn(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(paddingValues),
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .padding(paddingValues),
             contentPadding = PaddingValues(16.dp),
-            verticalArrangement = Arrangement.spacedBy(16.dp)
+            verticalArrangement = Arrangement.spacedBy(16.dp),
         ) {
-
             item {
                 Text(
                     text = stringResource(R.string.auto_backup_schedule_section),
                     style = MaterialTheme.typography.labelLarge,
                     color = MaterialTheme.colorScheme.primary,
-                    modifier = Modifier.padding(horizontal = 4.dp, vertical = 4.dp)
+                    modifier = Modifier.padding(horizontal = 4.dp, vertical = 4.dp),
                 )
             }
             item {
                 SettingsGroup {
-                    val frequencies = listOf(
-                        LocalDataManager.AutoBackupFrequency.NONE to stringResource(R.string.auto_backup_frequency_none),
-                        LocalDataManager.AutoBackupFrequency.DAILY to stringResource(R.string.auto_backup_frequency_daily),
-                        LocalDataManager.AutoBackupFrequency.WEEKLY to stringResource(R.string.auto_backup_frequency_weekly),
-                        LocalDataManager.AutoBackupFrequency.MONTHLY to stringResource(R.string.auto_backup_frequency_monthly),
-                    )
+                    val frequencies =
+                        listOf(
+                            LocalDataManager.AutoBackupFrequency.NONE to stringResource(R.string.auto_backup_frequency_none),
+                            LocalDataManager.AutoBackupFrequency.DAILY to stringResource(R.string.auto_backup_frequency_daily),
+                            LocalDataManager.AutoBackupFrequency.WEEKLY to stringResource(R.string.auto_backup_frequency_weekly),
+                            LocalDataManager.AutoBackupFrequency.MONTHLY to stringResource(R.string.auto_backup_frequency_monthly),
+                        )
                     Column(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = 16.dp, vertical = 12.dp),
-                        verticalArrangement = Arrangement.spacedBy(8.dp)
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 16.dp, vertical = 12.dp),
+                        verticalArrangement = Arrangement.spacedBy(8.dp),
                     ) {
                         Row(
                             modifier = Modifier.fillMaxWidth(),
-                            horizontalArrangement = Arrangement.spacedBy(8.dp)
+                            horizontalArrangement = Arrangement.spacedBy(8.dp),
                         ) {
                             frequencies.take(2).forEach { (freq, label) ->
                                 FilterChip(
@@ -133,25 +121,32 @@ fun AutoBackupSettingsScreen(
                                         scope.launch {
                                             playerPrefs.setAutoBackupFrequency(freq)
                                             when (freq) {
-                                                LocalDataManager.AutoBackupFrequency.NONE ->
+                                                LocalDataManager.AutoBackupFrequency.NONE -> {
                                                     AutoBackupWorker.cancelBackup(context)
-                                                LocalDataManager.AutoBackupFrequency.DAILY ->
+                                                }
+
+                                                LocalDataManager.AutoBackupFrequency.DAILY -> {
                                                     AutoBackupWorker.scheduleBackup(context, 1L)
-                                                LocalDataManager.AutoBackupFrequency.WEEKLY ->
+                                                }
+
+                                                LocalDataManager.AutoBackupFrequency.WEEKLY -> {
                                                     AutoBackupWorker.scheduleBackup(context, 7L)
-                                                LocalDataManager.AutoBackupFrequency.MONTHLY ->
+                                                }
+
+                                                LocalDataManager.AutoBackupFrequency.MONTHLY -> {
                                                     AutoBackupWorker.scheduleBackup(context, 30L)
+                                                }
                                             }
                                         }
                                     },
                                     label = { Text(label) },
-                                    modifier = Modifier.weight(1f)
+                                    modifier = Modifier.weight(1f),
                                 )
                             }
                         }
                         Row(
                             modifier = Modifier.fillMaxWidth(),
-                            horizontalArrangement = Arrangement.spacedBy(8.dp)
+                            horizontalArrangement = Arrangement.spacedBy(8.dp),
                         ) {
                             frequencies.drop(2).forEach { (freq, label) ->
                                 FilterChip(
@@ -160,19 +155,26 @@ fun AutoBackupSettingsScreen(
                                         scope.launch {
                                             playerPrefs.setAutoBackupFrequency(freq)
                                             when (freq) {
-                                                LocalDataManager.AutoBackupFrequency.NONE ->
+                                                LocalDataManager.AutoBackupFrequency.NONE -> {
                                                     AutoBackupWorker.cancelBackup(context)
-                                                LocalDataManager.AutoBackupFrequency.DAILY ->
+                                                }
+
+                                                LocalDataManager.AutoBackupFrequency.DAILY -> {
                                                     AutoBackupWorker.scheduleBackup(context, 1L)
-                                                LocalDataManager.AutoBackupFrequency.WEEKLY ->
+                                                }
+
+                                                LocalDataManager.AutoBackupFrequency.WEEKLY -> {
                                                     AutoBackupWorker.scheduleBackup(context, 7L)
-                                                LocalDataManager.AutoBackupFrequency.MONTHLY ->
+                                                }
+
+                                                LocalDataManager.AutoBackupFrequency.MONTHLY -> {
                                                     AutoBackupWorker.scheduleBackup(context, 30L)
+                                                }
                                             }
                                         }
                                     },
                                     label = { Text(label) },
-                                    modifier = Modifier.weight(1f)
+                                    modifier = Modifier.weight(1f),
                                 )
                             }
                         }
@@ -185,40 +187,41 @@ fun AutoBackupSettingsScreen(
                     text = stringResource(R.string.auto_backup_type_section),
                     style = MaterialTheme.typography.labelLarge,
                     color = MaterialTheme.colorScheme.primary,
-                    modifier = Modifier.padding(horizontal = 4.dp, vertical = 4.dp)
+                    modifier = Modifier.padding(horizontal = 4.dp, vertical = 4.dp),
                 )
             }
             item {
                 SettingsGroup {
-                    val types = listOf(
-                        LocalDataManager.AutoBackupType.APP_DATA to stringResource(R.string.auto_backup_type_app_data),
-                        LocalDataManager.AutoBackupType.BRAIN to stringResource(R.string.auto_backup_type_brain),
-                        LocalDataManager.AutoBackupType.MASTER to stringResource(R.string.auto_backup_type_master),
-                    )
+                    val types =
+                        listOf(
+                            LocalDataManager.AutoBackupType.APP_DATA to stringResource(R.string.auto_backup_type_app_data),
+                            LocalDataManager.AutoBackupType.BRAIN to stringResource(R.string.auto_backup_type_brain),
+                            LocalDataManager.AutoBackupType.MASTER to stringResource(R.string.auto_backup_type_master),
+                        )
                     Column(modifier = Modifier.selectableGroup()) {
                         types.forEachIndexed { index, (type, label) ->
                             Row(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .selectable(
-                                        selected = backupType == type,
-                                        onClick = { scope.launch { playerPrefs.setAutoBackupType(type) } },
-                                        role = Role.RadioButton
-                                    )
-                                    .padding(horizontal = 16.dp, vertical = 14.dp),
+                                modifier =
+                                    Modifier
+                                        .fillMaxWidth()
+                                        .selectable(
+                                            selected = backupType == type,
+                                            onClick = { scope.launch { playerPrefs.setAutoBackupType(type) } },
+                                            role = Role.RadioButton,
+                                        ).padding(horizontal = 16.dp, vertical = 14.dp),
                                 verticalAlignment = Alignment.CenterVertically,
-                                horizontalArrangement = Arrangement.spacedBy(16.dp)
+                                horizontalArrangement = Arrangement.spacedBy(16.dp),
                             ) {
                                 RadioButton(
                                     selected = backupType == type,
-                                    onClick = null
+                                    onClick = null,
                                 )
                                 Text(label, style = MaterialTheme.typography.bodyLarge)
                             }
                             if (index < types.size - 1) {
                                 HorizontalDivider(
                                     modifier = Modifier.padding(start = 56.dp),
-                                    color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
+                                    color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f),
                                 )
                             }
                         }
@@ -231,7 +234,7 @@ fun AutoBackupSettingsScreen(
                     text = stringResource(R.string.auto_backup_folder_section),
                     style = MaterialTheme.typography.labelLarge,
                     color = MaterialTheme.colorScheme.primary,
-                    modifier = Modifier.padding(horizontal = 4.dp, vertical = 4.dp)
+                    modifier = Modifier.padding(horizontal = 4.dp, vertical = 4.dp),
                 )
             }
             item {
@@ -239,10 +242,15 @@ fun AutoBackupSettingsScreen(
                     SettingsItem(
                         icon = Icons.Outlined.Folder,
                         title = stringResource(R.string.auto_backup_folder_label),
-                        subtitle = folderUriStr?.let { uri ->
-                            try { Uri.parse(uri).lastPathSegment ?: uri } catch (_: Exception) { uri }
-                        } ?: stringResource(R.string.auto_backup_no_folder),
-                        onClick = { folderPickerLauncher.launch(null) }
+                        subtitle =
+                            folderUriStr?.let { uri ->
+                                try {
+                                    Uri.parse(uri).lastPathSegment ?: uri
+                                } catch (_: Exception) {
+                                    uri
+                                }
+                            } ?: stringResource(R.string.auto_backup_no_folder),
+                        onClick = { folderPickerLauncher.launch(null) },
                     )
                 }
             }
@@ -252,7 +260,7 @@ fun AutoBackupSettingsScreen(
                     text = stringResource(R.string.auto_backup_status_section),
                     style = MaterialTheme.typography.labelLarge,
                     color = MaterialTheme.colorScheme.primary,
-                    modifier = Modifier.padding(horizontal = 4.dp, vertical = 4.dp)
+                    modifier = Modifier.padding(horizontal = 4.dp, vertical = 4.dp),
                 )
             }
             item {
@@ -261,11 +269,11 @@ fun AutoBackupSettingsScreen(
                         icon = Icons.Outlined.History,
                         title = stringResource(R.string.auto_backup_last_run_label),
                         subtitle = lastRunText,
-                        onClick = {}
+                        onClick = {},
                     )
                     HorizontalDivider(
                         modifier = Modifier.padding(start = 56.dp),
-                        color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
+                        color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f),
                     )
                     SettingsItem(
                         icon = if (isRunningNow) Icons.Outlined.HourglassEmpty else Icons.Outlined.Backup,
@@ -276,29 +284,39 @@ fun AutoBackupSettingsScreen(
                                 isRunningNow = true
                                 scope.launch {
                                     val folderUri = Uri.parse(folderUriStr)
-                                    val result = when (backupType) {
-                                        LocalDataManager.AutoBackupType.APP_DATA ->
-                                            backupRepo.exportDataToFolder(folderUri)
-                                        LocalDataManager.AutoBackupType.BRAIN ->
-                                            backupRepo.exportBrainToFolder(folderUri)
-                                        LocalDataManager.AutoBackupType.MASTER ->
-                                            backupRepo.exportMasterToFolder(folderUri)
-                                    }
+                                    val result =
+                                        when (backupType) {
+                                            LocalDataManager.AutoBackupType.APP_DATA -> {
+                                                backupRepo.exportDataToFolder(folderUri)
+                                            }
+
+                                            LocalDataManager.AutoBackupType.BRAIN -> {
+                                                backupRepo.exportBrainToFolder(folderUri)
+                                            }
+
+                                            LocalDataManager.AutoBackupType.MASTER -> {
+                                                backupRepo.exportMasterToFolder(folderUri)
+                                            }
+                                        }
                                     if (result.isSuccess) {
                                         ldm.setAutoBackupLastRun(System.currentTimeMillis())
                                     }
                                     isRunningNow = false
-                                    android.widget.Toast.makeText(
-                                        context,
-                                        context.getString(
-                                            if (result.isSuccess) R.string.auto_backup_success
-                                            else R.string.auto_backup_failed
-                                        ),
-                                        android.widget.Toast.LENGTH_SHORT
-                                    ).show()
+                                    android.widget.Toast
+                                        .makeText(
+                                            context,
+                                            context.getString(
+                                                if (result.isSuccess) {
+                                                    R.string.auto_backup_success
+                                                } else {
+                                                    R.string.auto_backup_failed
+                                                },
+                                            ),
+                                            android.widget.Toast.LENGTH_SHORT,
+                                        ).show()
                                 }
                             }
-                        }
+                        },
                     )
                 }
             }

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/settings/BufferSettingsScreen.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/settings/BufferSettingsScreen.kt
@@ -12,20 +12,21 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import io.github.aedev.flow.R
 import io.github.aedev.flow.data.local.BufferProfile
 import io.github.aedev.flow.data.local.PlayerPreferences
+import io.github.aedev.flow.ui.components.layout.topbar.FlowTopBar
 import kotlinx.coroutines.launch
 
 @Composable
-fun BufferSettingsScreen(
-    onNavigateBack: () -> Unit
-) {
+fun BufferSettingsScreen(onNavigateBack: () -> Unit) {
     val context = LocalContext.current
     val coroutineScope = rememberCoroutineScope()
     val playerPreferences = remember { PlayerPreferences(context) }
-    
+
     // Buffer Settings
     val minBufferMs by playerPreferences.minBufferMs.collectAsState(initial = 30000)
     val maxBufferMs by playerPreferences.maxBufferMs.collectAsState(initial = 100000)
@@ -35,16 +36,16 @@ fun BufferSettingsScreen(
 
     // Cache size
     val cacheSizeMb by playerPreferences.mediaCacheSizeMb.collectAsState(initial = 500)
-    
+
     // Local state for sliders when in custom mode
     var tempMinBuffer by remember { mutableFloatStateOf(minBufferMs.toFloat()) }
     var tempMaxBuffer by remember { mutableFloatStateOf(maxBufferMs.toFloat()) }
     var tempPlaybackBuffer by remember { mutableFloatStateOf(bufferForPlaybackMs.toFloat()) }
     var tempRebuffer by remember { mutableFloatStateOf(bufferForPlaybackAfterRebufferMs.toFloat()) }
-    
+
     // Sync local state when preferences change from external source or profile switch
     LaunchedEffect(currentBufferProfile, minBufferMs, maxBufferMs, bufferForPlaybackMs, bufferForPlaybackAfterRebufferMs) {
-         if (currentBufferProfile != BufferProfile.CUSTOM) {
+        if (currentBufferProfile != BufferProfile.CUSTOM) {
             tempMinBuffer = currentBufferProfile.minBuffer.toFloat()
             tempMaxBuffer = currentBufferProfile.maxBuffer.toFloat()
             tempPlaybackBuffer = currentBufferProfile.playbackBuffer.toFloat()
@@ -60,101 +61,120 @@ fun BufferSettingsScreen(
     Scaffold(
         contentWindowInsets = WindowInsets(0.dp),
         topBar = {
-            Surface(
-                modifier = Modifier.fillMaxWidth(),
-                color = MaterialTheme.colorScheme.background
-            ) {
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 4.dp, vertical = 8.dp),
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    IconButton(onClick = onNavigateBack) {
-                        Icon(Icons.Default.ArrowBack, androidx.compose.ui.res.stringResource(io.github.aedev.flow.R.string.btn_back))
-                    }
-                    Text(
-                        text = androidx.compose.ui.res.stringResource(io.github.aedev.flow.R.string.buffer_settings_title),
-                        style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold)
-                    )
-                }
-            }
-        }
+            FlowTopBar(
+                title = stringResource(R.string.buffer_settings_title),
+                onBack = onNavigateBack,
+            )
+        },
     ) { paddingValues ->
         LazyColumn(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(paddingValues)
-                .background(MaterialTheme.colorScheme.background),
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .padding(paddingValues)
+                    .background(MaterialTheme.colorScheme.background),
             contentPadding = PaddingValues(16.dp),
-            verticalArrangement = Arrangement.spacedBy(16.dp)
+            verticalArrangement = Arrangement.spacedBy(16.dp),
         ) {
-            
             item {
                 Text(
-                    text = androidx.compose.ui.res.stringResource(io.github.aedev.flow.R.string.buffer_settings_desc),
+                    text =
+                        androidx.compose.ui.res
+                            .stringResource(io.github.aedev.flow.R.string.buffer_settings_desc),
                     style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
             }
-            
+
             // Profile Selection
-            item { SectionHeader(text = androidx.compose.ui.res.stringResource(io.github.aedev.flow.R.string.buffer_settings_header_profile)) }
-            
+            item {
+                SectionHeader(
+                    text =
+                        androidx.compose.ui.res
+                            .stringResource(io.github.aedev.flow.R.string.buffer_settings_header_profile),
+                )
+            }
+
             item {
                 SettingsGroup {
                     BufferProfile.values().filter { it != BufferProfile.CUSTOM }.forEachIndexed { index, profile ->
                         val isSelected = currentBufferProfile == profile
                         ProfileSelectionItem(
-                            title = androidx.compose.ui.res.stringResource(getProfileNameRes(profile)),
-                            subtitle = getProfileDescriptionRes(profile)?.let { androidx.compose.ui.res.stringResource(it) } ?: "",
+                            title =
+                                androidx.compose.ui.res
+                                    .stringResource(getProfileNameRes(profile)),
+                            subtitle =
+                                getProfileDescriptionRes(profile)?.let {
+                                    androidx.compose.ui.res
+                                        .stringResource(it)
+                                } ?: "",
                             isSelected = isSelected,
-                            onClick = { 
-                                coroutineScope.launch { 
+                            onClick = {
+                                coroutineScope.launch {
                                     playerPreferences.setBufferProfile(profile)
                                     // Also explicitly set values to ensure player picks them up immediately
                                     playerPreferences.setMinBufferMs(profile.minBuffer)
                                     playerPreferences.setMaxBufferMs(profile.maxBuffer)
                                     playerPreferences.setBufferForPlaybackMs(profile.playbackBuffer)
                                     playerPreferences.setBufferForPlaybackAfterRebufferMs(profile.rebufferBuffer)
-                                } 
-                            }
+                                }
+                            },
                         )
-                         if (index < BufferProfile.values().filter { it != BufferProfile.CUSTOM }.lastIndex) {
-                            HorizontalDivider(Modifier.padding(start = 56.dp), color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f))
+                        if (index < BufferProfile.values().filter { it != BufferProfile.CUSTOM }.lastIndex) {
+                            HorizontalDivider(
+                                Modifier.padding(start = 56.dp),
+                                color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f),
+                            )
                         }
                     }
                 }
             }
-            
+
             // Custom Profile
-             item { SectionHeader(text = androidx.compose.ui.res.stringResource(io.github.aedev.flow.R.string.buffer_settings_header_custom)) }
-             
-             item {
-                 SettingsGroup {
-                     ProfileSelectionItem(
-                        title = androidx.compose.ui.res.stringResource(io.github.aedev.flow.R.string.buffer_profile_custom),
-                        subtitle = androidx.compose.ui.res.stringResource(io.github.aedev.flow.R.string.buffer_profile_custom_desc),
+            item {
+                SectionHeader(
+                    text =
+                        androidx.compose.ui.res
+                            .stringResource(io.github.aedev.flow.R.string.buffer_settings_header_custom),
+                )
+            }
+
+            item {
+                SettingsGroup {
+                    ProfileSelectionItem(
+                        title =
+                            androidx.compose.ui.res
+                                .stringResource(io.github.aedev.flow.R.string.buffer_profile_custom),
+                        subtitle =
+                            androidx.compose.ui.res
+                                .stringResource(io.github.aedev.flow.R.string.buffer_profile_custom_desc),
                         isSelected = currentBufferProfile == BufferProfile.CUSTOM,
-                        onClick = { coroutineScope.launch { playerPreferences.setBufferProfile(BufferProfile.CUSTOM) } }
+                        onClick = { coroutineScope.launch { playerPreferences.setBufferProfile(BufferProfile.CUSTOM) } },
                     )
-                 }
-             }
+                }
+            }
 
             if (currentBufferProfile == BufferProfile.CUSTOM) {
                 item {
                     SettingsGroup {
-
                         Column(Modifier.padding(16.dp)) {
-                            Text(androidx.compose.ui.res.stringResource(io.github.aedev.flow.R.string.buffer_custom_mode_desc), 
-                                style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.onSurfaceVariant)
-                            
-                            Spacer(Modifier.height(16.dp))
-                            
+                            Text(
+                                androidx.compose.ui.res
+                                    .stringResource(io.github.aedev.flow.R.string.buffer_custom_mode_desc),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
 
-                            
+                            Spacer(Modifier.height(16.dp))
+
                             // Min Buffer
-                            Text(androidx.compose.ui.res.stringResource(io.github.aedev.flow.R.string.buffer_label_min, tempMinBuffer.toInt()/1000), style = MaterialTheme.typography.bodyMedium)
+                            Text(
+                                androidx.compose.ui.res.stringResource(
+                                    io.github.aedev.flow.R.string.buffer_label_min,
+                                    tempMinBuffer.toInt() / 1000,
+                                ),
+                                style = MaterialTheme.typography.bodyMedium,
+                            )
                             Slider(
                                 value = tempMinBuffer,
                                 onValueChange = { tempMinBuffer = it },
@@ -162,15 +182,19 @@ fun BufferSettingsScreen(
                                     coroutineScope.launch { playerPreferences.setMinBufferMs(tempMinBuffer.toInt()) }
                                 },
                                 valueRange = 1000f..60000f,
-                                steps = 59
+                                steps = 59,
                             )
-                            
-                            Spacer(Modifier.height(8.dp))
-                            
 
-                            
+                            Spacer(Modifier.height(8.dp))
+
                             // Max Buffer
-                            Text(androidx.compose.ui.res.stringResource(io.github.aedev.flow.R.string.buffer_label_max, tempMaxBuffer.toInt()/1000), style = MaterialTheme.typography.bodyMedium)
+                            Text(
+                                androidx.compose.ui.res.stringResource(
+                                    io.github.aedev.flow.R.string.buffer_label_max,
+                                    tempMaxBuffer.toInt() / 1000,
+                                ),
+                                style = MaterialTheme.typography.bodyMedium,
+                            )
                             Slider(
                                 value = tempMaxBuffer,
                                 onValueChange = { tempMaxBuffer = it },
@@ -178,15 +202,19 @@ fun BufferSettingsScreen(
                                     coroutineScope.launch { playerPreferences.setMaxBufferMs(tempMaxBuffer.toInt()) }
                                 },
                                 valueRange = 30000f..180000f,
-                                steps = 30
+                                steps = 30,
                             )
-                            
+
                             Spacer(Modifier.height(8.dp))
 
-
-
                             // Playback Buffer
-                            Text(androidx.compose.ui.res.stringResource(io.github.aedev.flow.R.string.buffer_label_playback, tempPlaybackBuffer.toInt()/1000), style = MaterialTheme.typography.bodyMedium)
+                            Text(
+                                androidx.compose.ui.res.stringResource(
+                                    io.github.aedev.flow.R.string.buffer_label_playback,
+                                    tempPlaybackBuffer.toInt() / 1000,
+                                ),
+                                style = MaterialTheme.typography.bodyMedium,
+                            )
                             Slider(
                                 value = tempPlaybackBuffer,
                                 onValueChange = { tempPlaybackBuffer = it },
@@ -194,15 +222,19 @@ fun BufferSettingsScreen(
                                     coroutineScope.launch { playerPreferences.setBufferForPlaybackMs(tempPlaybackBuffer.toInt()) }
                                 },
                                 valueRange = 500f..5000f,
-                                steps = 9
+                                steps = 9,
                             )
-                            
-                            Spacer(Modifier.height(8.dp))
-                            
 
-                            
+                            Spacer(Modifier.height(8.dp))
+
                             // Rebuffer
-                            Text(androidx.compose.ui.res.stringResource(io.github.aedev.flow.R.string.buffer_label_rebuffer, tempRebuffer.toInt()/1000), style = MaterialTheme.typography.bodyMedium)
+                            Text(
+                                androidx.compose.ui.res.stringResource(
+                                    io.github.aedev.flow.R.string.buffer_label_rebuffer,
+                                    tempRebuffer.toInt() / 1000,
+                                ),
+                                style = MaterialTheme.typography.bodyMedium,
+                            )
                             Slider(
                                 value = tempRebuffer,
                                 onValueChange = { tempRebuffer = it },
@@ -210,44 +242,63 @@ fun BufferSettingsScreen(
                                     coroutineScope.launch { playerPreferences.setBufferForPlaybackAfterRebufferMs(tempRebuffer.toInt()) }
                                 },
                                 valueRange = 1000f..10000f,
-                                steps = 9
+                                steps = 9,
                             )
                         }
                     }
                 }
             } else {
-                 item {
-                     Text(
-                        text = androidx.compose.ui.res.stringResource(io.github.aedev.flow.R.string.buffer_switch_to_custom),
+                item {
+                    Text(
+                        text =
+                            androidx.compose.ui.res
+                                .stringResource(io.github.aedev.flow.R.string.buffer_switch_to_custom),
                         style = MaterialTheme.typography.bodySmall,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        modifier = Modifier.padding(start = 16.dp)
-                     )
-                 }
+                        modifier = Modifier.padding(start = 16.dp),
+                    )
+                }
             }
 
             // Cache Size Section
-            item { SectionHeader(text = androidx.compose.ui.res.stringResource(io.github.aedev.flow.R.string.cache_size_header)) }
+            item {
+                SectionHeader(
+                    text =
+                        androidx.compose.ui.res
+                            .stringResource(io.github.aedev.flow.R.string.cache_size_header),
+                )
+            }
             item {
                 Text(
-                    text = androidx.compose.ui.res.stringResource(io.github.aedev.flow.R.string.cache_size_desc),
+                    text =
+                        androidx.compose.ui.res
+                            .stringResource(io.github.aedev.flow.R.string.cache_size_desc),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.padding(bottom = 8.dp)
+                    modifier = Modifier.padding(bottom = 8.dp),
                 )
-                val cacheOptions = listOf(
-                    100 to androidx.compose.ui.res.stringResource(io.github.aedev.flow.R.string.cache_size_100mb),
-                    200 to androidx.compose.ui.res.stringResource(io.github.aedev.flow.R.string.cache_size_200mb),
-                    500 to androidx.compose.ui.res.stringResource(io.github.aedev.flow.R.string.cache_size_500mb),
-                    0 to androidx.compose.ui.res.stringResource(io.github.aedev.flow.R.string.cache_size_unlimited)
-                )
+                val cacheOptions =
+                    listOf(
+                        100 to
+                            androidx.compose.ui.res
+                                .stringResource(io.github.aedev.flow.R.string.cache_size_100mb),
+                        200 to
+                            androidx.compose.ui.res
+                                .stringResource(io.github.aedev.flow.R.string.cache_size_200mb),
+                        500 to
+                            androidx.compose.ui.res
+                                .stringResource(io.github.aedev.flow.R.string.cache_size_500mb),
+                        0 to
+                            androidx.compose.ui.res
+                                .stringResource(io.github.aedev.flow.R.string.cache_size_unlimited),
+                    )
                 androidx.compose.foundation.layout.Column {
                     cacheOptions.forEach { (sizeMb, label) ->
                         ProfileSelectionItem(
                             title = label,
                             subtitle = "",
                             isSelected = cacheSizeMb == sizeMb,
-                            onClick = { coroutineScope.launch { playerPreferences.setMediaCacheSizeMb(sizeMb) } }
+                            onClick = { coroutineScope.launch { playerPreferences.setMediaCacheSizeMb(sizeMb) } },
                         )
                     }
                 }
@@ -261,22 +312,23 @@ fun ProfileSelectionItem(
     title: String,
     subtitle: String,
     isSelected: Boolean,
-    onClick: () -> Unit
+    onClick: () -> Unit,
 ) {
     Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .clickable(onClick = onClick)
-            .padding(16.dp),
-        verticalAlignment = Alignment.CenterVertically
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .clickable(onClick = onClick)
+                .padding(16.dp),
+        verticalAlignment = Alignment.CenterVertically,
     ) {
-         RadioButton(
+        RadioButton(
             selected = isSelected,
-            onClick = null 
+            onClick = null,
         )
-        
+
         Spacer(modifier = Modifier.width(16.dp))
-        
+
         Column {
             Text(text = title, style = MaterialTheme.typography.bodyLarge)
             if (subtitle.isNotEmpty()) {
@@ -286,22 +338,19 @@ fun ProfileSelectionItem(
     }
 }
 
-
-private fun getProfileNameRes(profile: BufferProfile): Int {
-    return when (profile) {
+private fun getProfileNameRes(profile: BufferProfile): Int =
+    when (profile) {
         BufferProfile.STABLE -> io.github.aedev.flow.R.string.buffer_profile_stable
         BufferProfile.AGGRESSIVE -> io.github.aedev.flow.R.string.buffer_profile_aggressive
         BufferProfile.DATASAVER -> io.github.aedev.flow.R.string.buffer_profile_datasaver
         BufferProfile.CUSTOM -> io.github.aedev.flow.R.string.buffer_profile_custom
         else -> io.github.aedev.flow.R.string.buffer_profile_stable // Default fallback
     }
-}
 
-private fun getProfileDescriptionRes(profile: BufferProfile): Int? {
-    return when (profile) {
+private fun getProfileDescriptionRes(profile: BufferProfile): Int? =
+    when (profile) {
         BufferProfile.STABLE -> io.github.aedev.flow.R.string.buffer_desc_stable
         BufferProfile.AGGRESSIVE -> io.github.aedev.flow.R.string.buffer_desc_aggressive
         BufferProfile.DATASAVER -> io.github.aedev.flow.R.string.buffer_desc_datasaver
         else -> null
     }
-}

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/settings/ContentSettingsScreen.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/settings/ContentSettingsScreen.kt
@@ -53,6 +53,7 @@ import io.github.aedev.flow.data.local.PlayerPreferences
 import io.github.aedev.flow.data.local.PlayerRelatedCardStyle
 import io.github.aedev.flow.data.local.WatchedThreshold
 import io.github.aedev.flow.ui.NavigationVisibility
+import io.github.aedev.flow.ui.components.layout.topbar.FlowTopBar
 import io.github.aedev.flow.ui.resolveDefaultNavTabIndex
 import io.github.aedev.flow.ui.theme.GridItemSize
 import io.github.aedev.flow.ui.visibleNavTabIndices
@@ -138,26 +139,10 @@ fun ContentSettingsScreen(onBackClick: () -> Unit) {
     Scaffold(
         contentWindowInsets = WindowInsets(0.dp),
         topBar = {
-            Surface(
-                modifier = Modifier.fillMaxWidth(),
-                color = MaterialTheme.colorScheme.background,
-            ) {
-                Row(
-                    modifier =
-                        Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = 4.dp, vertical = 8.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    IconButton(onClick = onBackClick) {
-                        Icon(Icons.AutoMirrored.Filled.ArrowBack, stringResource(R.string.btn_back))
-                    }
-                    Text(
-                        text = stringResource(R.string.content_settings_title),
-                        style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
-                    )
-                }
-            }
+            FlowTopBar(
+                title = stringResource(R.string.content_settings_title),
+                onBack = onBackClick,
+            )
         },
     ) { padding ->
         LazyColumn(

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/settings/DateTimeSettingsScreen.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/settings/DateTimeSettingsScreen.kt
@@ -17,12 +17,13 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import io.github.aedev.flow.R
 import io.github.aedev.flow.data.local.PlayerPreferences
+import io.github.aedev.flow.ui.components.layout.topbar.FlowTopBar
+import io.github.aedev.flow.utils.DateContext
 import io.github.aedev.flow.utils.DateContextMode
 import io.github.aedev.flow.utils.DateDisplayMode
 import io.github.aedev.flow.utils.DateDisplaySettings
 import io.github.aedev.flow.utils.DateFormatStyle
 import io.github.aedev.flow.utils.formatExactDate
-import io.github.aedev.flow.utils.DateContext
 import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -46,44 +47,43 @@ fun DateTimeSettingsScreen(onNavigateBack: () -> Unit) {
     Scaffold(
         contentWindowInsets = WindowInsets(0.dp),
         topBar = {
-            Surface(modifier = Modifier.fillMaxWidth(), color = MaterialTheme.colorScheme.background) {
-                Row(
-                    modifier = Modifier.fillMaxWidth().padding(horizontal = 4.dp, vertical = 8.dp),
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    IconButton(onClick = onNavigateBack) {
-                        Icon(Icons.Default.ArrowBack, stringResource(R.string.btn_back))
-                    }
-                    Text(
-                        text = stringResource(R.string.datetime_title),
-                        style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold)
-                    )
-                }
-            }
-        }
+            FlowTopBar(
+                title = stringResource(R.string.datetime_title),
+                onBack = onNavigateBack,
+            )
+        },
     ) { paddingValues ->
         LazyColumn(
             modifier = Modifier.fillMaxSize().padding(paddingValues).background(MaterialTheme.colorScheme.background),
             contentPadding = PaddingValues(16.dp),
-            verticalArrangement = Arrangement.spacedBy(20.dp)
+            verticalArrangement = Arrangement.spacedBy(20.dp),
         ) {
             // ── Live preview ──
             item {
                 Card(
                     colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.primaryContainer),
                     shape = MaterialTheme.shapes.large,
-                    modifier = Modifier.fillMaxWidth()
+                    modifier = Modifier.fillMaxWidth(),
                 ) {
                     Column(Modifier.padding(16.dp)) {
                         Text(
                             text = stringResource(R.string.datetime_preview_header),
                             style = MaterialTheme.typography.labelMedium,
-                            color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.8f)
+                            color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.8f),
                         )
                         Spacer(Modifier.height(8.dp))
-                        PreviewLine(stringResource(R.string.datetime_context_lists), settings.format(sampleRelative, DateContext.LISTS, sampleTimestamp))
-                        PreviewLine(stringResource(R.string.datetime_context_watch), settings.format(sampleRelative, DateContext.WATCH, sampleTimestamp))
-                        PreviewLine(stringResource(R.string.datetime_context_description), settings.format(sampleRelative, DateContext.DESCRIPTION, sampleTimestamp))
+                        PreviewLine(
+                            stringResource(R.string.datetime_context_lists),
+                            settings.format(sampleRelative, DateContext.LISTS, sampleTimestamp),
+                        )
+                        PreviewLine(
+                            stringResource(R.string.datetime_context_watch),
+                            settings.format(sampleRelative, DateContext.WATCH, sampleTimestamp),
+                        )
+                        PreviewLine(
+                            stringResource(R.string.datetime_context_description),
+                            settings.format(sampleRelative, DateContext.DESCRIPTION, sampleTimestamp),
+                        )
                     }
                 }
             }
@@ -91,16 +91,17 @@ fun DateTimeSettingsScreen(onNavigateBack: () -> Unit) {
             item { SectionHeader(text = stringResource(R.string.datetime_mode_header)) }
             item {
                 SettingsGroup {
-                    val modes = listOf(
-                        DateDisplayMode.RELATIVE to R.string.datetime_mode_relative,
-                        DateDisplayMode.EXACT to R.string.datetime_mode_exact,
-                        DateDisplayMode.BOTH to R.string.datetime_mode_both,
-                    )
+                    val modes =
+                        listOf(
+                            DateDisplayMode.RELATIVE to R.string.datetime_mode_relative,
+                            DateDisplayMode.EXACT to R.string.datetime_mode_exact,
+                            DateDisplayMode.BOTH to R.string.datetime_mode_both,
+                        )
                     modes.forEachIndexed { index, (mode, labelRes) ->
                         DateRadioRow(
                             title = stringResource(labelRes),
                             selected = globalMode == mode,
-                            onClick = { scope.launch { prefs.setDateDisplayMode(mode) } }
+                            onClick = { scope.launch { prefs.setDateDisplayMode(mode) } },
                         )
                         if (index < modes.size - 1) RowDivider()
                     }
@@ -114,16 +115,17 @@ fun DateTimeSettingsScreen(onNavigateBack: () -> Unit) {
                     styles.forEachIndexed { index, style ->
                         val sample = formatExactDate(sampleTimestamp, style)
                         val title = if (style == DateFormatStyle.SYSTEM) stringResource(R.string.datetime_format_system) else sample
-                        val subtitle = when (style) {
-                            DateFormatStyle.SYSTEM -> sample
-                            DateFormatStyle.ISO -> stringResource(R.string.datetime_format_iso_hint)
-                            else -> null
-                        }
+                        val subtitle =
+                            when (style) {
+                                DateFormatStyle.SYSTEM -> sample
+                                DateFormatStyle.ISO -> stringResource(R.string.datetime_format_iso_hint)
+                                else -> null
+                            }
                         DateRadioRow(
                             title = title,
                             subtitle = subtitle,
                             selected = formatStyle == style,
-                            onClick = { scope.launch { prefs.setDateFormatStyle(style) } }
+                            onClick = { scope.launch { prefs.setDateFormatStyle(style) } },
                         )
                         if (index < styles.size - 1) RowDivider()
                     }
@@ -136,7 +138,7 @@ fun DateTimeSettingsScreen(onNavigateBack: () -> Unit) {
                     text = stringResource(R.string.datetime_overrides_note),
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    modifier = Modifier.padding(start = 8.dp)
+                    modifier = Modifier.padding(start = 8.dp),
                 )
             }
             item {
@@ -144,19 +146,19 @@ fun DateTimeSettingsScreen(onNavigateBack: () -> Unit) {
                     OverrideRow(
                         label = stringResource(R.string.datetime_context_lists),
                         value = listsMode,
-                        onSelect = { scope.launch { prefs.setDateModeLists(it) } }
+                        onSelect = { scope.launch { prefs.setDateModeLists(it) } },
                     )
                     RowDivider()
                     OverrideRow(
                         label = stringResource(R.string.datetime_context_watch),
                         value = watchMode,
-                        onSelect = { scope.launch { prefs.setDateModeWatch(it) } }
+                        onSelect = { scope.launch { prefs.setDateModeWatch(it) } },
                     )
                     RowDivider()
                     OverrideRow(
                         label = stringResource(R.string.datetime_context_description),
                         value = descriptionMode,
-                        onSelect = { scope.launch { prefs.setDateModeDescription(it) } }
+                        onSelect = { scope.launch { prefs.setDateModeDescription(it) } },
                     )
                 }
             }
@@ -165,18 +167,21 @@ fun DateTimeSettingsScreen(onNavigateBack: () -> Unit) {
 }
 
 @Composable
-private fun PreviewLine(label: String, value: String) {
+private fun PreviewLine(
+    label: String,
+    value: String,
+) {
     Row(Modifier.fillMaxWidth().padding(vertical = 2.dp)) {
         Text(
             text = "$label:",
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onPrimaryContainer.copy(alpha = 0.7f),
-            modifier = Modifier.weight(1f)
+            modifier = Modifier.weight(1f),
         )
         Text(
             text = value,
             style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.Medium),
-            color = MaterialTheme.colorScheme.onPrimaryContainer
+            color = MaterialTheme.colorScheme.onPrimaryContainer,
         )
     }
 }
@@ -186,11 +191,11 @@ private fun DateRadioRow(
     title: String,
     subtitle: String? = null,
     selected: Boolean,
-    onClick: () -> Unit
+    onClick: () -> Unit,
 ) {
     Row(
         modifier = Modifier.fillMaxWidth().clickable(onClick = onClick).padding(16.dp),
-        verticalAlignment = Alignment.CenterVertically
+        verticalAlignment = Alignment.CenterVertically,
     ) {
         RadioButton(selected = selected, onClick = null)
         Spacer(Modifier.width(16.dp))
@@ -208,17 +213,18 @@ private fun DateRadioRow(
 private fun OverrideRow(
     label: String,
     value: DateContextMode,
-    onSelect: (DateContextMode) -> Unit
+    onSelect: (DateContextMode) -> Unit,
 ) {
     Column(Modifier.fillMaxWidth().padding(horizontal = 16.dp, vertical = 12.dp)) {
         Text(text = label, style = MaterialTheme.typography.bodyLarge, color = MaterialTheme.colorScheme.onSurface)
         Spacer(Modifier.height(8.dp))
-        val options = listOf(
-            DateContextMode.DEFAULT to R.string.datetime_override_default,
-            DateContextMode.RELATIVE to R.string.datetime_override_relative,
-            DateContextMode.EXACT to R.string.datetime_override_exact,
-            DateContextMode.BOTH to R.string.datetime_override_both,
-        )
+        val options =
+            listOf(
+                DateContextMode.DEFAULT to R.string.datetime_override_default,
+                DateContextMode.RELATIVE to R.string.datetime_override_relative,
+                DateContextMode.EXACT to R.string.datetime_override_exact,
+                DateContextMode.BOTH to R.string.datetime_override_both,
+            )
         SingleChoiceSegmentedButtonRow(Modifier.fillMaxWidth()) {
             options.forEachIndexed { index, (mode, labelRes) ->
                 SegmentedButton(
@@ -230,9 +236,9 @@ private fun OverrideRow(
                             text = stringResource(labelRes),
                             maxLines = 1,
                             overflow = TextOverflow.Ellipsis,
-                            style = MaterialTheme.typography.labelMedium
+                            style = MaterialTheme.typography.labelMedium,
                         )
-                    }
+                    },
                 )
             }
         }

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/settings/DiagnosticsScreen.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/settings/DiagnosticsScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import io.github.aedev.flow.R
+import io.github.aedev.flow.ui.components.layout.topbar.FlowTopBar
 import io.github.aedev.flow.utils.FlowDiagnostics
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
@@ -46,10 +47,10 @@ private fun detectLevel(line: String): LogLevel {
     // Logcat format: "MM-DD HH:MM:SS.mmm  PID  TID LEVEL TAG: message"
     return when {
         line.contains(Regex("""\s[EF]\s""")) -> LogLevel.ERROR
-        line.contains(Regex("""\sW\s"""))    -> LogLevel.WARN
-        line.contains(Regex("""\sI\s"""))    -> LogLevel.INFO
-        line.contains(Regex("""\sD\s"""))    -> LogLevel.DEBUG
-        else                                 -> LogLevel.OTHER
+        line.contains(Regex("""\sW\s""")) -> LogLevel.WARN
+        line.contains(Regex("""\sI\s""")) -> LogLevel.INFO
+        line.contains(Regex("""\sD\s""")) -> LogLevel.DEBUG
+        else -> LogLevel.OTHER
     }
 }
 
@@ -58,8 +59,8 @@ private fun levelColor(level: LogLevel): Color {
     val cs = MaterialTheme.colorScheme
     return when (level) {
         LogLevel.ERROR -> Color(0xFFFF6B6B)
-        LogLevel.WARN  -> Color(0xFFFFD93D)
-        LogLevel.INFO  -> cs.onSurface.copy(alpha = 0.85f)
+        LogLevel.WARN -> Color(0xFFFFD93D)
+        LogLevel.INFO -> cs.onSurface.copy(alpha = 0.85f)
         LogLevel.DEBUG -> cs.onSurface.copy(alpha = 0.50f)
         LogLevel.OTHER -> cs.onSurface.copy(alpha = 0.65f)
     }
@@ -72,25 +73,24 @@ private fun levelColor(level: LogLevel): Color {
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun DiagnosticsScreen(onNavigateBack: () -> Unit) {
-
-    val context       = LocalContext.current
-    val scope         = rememberCoroutineScope()
-    val clipboard     = LocalClipboardManager.current
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+    val clipboard = LocalClipboardManager.current
 
     // Tab state
     var selectedTab by remember { mutableIntStateOf(0) }
 
     // Log content
-    var sessionLines   by remember { mutableStateOf<List<String>>(emptyList()) }
-    var crashText      by remember { mutableStateOf("") }
-    var isLoadingLogs  by remember { mutableStateOf(true) }
+    var sessionLines by remember { mutableStateOf<List<String>>(emptyList()) }
+    var crashText by remember { mutableStateOf("") }
+    var isLoadingLogs by remember { mutableStateOf(true) }
     var isLoadingCrash by remember { mutableStateOf(true) }
 
     // UI feedback
-    var showClearDialog  by remember { mutableStateOf(false) }
+    var showClearDialog by remember { mutableStateOf(false) }
     var copiedSnackShown by remember { mutableStateOf(false) }
-    val snackbarHost     = remember { SnackbarHostState() }
-    val listState        = rememberLazyListState()
+    val snackbarHost = remember { SnackbarHostState() }
+    val listState = rememberLazyListState()
 
     val deviceInfo = remember { FlowDiagnostics.buildDeviceInfo(context) }
 
@@ -99,13 +99,13 @@ fun DiagnosticsScreen(onNavigateBack: () -> Unit) {
     // -----------------------------------------------------------------------
     LaunchedEffect(Unit) {
         withContext(Dispatchers.IO) {
-            val raw       = FlowDiagnostics.readSessionLogs()
-            val lines     = raw.lines()
-            val crashRaw  = FlowDiagnostics.getCrashLogs(context)
+            val raw = FlowDiagnostics.readSessionLogs()
+            val lines = raw.lines()
+            val crashRaw = FlowDiagnostics.getCrashLogs(context)
             withContext(Dispatchers.Main) {
-                sessionLines   = lines
-                isLoadingLogs  = false
-                crashText      = crashRaw
+                sessionLines = lines
+                isLoadingLogs = false
+                crashText = crashRaw
                 isLoadingCrash = false
             }
         }
@@ -115,17 +115,18 @@ fun DiagnosticsScreen(onNavigateBack: () -> Unit) {
     // Helper – copy current tab's content to clipboard
     // -----------------------------------------------------------------------
     fun copyCurrentTab() {
-        val text = when (selectedTab) {
-            0    -> FlowDiagnostics.buildFullReport(context, sessionLines.joinToString("\n"))
-            else -> "$deviceInfo\n\n$crashText"
-        }
+        val text =
+            when (selectedTab) {
+                0 -> FlowDiagnostics.buildFullReport(context, sessionLines.joinToString("\n"))
+                else -> "$deviceInfo\n\n$crashText"
+            }
         clipboard.setText(AnnotatedString(text))
         if (!copiedSnackShown) {
             copiedSnackShown = true
             scope.launch {
                 snackbarHost.showSnackbar(
-                    message  = context.getString(R.string.diagnostics_copied),
-                    duration = SnackbarDuration.Short
+                    message = context.getString(R.string.diagnostics_copied),
+                    duration = SnackbarDuration.Short,
                 )
                 delay(2500)
                 copiedSnackShown = false
@@ -138,11 +139,12 @@ fun DiagnosticsScreen(onNavigateBack: () -> Unit) {
     // -----------------------------------------------------------------------
     fun shareReport() {
         val report = FlowDiagnostics.buildFullReport(context, sessionLines.joinToString("\n"))
-        val intent = Intent(Intent.ACTION_SEND).apply {
-            type = "text/plain"
-            putExtra(Intent.EXTRA_SUBJECT, "Flow Diagnostics Report")
-            putExtra(Intent.EXTRA_TEXT, report)
-        }
+        val intent =
+            Intent(Intent.ACTION_SEND).apply {
+                type = "text/plain"
+                putExtra(Intent.EXTRA_SUBJECT, "Flow Diagnostics Report")
+                putExtra(Intent.EXTRA_TEXT, report)
+            }
         context.startActivity(Intent.createChooser(intent, context.getString(R.string.diagnostics_share)))
     }
 
@@ -152,80 +154,67 @@ fun DiagnosticsScreen(onNavigateBack: () -> Unit) {
     Scaffold(
         contentWindowInsets = WindowInsets(0.dp),
         topBar = {
-            Surface(
-                modifier = Modifier.fillMaxWidth(),
-                color = MaterialTheme.colorScheme.background
-            ) {
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 4.dp, vertical = 8.dp),
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    IconButton(onClick = onNavigateBack) {
-                        Icon(
-                            Icons.Default.ArrowBack,
-                            contentDescription = stringResource(R.string.btn_back)
-                        )
-                    }
-                    Text(
-                        text = stringResource(R.string.diagnostics_title),
-                        style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
-                        modifier = Modifier.weight(1f)
-                    )
+            FlowTopBar(
+                title = stringResource(R.string.diagnostics_title),
+                onBack = onNavigateBack,
+                actions = {
                     IconButton(onClick = ::shareReport) {
                         Icon(
                             Icons.Outlined.Share,
-                            contentDescription = stringResource(R.string.diagnostics_share)
+                            contentDescription = stringResource(R.string.diagnostics_share),
                         )
                     }
                     IconButton(onClick = ::copyCurrentTab) {
                         Icon(
                             Icons.Outlined.ContentCopy,
-                            contentDescription = stringResource(R.string.diagnostics_copy)
+                            contentDescription = stringResource(R.string.diagnostics_copy),
                         )
                     }
-                }
-            }
+                },
+            )
         },
         snackbarHost = { SnackbarHost(snackbarHost) },
-        containerColor = MaterialTheme.colorScheme.background
+        containerColor = MaterialTheme.colorScheme.background,
     ) { padding ->
         Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(padding)
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .padding(padding),
         ) {
             // ----------------------------------------------------------------
             // Device info card (always visible)
             // ----------------------------------------------------------------
             Card(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp, vertical = 4.dp),
-                shape  = RoundedCornerShape(12.dp),
-                colors = CardDefaults.cardColors(
-                    containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.4f)
-                )
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 4.dp),
+                shape = RoundedCornerShape(12.dp),
+                colors =
+                    CardDefaults.cardColors(
+                        containerColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.4f),
+                    ),
             ) {
                 Row(
                     modifier = Modifier.padding(12.dp),
-                    verticalAlignment = Alignment.CenterVertically
+                    verticalAlignment = Alignment.CenterVertically,
                 ) {
                     Icon(
                         Icons.Outlined.PhoneAndroid,
                         contentDescription = null,
-                        tint     = MaterialTheme.colorScheme.primary,
-                        modifier = Modifier.size(20.dp)
+                        tint = MaterialTheme.colorScheme.primary,
+                        modifier = Modifier.size(20.dp),
                     )
                     Spacer(Modifier.width(10.dp))
                     Text(
-                        text  = deviceInfo,
-                        style = MaterialTheme.typography.bodySmall.copy(
-                            fontFamily = FontFamily.Monospace,
-                            lineHeight = 18.sp
-                        ),
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                        text = deviceInfo,
+                        style =
+                            MaterialTheme.typography.bodySmall.copy(
+                                fontFamily = FontFamily.Monospace,
+                                lineHeight = 18.sp,
+                            ),
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
                 }
             }
@@ -235,28 +224,32 @@ fun DiagnosticsScreen(onNavigateBack: () -> Unit) {
             // ----------------------------------------------------------------
             TabRow(
                 selectedTabIndex = selectedTab,
-                containerColor   = MaterialTheme.colorScheme.background,
-                divider          = {
+                containerColor = MaterialTheme.colorScheme.background,
+                divider = {
                     HorizontalDivider(color = MaterialTheme.colorScheme.surfaceVariant)
-                }
+                },
             ) {
                 Tab(
                     selected = selectedTab == 0,
-                    onClick  = { selectedTab = 0 },
-                    text     = {
-                        Text(stringResource(R.string.diagnostics_tab_session),
-                            fontWeight = if (selectedTab == 0) FontWeight.Bold else FontWeight.Normal)
+                    onClick = { selectedTab = 0 },
+                    text = {
+                        Text(
+                            stringResource(R.string.diagnostics_tab_session),
+                            fontWeight = if (selectedTab == 0) FontWeight.Bold else FontWeight.Normal,
+                        )
                     },
-                    icon = { Icon(Icons.Outlined.BugReport, contentDescription = null, Modifier.size(16.dp)) }
+                    icon = { Icon(Icons.Outlined.BugReport, contentDescription = null, Modifier.size(16.dp)) },
                 )
                 Tab(
                     selected = selectedTab == 1,
-                    onClick  = { selectedTab = 1 },
-                    text     = {
-                        Text(stringResource(R.string.diagnostics_tab_crashes),
-                            fontWeight = if (selectedTab == 1) FontWeight.Bold else FontWeight.Normal)
+                    onClick = { selectedTab = 1 },
+                    text = {
+                        Text(
+                            stringResource(R.string.diagnostics_tab_crashes),
+                            fontWeight = if (selectedTab == 1) FontWeight.Bold else FontWeight.Normal,
+                        )
                     },
-                    icon = { Icon(Icons.Outlined.Warning, contentDescription = null, Modifier.size(16.dp)) }
+                    icon = { Icon(Icons.Outlined.Warning, contentDescription = null, Modifier.size(16.dp)) },
                 )
             }
 
@@ -264,28 +257,33 @@ fun DiagnosticsScreen(onNavigateBack: () -> Unit) {
             // Content area
             // ----------------------------------------------------------------
             Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(horizontal = 16.dp, vertical = 8.dp)
+                modifier =
+                    Modifier
+                        .fillMaxSize()
+                        .padding(horizontal = 16.dp, vertical = 8.dp),
             ) {
                 when {
                     // Session logs tab
-                    selectedTab == 0 && isLoadingLogs -> LoadingState()
+                    selectedTab == 0 && isLoadingLogs -> {
+                        LoadingState()
+                    }
 
                     selectedTab == 0 -> {
                         LogList(
-                            lines     = sessionLines,
-                            listState = listState
+                            lines = sessionLines,
+                            listState = listState,
                         )
                     }
 
                     // Crash reports tab
-                    selectedTab == 1 && isLoadingCrash -> LoadingState()
+                    selectedTab == 1 && isLoadingCrash -> {
+                        LoadingState()
+                    }
 
                     selectedTab == 1 -> {
                         CrashContent(
-                            text             = crashText,
-                            onClearRequest   = { showClearDialog = true }
+                            text = crashText,
+                            onClearRequest = { showClearDialog = true },
                         )
                     }
                 }
@@ -299,29 +297,43 @@ fun DiagnosticsScreen(onNavigateBack: () -> Unit) {
     if (showClearDialog) {
         AlertDialog(
             onDismissRequest = { showClearDialog = false },
-            icon  = { Icon(Icons.Outlined.DeleteForever, null,
-                tint = MaterialTheme.colorScheme.error) },
-            title = { Text(stringResource(R.string.diagnostics_clear_confirm_title),
-                fontWeight = FontWeight.Bold) },
-            text  = { Text(stringResource(R.string.diagnostics_clear_confirm_body),
-                style = MaterialTheme.typography.bodyMedium) },
+            icon = {
+                Icon(
+                    Icons.Outlined.DeleteForever,
+                    null,
+                    tint = MaterialTheme.colorScheme.error,
+                )
+            },
+            title = {
+                Text(
+                    stringResource(R.string.diagnostics_clear_confirm_title),
+                    fontWeight = FontWeight.Bold,
+                )
+            },
+            text = {
+                Text(
+                    stringResource(R.string.diagnostics_clear_confirm_body),
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+            },
             confirmButton = {
                 Button(
                     onClick = {
                         FlowDiagnostics.clearCrashLogs(context)
-                        crashText       = context.getString(R.string.ui_no_crash_logs)
+                        crashText = context.getString(R.string.ui_no_crash_logs)
                         showClearDialog = false
                     },
-                    colors = ButtonDefaults.buttonColors(
-                        containerColor = MaterialTheme.colorScheme.error
-                    )
+                    colors =
+                        ButtonDefaults.buttonColors(
+                            containerColor = MaterialTheme.colorScheme.error,
+                        ),
                 ) { Text(stringResource(R.string.clear)) }
             },
             dismissButton = {
                 TextButton(onClick = { showClearDialog = false }) {
                     Text(stringResource(R.string.cancel))
                 }
-            }
+            },
         )
     }
 }
@@ -337,8 +349,8 @@ private fun LoadingState() {
             CircularProgressIndicator()
             Spacer(Modifier.height(16.dp))
             Text(
-                text  = stringResource(R.string.diagnostics_loading),
-                color = MaterialTheme.colorScheme.onSurfaceVariant
+                text = stringResource(R.string.diagnostics_loading),
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         }
     }
@@ -348,7 +360,7 @@ private fun LoadingState() {
 @Composable
 private fun LogList(
     lines: List<String>,
-    listState: androidx.compose.foundation.lazy.LazyListState
+    listState: androidx.compose.foundation.lazy.LazyListState,
 ) {
     val surfaceColor = MaterialTheme.colorScheme.surface
 
@@ -358,34 +370,38 @@ private fun LogList(
     }
 
     // Pre-compute levels once so recomposition doesn't re-evaluate regexes
-    val parsed = remember(lines) {
-        lines.map { line -> Pair(line, detectLevel(line)) }
-    }
+    val parsed =
+        remember(lines) {
+            lines.map { line -> Pair(line, detectLevel(line)) }
+        }
 
     Card(
-        shape  = RoundedCornerShape(12.dp),
+        shape = RoundedCornerShape(12.dp),
         colors = CardDefaults.cardColors(containerColor = surfaceColor),
-        modifier = Modifier.fillMaxSize()
+        modifier = Modifier.fillMaxSize(),
     ) {
         LazyColumn(
-            state           = listState,
-            modifier        = Modifier
-                .fillMaxSize()
-                .padding(horizontal = 8.dp, vertical = 6.dp),
-            verticalArrangement = Arrangement.spacedBy(1.dp)
+            state = listState,
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .padding(horizontal = 8.dp, vertical = 6.dp),
+            verticalArrangement = Arrangement.spacedBy(1.dp),
         ) {
             itemsIndexed(parsed, key = { index, _ -> index }) { _, (line, level) ->
                 Text(
-                    text     = line,
-                    style    = MaterialTheme.typography.bodySmall.copy(
-                        fontFamily = FontFamily.Monospace,
-                        lineHeight = 16.sp,
-                        fontSize   = 11.sp
-                    ),
-                    color    = levelColor(level),
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .horizontalScroll(rememberScrollState())
+                    text = line,
+                    style =
+                        MaterialTheme.typography.bodySmall.copy(
+                            fontFamily = FontFamily.Monospace,
+                            lineHeight = 16.sp,
+                            fontSize = 11.sp,
+                        ),
+                    color = levelColor(level),
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .horizontalScroll(rememberScrollState()),
                 )
             }
         }
@@ -396,7 +412,7 @@ private fun LogList(
 @Composable
 private fun CrashContent(
     text: String,
-    onClearRequest: () -> Unit
+    onClearRequest: () -> Unit,
 ) {
     val noCrashes = text.isBlank() || text.trim() == "No crash logs"
 
@@ -406,44 +422,54 @@ private fun CrashContent(
                 Modifier
                     .weight(1f)
                     .fillMaxWidth(),
-                contentAlignment = Alignment.Center
+                contentAlignment = Alignment.Center,
             ) {
                 EmptyLogsState(stringResource(R.string.diagnostics_no_crashes))
             }
         } else {
             val lines = remember(text) { text.lines() }
             Card(
-                shape    = RoundedCornerShape(12.dp),
-                colors   = CardDefaults.cardColors(
-                    containerColor = MaterialTheme.colorScheme.surface
-                ),
-                modifier = Modifier
-                    .weight(1f)
-                    .fillMaxWidth()
+                shape = RoundedCornerShape(12.dp),
+                colors =
+                    CardDefaults.cardColors(
+                        containerColor = MaterialTheme.colorScheme.surface,
+                    ),
+                modifier =
+                    Modifier
+                        .weight(1f)
+                        .fillMaxWidth(),
             ) {
                 LazyColumn(
-                    modifier = Modifier
-                        .fillMaxSize()
-                        .padding(horizontal = 8.dp, vertical = 6.dp),
-                    verticalArrangement = Arrangement.spacedBy(1.dp)
+                    modifier =
+                        Modifier
+                            .fillMaxSize()
+                            .padding(horizontal = 8.dp, vertical = 6.dp),
+                    verticalArrangement = Arrangement.spacedBy(1.dp),
                 ) {
                     items(lines) { line ->
                         Text(
-                            text  = line,
-                            style = MaterialTheme.typography.bodySmall.copy(
-                                fontFamily = FontFamily.Monospace,
-                                lineHeight = 16.sp,
-                                fontSize   = 11.sp
-                            ),
-                            color = when {
-                                line.contains("Exception") || line.contains("CRASH") ->
-                                    Color(0xFFFF6B6B)
-                                line.startsWith("=") ->
-                                    MaterialTheme.colorScheme.primary
-                                else ->
-                                    MaterialTheme.colorScheme.onSurface.copy(alpha = 0.82f)
-                            },
-                            modifier = Modifier.fillMaxWidth()
+                            text = line,
+                            style =
+                                MaterialTheme.typography.bodySmall.copy(
+                                    fontFamily = FontFamily.Monospace,
+                                    lineHeight = 16.sp,
+                                    fontSize = 11.sp,
+                                ),
+                            color =
+                                when {
+                                    line.contains("Exception") || line.contains("CRASH") -> {
+                                        Color(0xFFFF6B6B)
+                                    }
+
+                                    line.startsWith("=") -> {
+                                        MaterialTheme.colorScheme.primary
+                                    }
+
+                                    else -> {
+                                        MaterialTheme.colorScheme.onSurface.copy(alpha = 0.82f)
+                                    }
+                                },
+                            modifier = Modifier.fillMaxWidth(),
                         )
                     }
                 }
@@ -452,14 +478,18 @@ private fun CrashContent(
             Spacer(Modifier.height(8.dp))
 
             OutlinedButton(
-                onClick  = onClearRequest,
+                onClick = onClearRequest,
                 modifier = Modifier.fillMaxWidth(),
-                colors   = ButtonDefaults.outlinedButtonColors(
-                    contentColor = MaterialTheme.colorScheme.error
-                )
+                colors =
+                    ButtonDefaults.outlinedButtonColors(
+                        contentColor = MaterialTheme.colorScheme.error,
+                    ),
             ) {
-                Icon(Icons.Outlined.DeleteForever, contentDescription = null,
-                    modifier = Modifier.size(18.dp))
+                Icon(
+                    Icons.Outlined.DeleteForever,
+                    contentDescription = null,
+                    modifier = Modifier.size(18.dp),
+                )
                 Spacer(Modifier.width(8.dp))
                 Text(stringResource(R.string.diagnostics_clear_crashes))
             }
@@ -471,19 +501,19 @@ private fun CrashContent(
 private fun EmptyLogsState(message: String) {
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
-        modifier            = Modifier.fillMaxWidth()
+        modifier = Modifier.fillMaxWidth(),
     ) {
         Icon(
-            imageVector      = Icons.Outlined.CheckCircle,
+            imageVector = Icons.Outlined.CheckCircle,
             contentDescription = null,
-            tint             = MaterialTheme.colorScheme.primary.copy(alpha = 0.6f),
-            modifier         = Modifier.size(48.dp)
+            tint = MaterialTheme.colorScheme.primary.copy(alpha = 0.6f),
+            modifier = Modifier.size(48.dp),
         )
         Spacer(Modifier.height(12.dp))
         Text(
-            text  = message,
+            text = message,
             style = MaterialTheme.typography.bodyMedium,
-            color = MaterialTheme.colorScheme.onSurfaceVariant
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
     }
 }

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/settings/DiscordSettingsScreen.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/settings/DiscordSettingsScreen.kt
@@ -55,6 +55,7 @@ import io.github.aedev.flow.discord.DiscordConnectionState
 import io.github.aedev.flow.discord.DiscordPresenceRuntime
 import io.github.aedev.flow.discord.DiscordSettingsState
 import io.github.aedev.flow.discord.DiscordSettingsSummary
+import io.github.aedev.flow.ui.components.layout.topbar.FlowTopBar
 import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -67,30 +68,19 @@ fun DiscordSettingsScreen(onNavigateBack: () -> Unit) {
     Scaffold(
         contentWindowInsets = WindowInsets(0.dp),
         topBar = {
-            TopAppBar(
-                title = { Text(stringResource(R.string.discord_presence_title)) },
-                navigationIcon = {
-                    IconButton(onClick = onNavigateBack) {
-                        Icon(
-                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = stringResource(R.string.btn_back),
-                        )
-                    }
-                },
-                colors = TopAppBarDefaults.topAppBarColors(
-                    containerColor = MaterialTheme.colorScheme.background,
-                    titleContentColor = MaterialTheme.colorScheme.onBackground,
-                ),
-                windowInsets = WindowInsets(0),
+            FlowTopBar(
+                title = stringResource(R.string.discord_presence_title),
+                onBack = onNavigateBack,
             )
         },
         containerColor = MaterialTheme.colorScheme.background,
     ) { innerPadding ->
         LazyColumn(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(innerPadding)
-                .background(MaterialTheme.colorScheme.background),
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .padding(innerPadding)
+                    .background(MaterialTheme.colorScheme.background),
             contentPadding = PaddingValues(16.dp),
             verticalArrangement = Arrangement.spacedBy(16.dp),
         ) {
@@ -125,12 +115,13 @@ fun DiscordSettingsScreen(onNavigateBack: () -> Unit) {
                             onUnlink = { scope.launch { DiscordPresenceRuntime.unlink() } },
                         )
 
-                        state.errorMessage?.takeIf {
-                            state.summary == DiscordSettingsSummary.ERROR || !state.isAvailable
-                        }?.let { error ->
-                            HorizontalDivider(Modifier.padding(start = 56.dp))
-                            DiscordErrorRow(error)
-                        }
+                        state.errorMessage
+                            ?.takeIf {
+                                state.summary == DiscordSettingsSummary.ERROR || !state.isAvailable
+                            }?.let { error ->
+                                HorizontalDivider(Modifier.padding(start = 56.dp))
+                                DiscordErrorRow(error)
+                            }
                     }
                 }
             }
@@ -199,9 +190,10 @@ private fun DiscordSettingsGroup(content: @Composable ColumnScope.() -> Unit) {
     Card(
         modifier = Modifier.fillMaxWidth(),
         shape = MaterialTheme.shapes.large,
-        colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surfaceContainer,
-        ),
+        colors =
+            CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.surfaceContainer,
+            ),
     ) {
         Column(content = content)
     }
@@ -213,13 +205,15 @@ private fun DiscordAccountRow(
     onConnect: () -> Unit,
     onUnlink: () -> Unit,
 ) {
-    val connectionPending = state.connectionState == DiscordConnectionState.LINKING ||
-        state.connectionState == DiscordConnectionState.CONNECTING
+    val connectionPending =
+        state.connectionState == DiscordConnectionState.LINKING ||
+            state.connectionState == DiscordConnectionState.CONNECTING
 
     Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(16.dp),
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Icon(
@@ -241,20 +235,26 @@ private fun DiscordAccountRow(
         }
 
         when {
-            connectionPending -> CircularProgressIndicator(
-                modifier = Modifier.size(24.dp),
-                strokeWidth = 2.dp,
-            )
-
-            state.accountName != null -> TextButton(onClick = onUnlink) {
-                Text(stringResource(R.string.discord_presence_unlink_action))
+            connectionPending -> {
+                CircularProgressIndicator(
+                    modifier = Modifier.size(24.dp),
+                    strokeWidth = 2.dp,
+                )
             }
 
-            state.isAvailable -> TextButton(
-                onClick = onConnect,
-                enabled = state.isEnabled,
-            ) {
-                Text(stringResource(R.string.discord_presence_connect_action))
+            state.accountName != null -> {
+                TextButton(onClick = onUnlink) {
+                    Text(stringResource(R.string.discord_presence_unlink_action))
+                }
+            }
+
+            state.isAvailable -> {
+                TextButton(
+                    onClick = onConnect,
+                    enabled = state.isEnabled,
+                ) {
+                    Text(stringResource(R.string.discord_presence_connect_action))
+                }
             }
         }
     }
@@ -263,9 +263,10 @@ private fun DiscordAccountRow(
 @Composable
 private fun DiscordErrorRow(message: String) {
     Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(16.dp),
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
         verticalAlignment = Alignment.Top,
     ) {
         Icon(
@@ -289,16 +290,18 @@ private fun DiscordInformationRow(
     body: String,
     isWarning: Boolean = false,
 ) {
-    val accentColor = if (isWarning) {
-        MaterialTheme.colorScheme.error
-    } else {
-        MaterialTheme.colorScheme.onSurfaceVariant
-    }
+    val accentColor =
+        if (isWarning) {
+            MaterialTheme.colorScheme.error
+        } else {
+            MaterialTheme.colorScheme.onSurfaceVariant
+        }
 
     Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(16.dp),
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
         verticalAlignment = Alignment.Top,
     ) {
         Icon(
@@ -323,22 +326,41 @@ private fun DiscordInformationRow(
 }
 
 @Composable
-fun discordSettingsSummaryText(state: DiscordSettingsState): String = when (state.summary) {
-    DiscordSettingsSummary.OFF -> stringResource(R.string.discord_presence_off)
-    DiscordSettingsSummary.NOT_CONNECTED -> stringResource(R.string.discord_presence_not_connected)
-    DiscordSettingsSummary.READY -> state.accountName?.let { account ->
-        stringResource(R.string.discord_presence_ready_as, account)
-    } ?: stringResource(R.string.discord_presence_ready)
-    DiscordSettingsSummary.CONNECTED -> state.accountName?.let { account ->
-        stringResource(R.string.discord_presence_connected_as, account)
-    } ?: stringResource(R.string.discord_presence_connected)
-    DiscordSettingsSummary.UNAVAILABLE -> stringResource(R.string.discord_presence_unavailable)
-    DiscordSettingsSummary.ERROR -> stringResource(R.string.discord_presence_connection_error)
-}
+fun discordSettingsSummaryText(state: DiscordSettingsState): String =
+    when (state.summary) {
+        DiscordSettingsSummary.OFF -> {
+            stringResource(R.string.discord_presence_off)
+        }
+
+        DiscordSettingsSummary.NOT_CONNECTED -> {
+            stringResource(R.string.discord_presence_not_connected)
+        }
+
+        DiscordSettingsSummary.READY -> {
+            state.accountName?.let { account ->
+                stringResource(R.string.discord_presence_ready_as, account)
+            } ?: stringResource(R.string.discord_presence_ready)
+        }
+
+        DiscordSettingsSummary.CONNECTED -> {
+            state.accountName?.let { account ->
+                stringResource(R.string.discord_presence_connected_as, account)
+            } ?: stringResource(R.string.discord_presence_connected)
+        }
+
+        DiscordSettingsSummary.UNAVAILABLE -> {
+            stringResource(R.string.discord_presence_unavailable)
+        }
+
+        DiscordSettingsSummary.ERROR -> {
+            stringResource(R.string.discord_presence_connection_error)
+        }
+    }
 
 @Composable
-private fun statusText(state: DiscordSettingsState): String = when (state.connectionState) {
-    DiscordConnectionState.LINKING -> stringResource(R.string.discord_presence_linking)
-    DiscordConnectionState.CONNECTING -> stringResource(R.string.discord_presence_connecting)
-    else -> discordSettingsSummaryText(state)
-}
+private fun statusText(state: DiscordSettingsState): String =
+    when (state.connectionState) {
+        DiscordConnectionState.LINKING -> stringResource(R.string.discord_presence_linking)
+        DiscordConnectionState.CONNECTING -> stringResource(R.string.discord_presence_connecting)
+        else -> discordSettingsSummaryText(state)
+    }

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/settings/DonationsScreen.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/settings/DonationsScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import io.github.aedev.flow.R
+import io.github.aedev.flow.ui.components.layout.topbar.FlowTopBar
 
 // Icon Ported from Mihon.
 private val IconPatreon: ImageVector by lazy {
@@ -66,19 +67,9 @@ fun DonationsScreen(
     Scaffold(
         contentWindowInsets = WindowInsets(0.dp),
         topBar = {
-            TopAppBar(
-                title = { Text(stringResource(R.string.support_donations_title)) },
-                navigationIcon = {
-                    IconButton(onClick = onNavigateBack) {
-                        Icon(Icons.Default.ArrowBack, stringResource(R.string.btn_back))
-                    }
-                },
-                colors =
-                    TopAppBarDefaults.topAppBarColors(
-                        containerColor = MaterialTheme.colorScheme.background,
-                        titleContentColor = MaterialTheme.colorScheme.onBackground,
-                    ),
-                windowInsets = WindowInsets(0),
+            FlowTopBar(
+                title = stringResource(R.string.support_donations_title),
+                onBack = onNavigateBack,
             )
         },
         containerColor = MaterialTheme.colorScheme.background,

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/settings/DownloadSettingsScreen.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/settings/DownloadSettingsScreen.kt
@@ -51,6 +51,7 @@ import io.github.aedev.flow.R
 import io.github.aedev.flow.data.local.PlayerPreferences
 import io.github.aedev.flow.data.local.VideoCodec
 import io.github.aedev.flow.data.local.VideoQuality
+import io.github.aedev.flow.ui.components.layout.topbar.FlowTopBar
 import kotlinx.coroutines.launch
 import java.io.File
 
@@ -294,25 +295,9 @@ fun DownloadSettingsScreen(onNavigateBack: () -> Unit) {
                 .fillMaxSize()
                 .background(MaterialTheme.colorScheme.background),
     ) {
-        TopAppBar(
-            title = {
-                Text(
-                    text = stringResource(R.string.download_settings_title),
-                    style = MaterialTheme.typography.titleLarge,
-                    fontWeight = FontWeight.Bold,
-                )
-            },
-            navigationIcon = {
-                IconButton(onClick = onNavigateBack) {
-                    Icon(Icons.AutoMirrored.Filled.ArrowBack, stringResource(R.string.btn_back))
-                }
-            },
-            colors =
-                TopAppBarDefaults.topAppBarColors(
-                    containerColor = MaterialTheme.colorScheme.background,
-                    titleContentColor = MaterialTheme.colorScheme.onBackground,
-                ),
-            windowInsets = WindowInsets(0.dp),
+        FlowTopBar(
+            title = stringResource(R.string.download_settings_title),
+            onBack = onNavigateBack,
         )
 
         LazyColumn(

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/settings/ExportDataScreen.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/settings/ExportDataScreen.kt
@@ -10,12 +10,12 @@ import androidx.compose.material.icons.outlined.Backup
 import androidx.compose.material.icons.outlined.History
 import androidx.compose.material.icons.outlined.Psychology
 import androidx.compose.material.icons.outlined.SaveAlt
-import androidx.compose.ui.res.painterResource
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
@@ -23,139 +23,147 @@ import androidx.compose.ui.unit.sp
 import io.github.aedev.flow.R
 import io.github.aedev.flow.data.local.BackupRepository
 import io.github.aedev.flow.data.recommendation.FlowNeuroEngine
+import io.github.aedev.flow.ui.components.layout.topbar.FlowTopBar
 import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun ExportDataScreen(
-    onNavigateBack: () -> Unit
-) {
+fun ExportDataScreen(onNavigateBack: () -> Unit) {
     val context = LocalContext.current
     val scope = rememberCoroutineScope()
     val backupRepo = remember { BackupRepository(context) }
 
-    val exportAppDataLauncher = rememberLauncherForActivityResult(
-        contract = ActivityResultContracts.CreateDocument("application/json")
-    ) { uri ->
-        uri?.let {
-            scope.launch {
-                val result = backupRepo.exportData(it)
-                android.widget.Toast.makeText(
-                    context,
-                    context.getString(
-                        if (result.isSuccess) R.string.settings_export_success
-                        else R.string.settings_export_failed
-                    ),
-                    android.widget.Toast.LENGTH_SHORT
-                ).show()
+    val exportAppDataLauncher =
+        rememberLauncherForActivityResult(
+            contract = ActivityResultContracts.CreateDocument("application/json"),
+        ) { uri ->
+            uri?.let {
+                scope.launch {
+                    val result = backupRepo.exportData(it)
+                    android.widget.Toast
+                        .makeText(
+                            context,
+                            context.getString(
+                                if (result.isSuccess) {
+                                    R.string.settings_export_success
+                                } else {
+                                    R.string.settings_export_failed
+                                },
+                            ),
+                            android.widget.Toast.LENGTH_SHORT,
+                        ).show()
+                }
             }
         }
-    }
 
-    val exportNewPipeSubscriptionsLauncher = rememberLauncherForActivityResult(
-        contract = ActivityResultContracts.CreateDocument("application/json")
-    ) { uri ->
-        uri?.let {
-            scope.launch {
-                val result = backupRepo.exportSubscriptionsAsNewPipe(it)
-                android.widget.Toast.makeText(
-                    context,
-                    context.getString(
-                        if (result.isSuccess) R.string.export_newpipe_subs_success
-                        else R.string.export_newpipe_subs_failed
-                    ),
-                    android.widget.Toast.LENGTH_SHORT
-                ).show()
+    val exportNewPipeSubscriptionsLauncher =
+        rememberLauncherForActivityResult(
+            contract = ActivityResultContracts.CreateDocument("application/json"),
+        ) { uri ->
+            uri?.let {
+                scope.launch {
+                    val result = backupRepo.exportSubscriptionsAsNewPipe(it)
+                    android.widget.Toast
+                        .makeText(
+                            context,
+                            context.getString(
+                                if (result.isSuccess) {
+                                    R.string.export_newpipe_subs_success
+                                } else {
+                                    R.string.export_newpipe_subs_failed
+                                },
+                            ),
+                            android.widget.Toast.LENGTH_SHORT,
+                        ).show()
+                }
             }
         }
-    }
 
-    val exportWatchHistoryLauncher = rememberLauncherForActivityResult(
-        contract = ActivityResultContracts.CreateDocument("application/json")
-    ) { uri ->
-        uri?.let {
-            scope.launch {
-                val result = backupRepo.exportWatchHistory(it)
-                android.widget.Toast.makeText(
-                    context,
-                    context.getString(
-                        if (result.isSuccess) R.string.settings_export_success
-                        else R.string.history_export_failed
-                    ),
-                    android.widget.Toast.LENGTH_SHORT
-                ).show()
+    val exportWatchHistoryLauncher =
+        rememberLauncherForActivityResult(
+            contract = ActivityResultContracts.CreateDocument("application/json"),
+        ) { uri ->
+            uri?.let {
+                scope.launch {
+                    val result = backupRepo.exportWatchHistory(it)
+                    android.widget.Toast
+                        .makeText(
+                            context,
+                            context.getString(
+                                if (result.isSuccess) {
+                                    R.string.settings_export_success
+                                } else {
+                                    R.string.history_export_failed
+                                },
+                            ),
+                            android.widget.Toast.LENGTH_SHORT,
+                        ).show()
+                }
             }
         }
-    }
 
-    val exportEngineLauncher = rememberLauncherForActivityResult(
-        contract = ActivityResultContracts.CreateDocument("application/json")
-    ) { uri ->
-        uri?.let {
-            scope.launch {
-                val success = context.contentResolver.openOutputStream(it)?.use { out ->
-                    FlowNeuroEngine.exportBrainToStream(out)
-                } ?: false
-                android.widget.Toast.makeText(
-                    context,
-                    context.getString(
-                        if (success) R.string.export_engine_success else R.string.export_engine_failed
-                    ),
-                    android.widget.Toast.LENGTH_SHORT
-                ).show()
+    val exportEngineLauncher =
+        rememberLauncherForActivityResult(
+            contract = ActivityResultContracts.CreateDocument("application/json"),
+        ) { uri ->
+            uri?.let {
+                scope.launch {
+                    val success =
+                        context.contentResolver.openOutputStream(it)?.use { out ->
+                            FlowNeuroEngine.exportBrainToStream(out)
+                        } ?: false
+                    android.widget.Toast
+                        .makeText(
+                            context,
+                            context.getString(
+                                if (success) R.string.export_engine_success else R.string.export_engine_failed,
+                            ),
+                            android.widget.Toast.LENGTH_SHORT,
+                        ).show()
+                }
             }
         }
-    }
 
-    val exportMasterLauncher = rememberLauncherForActivityResult(
-        contract = ActivityResultContracts.CreateDocument("application/zip")
-    ) { uri ->
-        uri?.let {
-            scope.launch {
-                val result = backupRepo.exportMasterBackup(it)
-                android.widget.Toast.makeText(
-                    context,
-                    context.getString(
-                        if (result.isSuccess) R.string.master_backup_export_success
-                        else R.string.master_backup_export_failed
-                    ),
-                    android.widget.Toast.LENGTH_SHORT
-                ).show()
+    val exportMasterLauncher =
+        rememberLauncherForActivityResult(
+            contract = ActivityResultContracts.CreateDocument("application/zip"),
+        ) { uri ->
+            uri?.let {
+                scope.launch {
+                    val result = backupRepo.exportMasterBackup(it)
+                    android.widget.Toast
+                        .makeText(
+                            context,
+                            context.getString(
+                                if (result.isSuccess) {
+                                    R.string.master_backup_export_success
+                                } else {
+                                    R.string.master_backup_export_failed
+                                },
+                            ),
+                            android.widget.Toast.LENGTH_SHORT,
+                        ).show()
+                }
             }
         }
-    }
 
     Scaffold(
         contentWindowInsets = WindowInsets(0.dp),
         topBar = {
-            Surface(
-                modifier = Modifier.fillMaxWidth(),
-                color = MaterialTheme.colorScheme.background
-            ) {
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 4.dp, vertical = 8.dp),
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    IconButton(onClick = onNavigateBack) {
-                        Icon(Icons.Default.ArrowBack, stringResource(R.string.btn_back))
-                    }
-                    Text(
-                        text = stringResource(R.string.export_data_screen_title),
-                        style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold)
-                    )
-                }
-            }
+            FlowTopBar(
+                title = stringResource(R.string.export_data_screen_title),
+                onBack = onNavigateBack,
+            )
         },
-        containerColor = MaterialTheme.colorScheme.background
+        containerColor = MaterialTheme.colorScheme.background,
     ) { paddingValues ->
         LazyColumn(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(paddingValues),
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .padding(paddingValues),
             contentPadding = PaddingValues(16.dp),
-            verticalArrangement = Arrangement.spacedBy(12.dp)
+            verticalArrangement = Arrangement.spacedBy(12.dp),
         ) {
             item {
                 Text(
@@ -164,13 +172,13 @@ fun ExportDataScreen(
                     fontWeight = FontWeight.ExtraBold,
                     color = MaterialTheme.colorScheme.primary,
                     letterSpacing = 0.5.sp,
-                    modifier = Modifier.padding(top = 8.dp, bottom = 4.dp)
+                    modifier = Modifier.padding(top = 8.dp, bottom = 4.dp),
                 )
                 Text(
                     text = stringResource(R.string.export_data_section_subtitle),
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    fontWeight = FontWeight.Medium
+                    fontWeight = FontWeight.Medium,
                 )
             }
 
@@ -182,7 +190,7 @@ fun ExportDataScreen(
                     containerColor = MaterialTheme.colorScheme.secondaryContainer,
                     onClick = {
                         exportAppDataLauncher.launch("flow_backup_${System.currentTimeMillis()}.json")
-                    }
+                    },
                 )
             }
 
@@ -194,7 +202,7 @@ fun ExportDataScreen(
                     containerColor = MaterialTheme.colorScheme.secondaryContainer,
                     onClick = {
                         exportNewPipeSubscriptionsLauncher.launch("newpipe_subscriptions_${System.currentTimeMillis()}.json")
-                    }
+                    },
                 )
             }
 
@@ -206,7 +214,7 @@ fun ExportDataScreen(
                     containerColor = MaterialTheme.colorScheme.secondaryContainer,
                     onClick = {
                         exportWatchHistoryLauncher.launch("flow-watch-history.json")
-                    }
+                    },
                 )
             }
 
@@ -218,7 +226,7 @@ fun ExportDataScreen(
                     containerColor = MaterialTheme.colorScheme.tertiaryContainer,
                     onClick = {
                         exportEngineLauncher.launch("flow_engine_${System.currentTimeMillis()}.json")
-                    }
+                    },
                 )
             }
 
@@ -230,7 +238,7 @@ fun ExportDataScreen(
                     containerColor = MaterialTheme.colorScheme.primaryContainer,
                     onClick = {
                         exportMasterLauncher.launch("flow_master_backup_${System.currentTimeMillis()}.zip")
-                    }
+                    },
                 )
             }
 

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/settings/ImportDataScreen.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/settings/ImportDataScreen.kt
@@ -42,6 +42,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import io.github.aedev.flow.R
 import io.github.aedev.flow.data.local.BackupRepository
 import io.github.aedev.flow.data.recommendation.FlowNeuroEngine
+import io.github.aedev.flow.ui.components.layout.topbar.FlowTopBar
 import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -252,27 +253,10 @@ fun ImportDataScreen(onNavigateBack: () -> Unit) {
     Scaffold(
         contentWindowInsets = WindowInsets(0.dp),
         topBar = {
-            Surface(
-                modifier = Modifier.fillMaxWidth(),
-                color = MaterialTheme.colorScheme.background,
-            ) {
-                Row(
-                    modifier =
-                        Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = 4.dp, vertical = 8.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    IconButton(onClick = onNavigateBack) {
-                        Icon(Icons.Default.ArrowBack, contentDescription = stringResource(R.string.btn_back))
-                    }
-                    Text(
-                        text = stringResource(R.string.import_data_title),
-                        style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
-                        modifier = Modifier.weight(1f),
-                    )
-                }
-            }
+            FlowTopBar(
+                title = stringResource(R.string.import_data_title),
+                onBack = onNavigateBack,
+            )
         },
         snackbarHost = { SnackbarHost(snackbarHostState) },
         containerColor = MaterialTheme.colorScheme.background,

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/settings/NotificationSettingsScreen.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/settings/NotificationSettingsScreen.kt
@@ -60,6 +60,7 @@ import io.github.aedev.flow.data.local.PlayerPreferences
 import io.github.aedev.flow.notification.BackgroundWorkPolicy
 import io.github.aedev.flow.notification.SubscriptionCheckWorker
 import io.github.aedev.flow.notification.UpdateCheckWorker
+import io.github.aedev.flow.ui.components.layout.topbar.FlowTopBar
 import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -114,26 +115,10 @@ fun NotificationSettingsScreen(onNavigateBack: () -> Unit) {
     Scaffold(
         contentWindowInsets = WindowInsets(0.dp),
         topBar = {
-            Surface(
-                modifier = Modifier.fillMaxWidth(),
-                color = MaterialTheme.colorScheme.background,
-            ) {
-                Row(
-                    modifier =
-                        Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = 4.dp, vertical = 8.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    IconButton(onClick = onNavigateBack) {
-                        Icon(Icons.Default.ArrowBack, stringResource(R.string.btn_back))
-                    }
-                    Text(
-                        text = stringResource(R.string.notif_settings_title),
-                        style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
-                    )
-                }
-            }
+            FlowTopBar(
+                title = stringResource(R.string.notif_settings_title),
+                onBack = onNavigateBack,
+            )
         },
     ) { paddingValues ->
         LazyColumn(

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/settings/PlayerAppearanceScreen.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/settings/PlayerAppearanceScreen.kt
@@ -47,6 +47,7 @@ import io.github.aedev.flow.data.local.SeekbarPaddingMode
 import io.github.aedev.flow.data.local.ShortsPlayerUiMode
 import io.github.aedev.flow.data.local.SliderStyle
 import io.github.aedev.flow.data.local.resolveSeekbarHorizontalPaddingDp
+import io.github.aedev.flow.ui.components.layout.topbar.FlowTopBar
 import io.github.aedev.flow.ui.components.rememberFlowSheetState
 import io.github.aedev.flow.ui.screens.music.player.components.PlayerSliderTrack
 import io.github.aedev.flow.ui.screens.music.player.components.SquigglySlider
@@ -292,26 +293,10 @@ fun PlayerAppearanceScreen(onNavigateBack: () -> Unit) {
     Scaffold(
         contentWindowInsets = WindowInsets(0.dp),
         topBar = {
-            Surface(
-                modifier = Modifier.fillMaxWidth(),
-                color = MaterialTheme.colorScheme.background,
-            ) {
-                Row(
-                    modifier =
-                        Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = 4.dp, vertical = 8.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    IconButton(onClick = onNavigateBack) {
-                        Icon(Icons.Default.ArrowBack, stringResource(R.string.btn_back))
-                    }
-                    Text(
-                        text = stringResource(R.string.player_appearance_title),
-                        style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
-                    )
-                }
-            }
+            FlowTopBar(
+                title = stringResource(R.string.player_appearance_title),
+                onBack = onNavigateBack,
+            )
         },
         containerColor = MaterialTheme.colorScheme.background,
     ) { paddingValues ->

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/settings/PlayerSettingsScreen.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/settings/PlayerSettingsScreen.kt
@@ -34,6 +34,7 @@ import io.github.aedev.flow.data.local.PlayerPreferences
 import io.github.aedev.flow.data.local.VideoCodec
 import io.github.aedev.flow.data.lyrics.LyricsProviderRegistry
 import io.github.aedev.flow.player.stream.CaptionTrackResolver
+import io.github.aedev.flow.ui.components.layout.topbar.FlowTopBar
 import io.github.aedev.flow.ui.components.rememberFlowSheetState
 import kotlinx.coroutines.launch
 
@@ -217,26 +218,10 @@ fun PlayerSettingsScreen(onNavigateBack: () -> Unit) {
     Scaffold(
         contentWindowInsets = WindowInsets(0.dp),
         topBar = {
-            Surface(
-                modifier = Modifier.fillMaxWidth(),
-                color = MaterialTheme.colorScheme.background,
-            ) {
-                Row(
-                    modifier =
-                        Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = 4.dp, vertical = 8.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    IconButton(onClick = onNavigateBack) {
-                        Icon(Icons.Default.ArrowBack, stringResource(R.string.btn_back))
-                    }
-                    Text(
-                        text = stringResource(R.string.player_settings_title),
-                        style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
-                    )
-                }
-            }
+            FlowTopBar(
+                title = stringResource(R.string.player_settings_title),
+                onBack = onNavigateBack,
+            )
         },
     ) { paddingValues ->
         LazyColumn(

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/settings/ProxySettingsScreen.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/settings/ProxySettingsScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
 import androidx.compose.material.icons.outlined.Info
@@ -50,13 +51,11 @@ import io.github.aedev.flow.R
 import io.github.aedev.flow.data.local.PlayerPreferences
 import io.github.aedev.flow.network.AppProxyConfig
 import io.github.aedev.flow.network.AppProxyType
+import io.github.aedev.flow.ui.components.layout.topbar.FlowTopBar
 import kotlinx.coroutines.launch
-import androidx.compose.foundation.text.KeyboardOptions
 
 @Composable
-fun ProxySettingsScreen(
-    onNavigateBack: () -> Unit
-) {
+fun ProxySettingsScreen(onNavigateBack: () -> Unit) {
     val context = LocalContext.current
     val coroutineScope = rememberCoroutineScope()
     val preferences = remember { PlayerPreferences(context) }
@@ -79,40 +78,26 @@ fun ProxySettingsScreen(
     Scaffold(
         contentWindowInsets = WindowInsets(0.dp),
         topBar = {
-            Surface(
-                modifier = Modifier.fillMaxWidth(),
-                color = MaterialTheme.colorScheme.background
-            ) {
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 4.dp, vertical = 8.dp),
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    IconButton(onClick = onNavigateBack) {
-                        Icon(Icons.Default.ArrowBack, stringResource(R.string.btn_back))
-                    }
-                    Text(
-                        text = stringResource(R.string.proxy_settings_title),
-                        style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold)
-                    )
-                }
-            }
-        }
+            FlowTopBar(
+                title = stringResource(R.string.proxy_settings_title),
+                onBack = onNavigateBack,
+            )
+        },
     ) { paddingValues ->
         LazyColumn(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(paddingValues)
-                .background(MaterialTheme.colorScheme.background),
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .padding(paddingValues)
+                    .background(MaterialTheme.colorScheme.background),
             contentPadding = PaddingValues(16.dp),
-            verticalArrangement = Arrangement.spacedBy(16.dp)
+            verticalArrangement = Arrangement.spacedBy(16.dp),
         ) {
             item {
                 Text(
                     text = stringResource(R.string.proxy_settings_description),
                     style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
                 )
             }
 
@@ -123,20 +108,21 @@ fun ProxySettingsScreen(
                         title = stringResource(R.string.proxy_settings_enabled),
                         subtitle = stringResource(R.string.proxy_settings_enabled_subtitle),
                         checked = enabled,
-                        onCheckedChange = { enabled = it }
+                        onCheckedChange = { enabled = it },
                     )
                     HorizontalDivider(
                         Modifier.padding(start = 56.dp),
-                        color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
+                        color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f),
                     )
                     SettingsItem(
                         icon = Icons.Outlined.Router,
                         title = stringResource(R.string.proxy_settings_type),
-                        subtitle = when (type) {
-                            AppProxyType.HTTP -> stringResource(R.string.proxy_type_http)
-                            AppProxyType.SOCKS5 -> stringResource(R.string.proxy_type_socks5)
-                        },
-                        onClick = { showTypeDialog = true }
+                        subtitle =
+                            when (type) {
+                                AppProxyType.HTTP -> stringResource(R.string.proxy_type_http)
+                                AppProxyType.SOCKS5 -> stringResource(R.string.proxy_type_socks5)
+                            },
+                        onClick = { showTypeDialog = true },
                     )
                 }
             }
@@ -151,14 +137,14 @@ fun ProxySettingsScreen(
                             label = { Text(stringResource(R.string.proxy_settings_host)) },
                             singleLine = true,
                             isError = hostError,
-                            leadingIcon = { Icon(Icons.Outlined.Public, contentDescription = null) }
+                            leadingIcon = { Icon(Icons.Outlined.Public, contentDescription = null) },
                         )
                         if (hostError) {
                             Text(
                                 text = stringResource(R.string.proxy_settings_invalid_host),
                                 style = MaterialTheme.typography.bodySmall,
                                 color = MaterialTheme.colorScheme.error,
-                                modifier = Modifier.padding(top = 4.dp)
+                                modifier = Modifier.padding(top = 4.dp),
                             )
                         }
 
@@ -172,14 +158,14 @@ fun ProxySettingsScreen(
                             singleLine = true,
                             isError = portError,
                             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
-                            leadingIcon = { Icon(Icons.Outlined.Tag, contentDescription = null) }
+                            leadingIcon = { Icon(Icons.Outlined.Tag, contentDescription = null) },
                         )
                         if (portError) {
                             Text(
                                 text = stringResource(R.string.proxy_settings_invalid_port),
                                 style = MaterialTheme.typography.bodySmall,
                                 color = MaterialTheme.colorScheme.error,
-                                modifier = Modifier.padding(top = 4.dp)
+                                modifier = Modifier.padding(top = 4.dp),
                             )
                         }
 
@@ -191,7 +177,7 @@ fun ProxySettingsScreen(
                             modifier = Modifier.fillMaxWidth(),
                             label = { Text(stringResource(R.string.proxy_settings_username)) },
                             singleLine = true,
-                            leadingIcon = { Icon(Icons.Outlined.Public, contentDescription = null) }
+                            leadingIcon = { Icon(Icons.Outlined.Public, contentDescription = null) },
                         )
 
                         Spacer(modifier = Modifier.height(12.dp))
@@ -203,7 +189,7 @@ fun ProxySettingsScreen(
                             label = { Text(stringResource(R.string.proxy_settings_password)) },
                             singleLine = true,
                             visualTransformation = PasswordVisualTransformation(),
-                            leadingIcon = { Icon(Icons.Outlined.Lock, contentDescription = null) }
+                            leadingIcon = { Icon(Icons.Outlined.Lock, contentDescription = null) },
                         )
 
                         Spacer(modifier = Modifier.height(12.dp))
@@ -211,7 +197,7 @@ fun ProxySettingsScreen(
                         Text(
                             text = stringResource(R.string.proxy_settings_optional_auth),
                             style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
                         )
                     }
                 }
@@ -221,18 +207,18 @@ fun ProxySettingsScreen(
                 SettingsGroup {
                     Row(
                         modifier = Modifier.padding(16.dp),
-                        verticalAlignment = Alignment.Top
+                        verticalAlignment = Alignment.Top,
                     ) {
                         Icon(
                             imageVector = Icons.Outlined.Info,
                             contentDescription = null,
-                            tint = MaterialTheme.colorScheme.onSurfaceVariant
+                            tint = MaterialTheme.colorScheme.onSurfaceVariant,
                         )
                         Text(
                             text = stringResource(R.string.proxy_settings_restart_notice),
                             style = MaterialTheme.typography.bodyMedium,
                             color = MaterialTheme.colorScheme.onSurfaceVariant,
-                            modifier = Modifier.padding(start = 16.dp)
+                            modifier = Modifier.padding(start = 16.dp),
                         )
                     }
                 }
@@ -250,18 +236,19 @@ fun ProxySettingsScreen(
                                     host = host,
                                     port = parsedPort ?: savedConfig.port,
                                     username = username,
-                                    password = password
-                                )
+                                    password = password,
+                                ),
                             )
-                            Toast.makeText(
-                                context,
-                                context.getString(R.string.proxy_settings_saved),
-                                Toast.LENGTH_SHORT
-                            ).show()
+                            Toast
+                                .makeText(
+                                    context,
+                                    context.getString(R.string.proxy_settings_saved),
+                                    Toast.LENGTH_SHORT,
+                                ).show()
                         }
                     },
                     enabled = canSave,
-                    modifier = Modifier.fillMaxWidth()
+                    modifier = Modifier.fillMaxWidth(),
                 ) {
                     Text(text = stringResource(R.string.btn_save))
                 }
@@ -294,7 +281,7 @@ fun ProxySettingsScreen(
                 TextButton(onClick = { showTypeDialog = false }) {
                     Text(stringResource(R.string.btn_cancel))
                 }
-            }
+            },
         )
     }
 }

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/settings/SearchHistorySettingsScreen.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/settings/SearchHistorySettingsScreen.kt
@@ -14,21 +14,24 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.res.stringResource
 import io.github.aedev.flow.R
+import io.github.aedev.flow.ui.components.layout.topbar.FlowTopBar
 import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun SearchHistorySettingsScreen(
-    onNavigateBack: () -> Unit
-) {
+fun SearchHistorySettingsScreen(onNavigateBack: () -> Unit) {
     val context = LocalContext.current
     val coroutineScope = rememberCoroutineScope()
-    val searchHistoryRepo = remember { io.github.aedev.flow.data.local.SearchHistoryRepository(context) }
-    
+    val searchHistoryRepo =
+        remember {
+            io.github.aedev.flow.data.local
+                .SearchHistoryRepository(context)
+        }
+
     // Search settings states
     val searchHistoryEnabled by searchHistoryRepo.isSearchHistoryEnabledFlow().collectAsState(initial = true)
     val searchSuggestionsEnabled by searchHistoryRepo.isSearchSuggestionsEnabledFlow().collectAsState(initial = true)
@@ -43,34 +46,20 @@ fun SearchHistorySettingsScreen(
     Scaffold(
         contentWindowInsets = WindowInsets(0.dp),
         topBar = {
-            Surface(
-                modifier = Modifier.fillMaxWidth(),
-                color = MaterialTheme.colorScheme.background
-            ) {
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 4.dp, vertical = 8.dp),
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    IconButton(onClick = onNavigateBack) {
-                        Icon(Icons.Default.ArrowBack, stringResource(R.string.btn_back))
-                    }
-                    Text(
-                        text = stringResource(R.string.search_history_title),
-                        style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold)
-                    )
-                }
-            }
-        }
+            FlowTopBar(
+                title = stringResource(R.string.search_history_title),
+                onBack = onNavigateBack,
+            )
+        },
     ) { paddingValues ->
         LazyColumn(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(paddingValues)
-                .background(MaterialTheme.colorScheme.background),
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .padding(paddingValues)
+                    .background(MaterialTheme.colorScheme.background),
             contentPadding = PaddingValues(16.dp),
-            verticalArrangement = Arrangement.spacedBy(16.dp)
+            verticalArrangement = Arrangement.spacedBy(16.dp),
         ) {
             item {
                 SettingsGroup {
@@ -79,7 +68,7 @@ fun SearchHistorySettingsScreen(
                         title = stringResource(R.string.save_search_history_title),
                         subtitle = stringResource(R.string.save_searches_subtitle),
                         checked = searchHistoryEnabled,
-                        onCheckedChange = { coroutineScope.launch { searchHistoryRepo.setSearchHistoryEnabled(it) } }
+                        onCheckedChange = { coroutineScope.launch { searchHistoryRepo.setSearchHistoryEnabled(it) } },
                     )
                     HorizontalDivider(Modifier.padding(start = 56.dp), color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f))
                     SettingsSwitchItem(
@@ -87,40 +76,51 @@ fun SearchHistorySettingsScreen(
                         title = stringResource(R.string.search_suggestions_title),
                         subtitle = stringResource(R.string.show_suggestions_subtitle),
                         checked = searchSuggestionsEnabled,
-                        onCheckedChange = { coroutineScope.launch { searchHistoryRepo.setSearchSuggestionsEnabled(it) } }
+                        onCheckedChange = { coroutineScope.launch { searchHistoryRepo.setSearchSuggestionsEnabled(it) } },
                     )
                     HorizontalDivider(Modifier.padding(start = 56.dp), color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f))
                     SettingsItem(
                         icon = Icons.Outlined.Storage,
                         title = stringResource(R.string.max_history_size_title),
                         subtitle = stringResource(R.string.currently_searches_template, maxHistorySize),
-                        onClick = { showHistorySizeDialog = true }
+                        onClick = { showHistorySizeDialog = true },
                     )
                     HorizontalDivider(Modifier.padding(start = 56.dp), color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f))
                     SettingsSwitchItem(
                         icon = Icons.Outlined.AutoDelete,
                         title = stringResource(R.string.auto_delete_history_title),
-                        subtitle = if (autoDeleteHistory) stringResource(R.string.delete_after_days_template, historyRetentionDays) else stringResource(R.string.never_delete_automatically),
+                        subtitle =
+                            if (autoDeleteHistory) {
+                                stringResource(
+                                    R.string.delete_after_days_template,
+                                    historyRetentionDays,
+                                )
+                            } else {
+                                stringResource(R.string.never_delete_automatically)
+                            },
                         checked = autoDeleteHistory,
-                        onCheckedChange = { coroutineScope.launch { searchHistoryRepo.setAutoDeleteHistory(it) } }
+                        onCheckedChange = { coroutineScope.launch { searchHistoryRepo.setAutoDeleteHistory(it) } },
                     )
-                    
+
                     if (autoDeleteHistory) {
-                        HorizontalDivider(Modifier.padding(start = 56.dp), color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f))
+                        HorizontalDivider(
+                            Modifier.padding(start = 56.dp),
+                            color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f),
+                        )
                         SettingsItem(
                             icon = Icons.Outlined.Schedule,
                             title = stringResource(R.string.retention_period_title),
                             subtitle = stringResource(R.string.delete_older_than_template, historyRetentionDays),
-                            onClick = { showRetentionDaysDialog = true }
+                            onClick = { showRetentionDaysDialog = true },
                         )
                     }
-                    
+
                     HorizontalDivider(Modifier.padding(start = 56.dp), color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f))
                     SettingsItem(
                         icon = Icons.Outlined.ManageSearch,
                         title = stringResource(R.string.clear_history_item_title),
                         subtitle = stringResource(R.string.remove_all_queries),
-                        onClick = { showClearSearchDialog = true }
+                        onClick = { showClearSearchDialog = true },
                     )
                 }
             }
@@ -132,15 +132,20 @@ fun SearchHistorySettingsScreen(
         SimpleConfirmDialog(
             title = stringResource(R.string.clear_history_dialog_title),
             text = stringResource(R.string.clear_history_dialog_text),
-            onConfirm = { coroutineScope.launch { searchHistoryRepo.clearSearchHistory(); showClearSearchDialog = false } },
-            onDismiss = { showClearSearchDialog = false }
+            onConfirm = {
+                coroutineScope.launch {
+                    searchHistoryRepo.clearSearchHistory()
+                    showClearSearchDialog = false
+                }
+            },
+            onDismiss = { showClearSearchDialog = false },
         )
     }
 
-     // Max History Size Dialog
+    // Max History Size Dialog
     if (showHistorySizeDialog) {
         var selectedSize by remember { mutableIntStateOf(maxHistorySize) }
-        
+
         AlertDialog(
             onDismissRequest = { showHistorySizeDialog = false },
             icon = { Icon(Icons.Outlined.Storage, contentDescription = null) },
@@ -150,12 +155,13 @@ fun SearchHistorySettingsScreen(
                     Text(stringResource(R.string.choose_history_size))
                     listOf(25, 50, 100, 200, 500).forEach { size ->
                         Row(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .clip(RoundedCornerShape(8.dp))
-                                .clickable { selectedSize = size }
-                                .padding(12.dp),
-                            verticalAlignment = Alignment.CenterVertically
+                            modifier =
+                                Modifier
+                                    .fillMaxWidth()
+                                    .clip(RoundedCornerShape(8.dp))
+                                    .clickable { selectedSize = size }
+                                    .padding(12.dp),
+                            verticalAlignment = Alignment.CenterVertically,
                         ) {
                             RadioButton(selected = selectedSize == size, onClick = { selectedSize = size })
                             Spacer(Modifier.width(8.dp))
@@ -166,17 +172,20 @@ fun SearchHistorySettingsScreen(
             },
             confirmButton = {
                 TextButton(onClick = {
-                    coroutineScope.launch { searchHistoryRepo.setMaxHistorySize(selectedSize); showHistorySizeDialog = false }
+                    coroutineScope.launch {
+                        searchHistoryRepo.setMaxHistorySize(selectedSize)
+                        showHistorySizeDialog = false
+                    }
                 }) { Text(stringResource(R.string.save)) }
             },
-            dismissButton = { TextButton(onClick = { showHistorySizeDialog = false }) { Text(stringResource(R.string.cancel)) } }
+            dismissButton = { TextButton(onClick = { showHistorySizeDialog = false }) { Text(stringResource(R.string.cancel)) } },
         )
     }
-    
+
     // Retention Days Dialog
     if (showRetentionDaysDialog) {
         var selectedDays by remember { mutableIntStateOf(historyRetentionDays) }
-        
+
         AlertDialog(
             onDismissRequest = { showRetentionDaysDialog = false },
             icon = { Icon(Icons.Outlined.Schedule, contentDescription = null) },
@@ -186,33 +195,39 @@ fun SearchHistorySettingsScreen(
                     Text(stringResource(R.string.delete_searches_older_than))
                     listOf(7, 30, 90, 180, 365).forEach { days ->
                         Row(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .clip(RoundedCornerShape(8.dp))
-                                .clickable { selectedDays = days }
-                                .padding(12.dp),
-                            verticalAlignment = Alignment.CenterVertically
+                            modifier =
+                                Modifier
+                                    .fillMaxWidth()
+                                    .clip(RoundedCornerShape(8.dp))
+                                    .clickable { selectedDays = days }
+                                    .padding(12.dp),
+                            verticalAlignment = Alignment.CenterVertically,
                         ) {
                             RadioButton(selected = selectedDays == days, onClick = { selectedDays = days })
                             Spacer(Modifier.width(8.dp))
-                            Text(when (days) {
-                                7 -> stringResource(R.string.period_one_week)
-                                30 -> stringResource(R.string.period_one_month)
-                                90 -> stringResource(R.string.period_three_months)
-                                180 -> stringResource(R.string.period_six_months)
-                                365 -> stringResource(R.string.period_one_year)
-                                else -> stringResource(R.string.days_count_template, days)
-                            })
+                            Text(
+                                when (days) {
+                                    7 -> stringResource(R.string.period_one_week)
+                                    30 -> stringResource(R.string.period_one_month)
+                                    90 -> stringResource(R.string.period_three_months)
+                                    180 -> stringResource(R.string.period_six_months)
+                                    365 -> stringResource(R.string.period_one_year)
+                                    else -> stringResource(R.string.days_count_template, days)
+                                },
+                            )
                         }
                     }
                 }
             },
             confirmButton = {
                 TextButton(onClick = {
-                    coroutineScope.launch { searchHistoryRepo.setHistoryRetentionDays(selectedDays); showRetentionDaysDialog = false }
+                    coroutineScope.launch {
+                        searchHistoryRepo.setHistoryRetentionDays(selectedDays)
+                        showRetentionDaysDialog = false
+                    }
                 }) { Text(stringResource(R.string.save)) }
             },
-            dismissButton = { TextButton(onClick = { showRetentionDaysDialog = false }) { Text(stringResource(R.string.cancel)) } }
+            dismissButton = { TextButton(onClick = { showRetentionDaysDialog = false }) { Text(stringResource(R.string.cancel)) } },
         )
     }
 }

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/settings/SettingsScreen.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/settings/SettingsScreen.kt
@@ -58,6 +58,8 @@ import io.github.aedev.flow.discord.DiscordPresenceRuntime
 import io.github.aedev.flow.network.AppProxyManager
 import io.github.aedev.flow.platform.AppUiMode
 import io.github.aedev.flow.player.DeepFlowManager
+import io.github.aedev.flow.ui.components.layout.topbar.FlowSearchTopBar
+import io.github.aedev.flow.ui.components.layout.topbar.FlowTopBar
 import io.github.aedev.flow.ui.theme.ThemeMode
 import io.github.aedev.flow.ui.theme.extendedColors
 import io.github.aedev.flow.utils.AppLanguageManager
@@ -177,10 +179,6 @@ fun SettingsScreen(
     // Search state
     var searchQuery by remember { mutableStateOf("") }
     var isSearchActive by remember { mutableStateOf(false) }
-    val searchFocusRequester = remember { FocusRequester() }
-    LaunchedEffect(isSearchActive) {
-        if (isSearchActive) runCatching { searchFocusRequester.requestFocus() }
-    }
     BackHandler(enabled = isSearchActive) {
         isSearchActive = false
         searchQuery = ""
@@ -487,68 +485,26 @@ fun SettingsScreen(
     Scaffold(
         contentWindowInsets = WindowInsets(0.dp),
         topBar = {
-            Surface(
-                modifier = Modifier.fillMaxWidth(),
-                color = MaterialTheme.colorScheme.background,
-            ) {
-                if (isSearchActive) {
-                    Row(
-                        modifier =
-                            Modifier
-                                .fillMaxWidth()
-                                .padding(horizontal = 4.dp, vertical = 8.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        IconButton(onClick = {
-                            isSearchActive = false
-                            searchQuery = ""
-                        }) {
-                            Icon(Icons.Default.ArrowBack, "Close search")
-                        }
-                        OutlinedTextField(
-                            value = searchQuery,
-                            onValueChange = { searchQuery = it },
-                            modifier =
-                                Modifier
-                                    .weight(1f)
-                                    .focusRequester(searchFocusRequester),
-                            placeholder = { Text(stringResource(R.string.ui_search_settings)) },
-                            singleLine = true,
-                            keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
-                            keyboardActions = KeyboardActions(onSearch = {}),
-                            colors =
-                                OutlinedTextFieldDefaults.colors(
-                                    focusedBorderColor = Color.Transparent,
-                                    unfocusedBorderColor = Color.Transparent,
-                                ),
-                        )
-                        if (searchQuery.isNotEmpty()) {
-                            IconButton(onClick = { searchQuery = "" }) {
-                                Icon(Icons.Outlined.Close, "Clear search")
-                            }
-                        }
-                    }
-                } else {
-                    Row(
-                        modifier =
-                            Modifier
-                                .fillMaxWidth()
-                                .padding(horizontal = 4.dp, vertical = 8.dp),
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        IconButton(onClick = onNavigateBack) {
-                            Icon(Icons.Default.ArrowBack, stringResource(R.string.btn_back))
-                        }
-                        Text(
-                            text = stringResource(R.string.settings_title),
-                            style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
-                            modifier = Modifier.weight(1f),
-                        )
+            if (isSearchActive) {
+                FlowSearchTopBar(
+                    query = searchQuery,
+                    onQueryChange = { searchQuery = it },
+                    onClose = {
+                        isSearchActive = false
+                        searchQuery = ""
+                    },
+                    placeholder = stringResource(R.string.ui_search_settings),
+                )
+            } else {
+                FlowTopBar(
+                    title = stringResource(R.string.settings_title),
+                    onBack = onNavigateBack,
+                    actions = {
                         IconButton(onClick = { isSearchActive = true }) {
                             Icon(Icons.Outlined.Search, stringResource(R.string.ui_search_settings))
                         }
-                    }
-                }
+                    },
+                )
             }
         },
         modifier = modifier,

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/settings/ShortsVideoQualitySettingsScreen.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/settings/ShortsVideoQualitySettingsScreen.kt
@@ -17,6 +17,7 @@ import androidx.compose.ui.unit.dp
 import io.github.aedev.flow.R
 import io.github.aedev.flow.data.local.PlayerPreferences
 import io.github.aedev.flow.data.local.VideoQuality
+import io.github.aedev.flow.ui.components.layout.topbar.FlowTopBar
 import kotlinx.coroutines.launch
 
 @Composable
@@ -42,26 +43,10 @@ fun ShortsVideoQualitySettingsScreen(onNavigateBack: () -> Unit) {
     Scaffold(
         contentWindowInsets = WindowInsets(0.dp),
         topBar = {
-            Surface(
-                modifier = Modifier.fillMaxWidth(),
-                color = MaterialTheme.colorScheme.background,
-            ) {
-                Row(
-                    modifier =
-                        Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = 4.dp, vertical = 8.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    IconButton(onClick = onNavigateBack) {
-                        Icon(Icons.Default.ArrowBack, stringResource(R.string.btn_back))
-                    }
-                    Text(
-                        text = stringResource(R.string.shorts_quality_settings_title),
-                        style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
-                    )
-                }
-            }
+            FlowTopBar(
+                title = stringResource(R.string.shorts_quality_settings_title),
+                onBack = onNavigateBack,
+            )
         },
     ) { paddingValues ->
         LazyColumn(

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/settings/SponsorBlockSettingsScreen.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/settings/SponsorBlockSettingsScreen.kt
@@ -29,25 +29,25 @@ import androidx.compose.ui.window.Dialog
 import io.github.aedev.flow.R
 import io.github.aedev.flow.data.local.PlayerPreferences
 import io.github.aedev.flow.data.local.SponsorBlockAction
+import io.github.aedev.flow.ui.components.layout.topbar.FlowTopBar
 import kotlinx.coroutines.launch
 
-private val SB_CATEGORIES_AND_LABELS = listOf(
-    "sponsor"          to R.string.sb_category_sponsor,
-    "intro"            to R.string.sb_category_intro,
-    "outro"            to R.string.sb_category_outro,
-    "selfpromo"        to R.string.sb_category_selfpromo,
-    "interaction"      to R.string.sb_category_interaction,
-    "music_offtopic"   to R.string.sb_category_music_offtopic,
-    "filler"           to R.string.sb_category_filler,
-    "preview"          to R.string.sb_category_preview,
-    "exclusive_access" to R.string.sb_category_exclusive_access
-)
+private val SB_CATEGORIES_AND_LABELS =
+    listOf(
+        "sponsor" to R.string.sb_category_sponsor,
+        "intro" to R.string.sb_category_intro,
+        "outro" to R.string.sb_category_outro,
+        "selfpromo" to R.string.sb_category_selfpromo,
+        "interaction" to R.string.sb_category_interaction,
+        "music_offtopic" to R.string.sb_category_music_offtopic,
+        "filler" to R.string.sb_category_filler,
+        "preview" to R.string.sb_category_preview,
+        "exclusive_access" to R.string.sb_category_exclusive_access,
+    )
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class)
 @Composable
-fun SponsorBlockSettingsScreen(
-    onNavigateBack: () -> Unit
-) {
+fun SponsorBlockSettingsScreen(onNavigateBack: () -> Unit) {
     val context = LocalContext.current
     val coroutineScope = rememberCoroutineScope()
     val playerPreferences = remember { PlayerPreferences(context) }
@@ -57,12 +57,14 @@ fun SponsorBlockSettingsScreen(
     val deArrowBadgeEnabled by playerPreferences.deArrowBadgeEnabled.collectAsState(initial = false)
     val rytdEnabled by playerPreferences.rytdEnabled.collectAsState(initial = true)
 
-    val sbActions = SB_CATEGORIES_AND_LABELS.associate { (category, _) ->
-        category to playerPreferences.sbActionForCategory(category).collectAsState(initial = SponsorBlockAction.SKIP).value
-    }
-    val sbColors = SB_CATEGORIES_AND_LABELS.associate { (category, _) ->
-        category to playerPreferences.sbColorForCategory(category).collectAsState(initial = null).value
-    }
+    val sbActions =
+        SB_CATEGORIES_AND_LABELS.associate { (category, _) ->
+            category to playerPreferences.sbActionForCategory(category).collectAsState(initial = SponsorBlockAction.SKIP).value
+        }
+    val sbColors =
+        SB_CATEGORIES_AND_LABELS.associate { (category, _) ->
+            category to playerPreferences.sbColorForCategory(category).collectAsState(initial = null).value
+        }
 
     val sbSubmitEnabled by playerPreferences.sbSubmitEnabled.collectAsState(initial = false)
     val sbUserId by playerPreferences.sbUserId.collectAsState(initial = null)
@@ -72,35 +74,21 @@ fun SponsorBlockSettingsScreen(
     Scaffold(
         contentWindowInsets = WindowInsets(0.dp),
         topBar = {
-            Surface(
-                modifier = Modifier.fillMaxWidth(),
-                color = MaterialTheme.colorScheme.background
-            ) {
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = 4.dp, vertical = 8.dp),
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    IconButton(onClick = onNavigateBack) {
-                        Icon(Icons.Default.ArrowBack, stringResource(R.string.btn_back))
-                    }
-                    Text(
-                        text = stringResource(R.string.sb_settings_title),
-                        style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold)
-                    )
-                }
-            }
+            FlowTopBar(
+                title = stringResource(R.string.sb_settings_title),
+                onBack = onNavigateBack,
+            )
         },
-        containerColor = MaterialTheme.colorScheme.background
+        containerColor = MaterialTheme.colorScheme.background,
     ) { paddingValues ->
         LazyColumn(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(paddingValues)
-                .background(MaterialTheme.colorScheme.background),
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .padding(paddingValues)
+                    .background(MaterialTheme.colorScheme.background),
             contentPadding = PaddingValues(16.dp),
-            verticalArrangement = Arrangement.spacedBy(16.dp)
+            verticalArrangement = Arrangement.spacedBy(16.dp),
         ) {
             item { SectionHeader(text = stringResource(R.string.sb_settings_general_header)) }
 
@@ -111,40 +99,40 @@ fun SponsorBlockSettingsScreen(
                         title = stringResource(R.string.player_settings_sponsorblock),
                         subtitle = stringResource(R.string.player_settings_sponsorblock_subtitle),
                         checked = sponsorBlockEnabled,
-                        onCheckedChange = { coroutineScope.launch { playerPreferences.setSponsorBlockEnabled(it) } }
+                        onCheckedChange = { coroutineScope.launch { playerPreferences.setSponsorBlockEnabled(it) } },
                     )
                     HorizontalDivider(
                         Modifier.padding(start = 56.dp),
-                        color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
+                        color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f),
                     )
                     SettingsSwitchItem(
                         icon = Icons.Outlined.AutoFixHigh,
                         title = stringResource(R.string.player_settings_dearrow),
                         subtitle = stringResource(R.string.player_settings_dearrow_subtitle),
                         checked = deArrowEnabled,
-                        onCheckedChange = { coroutineScope.launch { playerPreferences.setDeArrowEnabled(it) } }
+                        onCheckedChange = { coroutineScope.launch { playerPreferences.setDeArrowEnabled(it) } },
                     )
                     HorizontalDivider(
                         Modifier.padding(start = 56.dp),
-                        color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
+                        color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f),
                     )
                     SettingsSwitchItem(
                         icon = Icons.Outlined.AutoFixHigh,
                         title = stringResource(R.string.dearrow_badge_toggle),
                         subtitle = stringResource(R.string.dearrow_badge_toggle_subtitle),
                         checked = deArrowBadgeEnabled,
-                        onCheckedChange = { coroutineScope.launch { playerPreferences.setDeArrowBadgeEnabled(it) } }
+                        onCheckedChange = { coroutineScope.launch { playerPreferences.setDeArrowBadgeEnabled(it) } },
                     )
                     HorizontalDivider(
                         Modifier.padding(start = 56.dp),
-                        color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
+                        color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f),
                     )
                     SettingsSwitchItem(
                         icon = Icons.Outlined.ThumbDownOffAlt,
                         title = stringResource(R.string.player_settings_rytd_title),
                         subtitle = stringResource(R.string.player_settings_rytd_subtitle),
                         checked = rytdEnabled,
-                        onCheckedChange = { coroutineScope.launch { playerPreferences.setRytdEnabled(it) } }
+                        onCheckedChange = { coroutineScope.launch { playerPreferences.setRytdEnabled(it) } },
                     )
                 }
             }
@@ -170,7 +158,7 @@ fun SponsorBlockSettingsScreen(
                                 coroutineScope.launch {
                                     playerPreferences.setSbColorForCategory(category, colorArgb)
                                 }
-                            }
+                            },
                         )
                         if (index < SB_CATEGORIES_AND_LABELS.lastIndex) {
                             HorizontalDivider(modifier = Modifier.padding(horizontal = 16.dp))
@@ -193,36 +181,38 @@ fun SponsorBlockSettingsScreen(
                         checked = sbSubmitEnabled,
                         onCheckedChange = { enabled ->
                             coroutineScope.launch { playerPreferences.setSbSubmitEnabled(enabled) }
-                        }
+                        },
                     )
                     if (sbSubmitEnabled) {
                         HorizontalDivider(
                             Modifier.padding(start = 56.dp),
-                            color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f)
+                            color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f),
                         )
                         Row(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .clickable { showUserIdDialog = true }
-                                .padding(16.dp),
-                            verticalAlignment = Alignment.CenterVertically
+                            modifier =
+                                Modifier
+                                    .fillMaxWidth()
+                                    .clickable { showUserIdDialog = true }
+                                    .padding(16.dp),
+                            verticalAlignment = Alignment.CenterVertically,
                         ) {
                             Column(modifier = Modifier.weight(1f)) {
                                 Text(
                                     text = stringResource(R.string.sb_user_id_title),
-                                    style = MaterialTheme.typography.bodyLarge
+                                    style = MaterialTheme.typography.bodyLarge,
                                 )
                                 Text(
-                                    text = sbUserId?.let { it.take(8) + "…" }
-                                        ?: stringResource(R.string.sb_user_id_not_set),
+                                    text =
+                                        sbUserId?.let { it.take(8) + "…" }
+                                            ?: stringResource(R.string.sb_user_id_not_set),
                                     style = MaterialTheme.typography.bodyMedium,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
                                 )
                             }
                             Icon(
                                 imageVector = Icons.Outlined.ChevronRight,
                                 contentDescription = null,
-                                tint = MaterialTheme.colorScheme.onSurfaceVariant
+                                tint = MaterialTheme.colorScheme.onSurfaceVariant,
                             )
                         }
                     }
@@ -241,14 +231,14 @@ fun SponsorBlockSettingsScreen(
                     Text(
                         text = stringResource(R.string.sb_user_id_dialog_body),
                         style = MaterialTheme.typography.bodyMedium,
-                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
                     OutlinedTextField(
                         value = inputId,
                         onValueChange = { inputId = it },
                         label = { Text(stringResource(R.string.sb_user_id_hint)) },
                         singleLine = true,
-                        modifier = Modifier.fillMaxWidth()
+                        modifier = Modifier.fillMaxWidth(),
                     )
                 }
             },
@@ -265,7 +255,7 @@ fun SponsorBlockSettingsScreen(
                 TextButton(onClick = { showUserIdDialog = false }) {
                     Text(stringResource(R.string.btn_cancel))
                 }
-            }
+            },
         )
     }
 }
@@ -277,78 +267,80 @@ private fun SponsorBlockCategoryRow(
     selectedAction: SponsorBlockAction,
     customColorArgb: Int?,
     onActionSelected: (SponsorBlockAction) -> Unit,
-    onColorChanged: (Int?) -> Unit
+    onColorChanged: (Int?) -> Unit,
 ) {
     var expanded by remember { mutableStateOf(false) }
     var showColorPicker by remember { mutableStateOf(false) }
 
-    val presetColors = remember {
-        listOf(
-            Color(0xFF00D400), // green
-            Color(0xFFFFFF00), // yellow
-            Color(0xFF0000FF), // blue
-            Color(0xFFFF0000), // red
-            Color(0xFFFF7700), // orange
-            Color(0xFFFF69B4), // pink
-            Color(0xFF7700FF), // purple
-            Color(0xFF00FFFF), // cyan
-            Color(0xFFFFFFFF), // white
-            Color(0xFF008080), // teal
-            Color(0xFF3F51B5), // indigo
-            Color(0xFFFFC107), // amber
-            Color(0xFFCDDC39), // lime
-            Color(0xFF673AB7), // deep purple
-            Color(0xFFFF5722), // deep orange
-            Color(0xFFE91E63), // magenta / rose
-            Color(0xFF006400), // dark green
-            Color(0xFF8B4513), // brown
-            Color(0xFF808080), // gray
-            Color(0xFFC0C0C0), // silver
-            Color(0xFFFFD700), // gold
-            Color(0xFF40E0D0), // turquoise
-            Color(0xFF4B0082), // indigo / dark violet
-        )
-    }
+    val presetColors =
+        remember {
+            listOf(
+                Color(0xFF00D400), // green
+                Color(0xFFFFFF00), // yellow
+                Color(0xFF0000FF), // blue
+                Color(0xFFFF0000), // red
+                Color(0xFFFF7700), // orange
+                Color(0xFFFF69B4), // pink
+                Color(0xFF7700FF), // purple
+                Color(0xFF00FFFF), // cyan
+                Color(0xFFFFFFFF), // white
+                Color(0xFF008080), // teal
+                Color(0xFF3F51B5), // indigo
+                Color(0xFFFFC107), // amber
+                Color(0xFFCDDC39), // lime
+                Color(0xFF673AB7), // deep purple
+                Color(0xFFFF5722), // deep orange
+                Color(0xFFE91E63), // magenta / rose
+                Color(0xFF006400), // dark green
+                Color(0xFF8B4513), // brown
+                Color(0xFF808080), // gray
+                Color(0xFFC0C0C0), // silver
+                Color(0xFFFFD700), // gold
+                Color(0xFF40E0D0), // turquoise
+                Color(0xFF4B0082), // indigo / dark violet
+            )
+        }
 
     if (showColorPicker) {
         Dialog(onDismissRequest = { showColorPicker = false }) {
             Surface(
                 shape = RoundedCornerShape(16.dp),
                 color = MaterialTheme.colorScheme.surface,
-                tonalElevation = 4.dp
+                tonalElevation = 4.dp,
             ) {
                 Column(
                     modifier = Modifier.padding(20.dp),
-                    verticalArrangement = Arrangement.spacedBy(12.dp)
+                    verticalArrangement = Arrangement.spacedBy(12.dp),
                 ) {
                     Text(
                         text = stringResource(R.string.sb_color_picker_title),
                         style = MaterialTheme.typography.titleMedium,
-                        fontWeight = FontWeight.Bold
+                        fontWeight = FontWeight.Bold,
                     )
                     FlowRow(
                         horizontalArrangement = Arrangement.spacedBy(12.dp),
-                        verticalArrangement = Arrangement.spacedBy(12.dp)
+                        verticalArrangement = Arrangement.spacedBy(12.dp),
                     ) {
                         presetColors.forEach { color ->
                             val isSelected = customColorArgb == color.toArgb()
                             Box(
-                                modifier = Modifier
-                                    .size(40.dp)
-                                    .clip(CircleShape)
-                                    .background(color)
-                                    .clickable {
-                                        onColorChanged(color.toArgb())
-                                        showColorPicker = false
-                                    },
-                                contentAlignment = Alignment.Center
+                                modifier =
+                                    Modifier
+                                        .size(40.dp)
+                                        .clip(CircleShape)
+                                        .background(color)
+                                        .clickable {
+                                            onColorChanged(color.toArgb())
+                                            showColorPicker = false
+                                        },
+                                contentAlignment = Alignment.Center,
                             ) {
                                 if (isSelected) {
                                     Icon(
                                         imageVector = Icons.Default.Check,
                                         contentDescription = null,
                                         tint = Color.Black.copy(alpha = 0.7f),
-                                        modifier = Modifier.size(20.dp)
+                                        modifier = Modifier.size(20.dp),
                                     )
                                 }
                             }
@@ -359,7 +351,7 @@ private fun SponsorBlockCategoryRow(
                             onColorChanged(null)
                             showColorPicker = false
                         },
-                        modifier = Modifier.align(Alignment.End)
+                        modifier = Modifier.align(Alignment.End),
                     ) {
                         Text(stringResource(R.string.sb_color_reset))
                     }
@@ -369,63 +361,73 @@ private fun SponsorBlockCategoryRow(
     }
 
     Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 12.dp),
-        verticalAlignment = Alignment.CenterVertically
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
     ) {
         val swatchColor = customColorArgb?.let { Color(it) } ?: MaterialTheme.colorScheme.primary
         Box(
-            modifier = Modifier
-                .size(20.dp)
-                .clip(CircleShape)
-                .background(swatchColor)
-                .clickable { showColorPicker = true }
+            modifier =
+                Modifier
+                    .size(20.dp)
+                    .clip(CircleShape)
+                    .background(swatchColor)
+                    .clickable { showColorPicker = true },
         )
         Spacer(modifier = Modifier.width(12.dp))
         Text(
             text = label,
             style = MaterialTheme.typography.bodyLarge,
-            modifier = Modifier.weight(1f)
+            modifier = Modifier.weight(1f),
         )
         Box {
             Row(
-                modifier = Modifier
-                    .clickable { expanded = true }
-                    .padding(horizontal = 8.dp, vertical = 4.dp),
-                verticalAlignment = Alignment.CenterVertically
+                modifier =
+                    Modifier
+                        .clickable { expanded = true }
+                        .padding(horizontal = 8.dp, vertical = 4.dp),
+                verticalAlignment = Alignment.CenterVertically,
             ) {
                 Text(
                     text = sbActionLabel(selectedAction),
                     style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.primary
+                    color = MaterialTheme.colorScheme.primary,
                 )
                 Icon(
                     imageVector = Icons.Outlined.ArrowDropDown,
                     contentDescription = null,
-                    tint = MaterialTheme.colorScheme.primary
+                    tint = MaterialTheme.colorScheme.primary,
                 )
             }
             DropdownMenu(
                 expanded = expanded,
                 onDismissRequest = { expanded = false },
-                modifier = Modifier.widthIn(min = 180.dp)
+                modifier = Modifier.widthIn(min = 180.dp),
             ) {
                 SponsorBlockAction.values().forEach { action ->
                     DropdownMenuItem(
                         text = {
                             Text(
                                 text = sbActionLabel(action),
-                                style = MaterialTheme.typography.bodyLarge
+                                style = MaterialTheme.typography.bodyLarge,
                             )
                         },
                         onClick = {
                             onActionSelected(action)
                             expanded = false
                         },
-                        trailingIcon = if (action == selectedAction) ({
-                            Icon(Icons.Default.Check, null, tint = MaterialTheme.colorScheme.primary)
-                        }) else null
+                        trailingIcon =
+                            if (action == selectedAction) {
+                                (
+                                    {
+                                        Icon(Icons.Default.Check, null, tint = MaterialTheme.colorScheme.primary)
+                                    }
+                                )
+                            } else {
+                                null
+                            },
                     )
                 }
             }
@@ -434,9 +436,10 @@ private fun SponsorBlockCategoryRow(
 }
 
 @Composable
-private fun sbActionLabel(action: SponsorBlockAction): String = when (action) {
-    SponsorBlockAction.SKIP -> stringResource(R.string.sb_action_skip)
-    SponsorBlockAction.MUTE -> stringResource(R.string.sb_action_mute)
-    SponsorBlockAction.SHOW_TOAST -> stringResource(R.string.sb_action_show_toast)
-    SponsorBlockAction.IGNORE -> stringResource(R.string.sb_action_ignore)
-}
+private fun sbActionLabel(action: SponsorBlockAction): String =
+    when (action) {
+        SponsorBlockAction.SKIP -> stringResource(R.string.sb_action_skip)
+        SponsorBlockAction.MUTE -> stringResource(R.string.sb_action_mute)
+        SponsorBlockAction.SHOW_TOAST -> stringResource(R.string.sb_action_show_toast)
+        SponsorBlockAction.IGNORE -> stringResource(R.string.sb_action_ignore)
+    }

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/settings/TimeManagementScreen.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/settings/TimeManagementScreen.kt
@@ -40,6 +40,7 @@ import androidx.compose.ui.unit.sp
 import androidx.core.content.ContextCompat
 import androidx.hilt.navigation.compose.hiltViewModel
 import io.github.aedev.flow.R
+import io.github.aedev.flow.ui.components.layout.topbar.FlowTopBar
 import java.util.Locale
 
 // ============================================================================
@@ -89,34 +90,11 @@ fun TimeManagementScreen(
     Scaffold(
         contentWindowInsets = WindowInsets(0.dp),
         topBar = {
-            Surface(
-                modifier = Modifier.fillMaxWidth(),
-                color = MaterialTheme.colorScheme.background,
-            ) {
-                Row(
-                    modifier =
-                        Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = 4.dp, vertical = 8.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    IconButton(onClick = onNavigateBack) {
-                        Icon(Icons.Default.ArrowBack, stringResource(R.string.btn_back))
-                    }
-                    Column {
-                        Text(
-                            stringResource(R.string.time_management_title),
-                            style = MaterialTheme.typography.titleLarge,
-                            fontWeight = FontWeight.Bold,
-                        )
-                        Text(
-                            stringResource(R.string.time_management_subtitle),
-                            style = MaterialTheme.typography.bodySmall,
-                            color = MaterialTheme.colorScheme.onSurfaceVariant,
-                        )
-                    }
-                }
-            }
+            FlowTopBar(
+                title = stringResource(R.string.time_management_title),
+                subtitle = stringResource(R.string.time_management_subtitle),
+                onBack = onNavigateBack,
+            )
         },
     ) { padding ->
         Column(

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/settings/UserPreferencesScreen.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/settings/UserPreferencesScreen.kt
@@ -30,72 +30,55 @@ import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.compose.ui.res.stringResource
 import io.github.aedev.flow.R
+import io.github.aedev.flow.data.local.PlayerPreferences
 import io.github.aedev.flow.data.recommendation.FlowNeuroEngine
 import io.github.aedev.flow.data.recommendation.NeuroTopicCatalog
 import io.github.aedev.flow.data.recommendation.TopicCategory
-import io.github.aedev.flow.data.local.PlayerPreferences
+import io.github.aedev.flow.ui.components.layout.topbar.FlowTopBar
 import io.github.aedev.flow.ui.components.topicCategoryIcon
 import io.github.aedev.flow.ui.theme.extendedColors
 import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalLayoutApi::class, androidx.compose.foundation.ExperimentalFoundationApi::class)
 @Composable
-fun UserPreferencesScreen(
-    onNavigateBack: () -> Unit
-) {
+fun UserPreferencesScreen(onNavigateBack: () -> Unit) {
     val context = LocalContext.current
     val coroutineScope = rememberCoroutineScope()
     val focusManager = LocalFocusManager.current
-    
+
     // State
     var preferredTopics by remember { mutableStateOf<Set<String>>(emptySet()) }
     var blockedTopics by remember { mutableStateOf<Set<String>>(emptySet()) }
     var newBlockedTopic by remember { mutableStateOf("") }
     var newInterestTopic by remember { mutableStateOf("") }
     var isLoading by remember { mutableStateOf(true) }
-    
+
     val pagerState = rememberPagerState(pageCount = { 2 })
-    
+
     // Load data on first composition
     LaunchedEffect(Unit) {
         preferredTopics = FlowNeuroEngine.getPreferredTopics()
         blockedTopics = FlowNeuroEngine.getBlockedTopics()
         isLoading = false
     }
-    
+
     Scaffold(
         contentWindowInsets = WindowInsets(0.dp),
         topBar = {
             Column(modifier = Modifier.background(MaterialTheme.colorScheme.background)) {
-                Surface(
-                    modifier = Modifier.fillMaxWidth(),
-                    color = MaterialTheme.colorScheme.background
-                ) {
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = 4.dp, vertical = 8.dp),
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        IconButton(onClick = onNavigateBack) {
-                            Icon(Icons.Default.ArrowBack, stringResource(R.string.btn_back))
-                        }
-                        Text(
-                            text = stringResource(R.string.content_preferences_title),
-                            style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
-                            modifier = Modifier.weight(1f)
-                        )
-                    }
-                }
-                
+                FlowTopBar(
+                    title = stringResource(R.string.content_preferences_title),
+                    onBack = onNavigateBack,
+                )
+
                 ScrollableTabRow(
                     selectedTabIndex = pagerState.currentPage,
                     containerColor = Color.Transparent,
@@ -106,17 +89,18 @@ fun UserPreferencesScreen(
                             TabRowDefaults.Indicator(
                                 modifier = Modifier.tabIndicatorOffset(tabPositions[pagerState.currentPage]),
                                 color = MaterialTheme.colorScheme.primary,
-                                height = 3.dp
+                                height = 3.dp,
                             )
                         }
                     },
-                    divider = {}
+                    divider = {},
                 ) {
-                    val tabs = listOf(
-                        Triple(stringResource(R.string.interests_tab), Icons.Outlined.Favorite, 0),
-                        Triple(stringResource(R.string.blocked_tab), Icons.Outlined.Block, 1)
-                    )
-                    
+                    val tabs =
+                        listOf(
+                            Triple(stringResource(R.string.interests_tab), Icons.Outlined.Favorite, 0),
+                            Triple(stringResource(R.string.blocked_tab), Icons.Outlined.Block, 1),
+                        )
+
                     for ((title, icon, index) in tabs) {
                         val isSelected = pagerState.currentPage == index
                         Tab(
@@ -130,37 +114,43 @@ fun UserPreferencesScreen(
                                 Text(
                                     text = title,
                                     style = MaterialTheme.typography.titleSmall,
-                                    fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Medium
+                                    fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Medium,
                                 )
                             },
                             icon = {
                                 Icon(
-                                    icon, 
+                                    icon,
                                     contentDescription = null,
                                     modifier = Modifier.size(20.dp),
-                                    tint = if (isSelected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant
+                                    tint =
+                                        if (isSelected) {
+                                            MaterialTheme.colorScheme.primary
+                                        } else {
+                                            MaterialTheme.colorScheme.onSurfaceVariant
+                                        },
                                 )
                             },
                             selectedContentColor = MaterialTheme.colorScheme.primary,
-                            unselectedContentColor = MaterialTheme.colorScheme.onSurfaceVariant
+                            unselectedContentColor = MaterialTheme.colorScheme.onSurfaceVariant,
                         )
                     }
                 }
             }
-        }
+        },
     ) { paddingValues ->
         HorizontalPager(
             state = pagerState,
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(paddingValues)
-                .background(MaterialTheme.colorScheme.background),
-            verticalAlignment = Alignment.Top
+            modifier =
+                Modifier
+                    .fillMaxSize()
+                    .padding(paddingValues)
+                    .background(MaterialTheme.colorScheme.background),
+            verticalAlignment = Alignment.Top,
         ) { pageIndex ->
             LazyColumn(
                 modifier = Modifier.fillMaxSize(),
                 contentPadding = PaddingValues(16.dp),
-                verticalArrangement = Arrangement.spacedBy(16.dp)
+                verticalArrangement = Arrangement.spacedBy(16.dp),
             ) {
                 when (pageIndex) {
                     0 -> {
@@ -173,31 +163,36 @@ fun UserPreferencesScreen(
                                 title = stringResource(R.string.your_interests_title),
                                 description = stringResource(R.string.your_interests_desc),
                                 containerColor = MaterialTheme.colorScheme.primary,
-                                iconTint = MaterialTheme.colorScheme.onPrimary
+                                iconTint = MaterialTheme.colorScheme.onPrimary,
                             )
                         }
-                        
+
                         if (preferredTopics.isNotEmpty()) {
                             item {
                                 PreferencesSectionHeader(
                                     title = stringResource(R.string.currently_following),
-                                    subtitle = stringResource(R.string.topics_count_template, preferredTopics.size)
+                                    subtitle = stringResource(R.string.topics_count_template, preferredTopics.size),
                                 )
                             }
-                            
+
                             item {
                                 Card(
                                     modifier = Modifier.fillMaxWidth(),
                                     shape = RoundedCornerShape(20.dp),
-                                    colors = CardDefaults.cardColors(
-                                        containerColor = MaterialTheme.colorScheme.surfaceColorAtElevation(2.dp)
-                                    ),
-                                    border = androidx.compose.foundation.BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f))
+                                    colors =
+                                        CardDefaults.cardColors(
+                                            containerColor = MaterialTheme.colorScheme.surfaceColorAtElevation(2.dp),
+                                        ),
+                                    border =
+                                        androidx.compose.foundation.BorderStroke(
+                                            1.dp,
+                                            MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f),
+                                        ),
                                 ) {
                                     FlowRow(
                                         modifier = Modifier.padding(16.dp),
                                         horizontalArrangement = Arrangement.spacedBy(8.dp),
-                                        verticalArrangement = Arrangement.spacedBy(8.dp)
+                                        verticalArrangement = Arrangement.spacedBy(8.dp),
                                     ) {
                                         for (topic in preferredTopics) {
                                             PreferredTopicChip(
@@ -207,18 +202,18 @@ fun UserPreferencesScreen(
                                                         FlowNeuroEngine.removePreferredTopic(context, topic)
                                                         preferredTopics = FlowNeuroEngine.getPreferredTopics()
                                                     }
-                                                }
+                                                },
                                             )
                                         }
                                     }
                                 }
                             }
                         }
-                        
+
                         item {
                             PreferencesSectionHeader(
                                 title = stringResource(R.string.ui_custom_interest_title),
-                                subtitle = stringResource(R.string.ui_custom_interest_subtitle)
+                                subtitle = stringResource(R.string.ui_custom_interest_subtitle),
                             )
                         }
 
@@ -226,10 +221,15 @@ fun UserPreferencesScreen(
                             Card(
                                 modifier = Modifier.fillMaxWidth(),
                                 shape = RoundedCornerShape(20.dp),
-                                colors = CardDefaults.cardColors(
-                                    containerColor = MaterialTheme.colorScheme.surfaceColorAtElevation(2.dp)
-                                ),
-                                border = androidx.compose.foundation.BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f))
+                                colors =
+                                    CardDefaults.cardColors(
+                                        containerColor = MaterialTheme.colorScheme.surfaceColorAtElevation(2.dp),
+                                    ),
+                                border =
+                                    androidx.compose.foundation.BorderStroke(
+                                        1.dp,
+                                        MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f),
+                                    ),
                             ) {
                                 Column(modifier = Modifier.padding(16.dp)) {
                                     OutlinedTextField(
@@ -251,26 +251,32 @@ fun UserPreferencesScreen(
                                                         }
                                                     }
                                                 },
-                                                enabled = newInterestTopic.isNotBlank()
+                                                enabled = newInterestTopic.isNotBlank(),
                                             ) {
                                                 Icon(
                                                     Icons.Default.AddCircle,
                                                     contentDescription = stringResource(R.string.ui_add_interest),
-                                                    tint = if (newInterestTopic.isNotBlank()) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant
+                                                    tint =
+                                                        if (newInterestTopic.isNotBlank()) {
+                                                            MaterialTheme.colorScheme.primary
+                                                        } else {
+                                                            MaterialTheme.colorScheme.onSurfaceVariant
+                                                        },
                                                 )
                                             }
                                         },
                                         keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
-                                        keyboardActions = KeyboardActions(onDone = {
-                                            if (newInterestTopic.isNotBlank()) {
-                                                coroutineScope.launch {
-                                                    FlowNeuroEngine.addPreferredTopic(context, newInterestTopic.trim())
-                                                    preferredTopics = FlowNeuroEngine.getPreferredTopics()
-                                                    newInterestTopic = ""
-                                                    focusManager.clearFocus()
+                                        keyboardActions =
+                                            KeyboardActions(onDone = {
+                                                if (newInterestTopic.isNotBlank()) {
+                                                    coroutineScope.launch {
+                                                        FlowNeuroEngine.addPreferredTopic(context, newInterestTopic.trim())
+                                                        preferredTopics = FlowNeuroEngine.getPreferredTopics()
+                                                        newInterestTopic = ""
+                                                        focusManager.clearFocus()
+                                                    }
                                                 }
-                                            }
-                                        })
+                                            }),
                                     )
                                 }
                             }
@@ -279,13 +285,13 @@ fun UserPreferencesScreen(
                         item {
                             PreferencesSectionHeader(
                                 title = stringResource(R.string.add_topics),
-                                subtitle = stringResource(R.string.browse_by_category)
+                                subtitle = stringResource(R.string.browse_by_category),
                             )
                         }
-                        
+
                         items(
                             items = NeuroTopicCatalog.TOPIC_CATEGORIES,
-                            key = { it.name }
+                            key = { it.name },
                         ) { category ->
                             TopicCategoryExpandableCard(
                                 category = category,
@@ -299,11 +305,11 @@ fun UserPreferencesScreen(
                                         }
                                         preferredTopics = FlowNeuroEngine.getPreferredTopics()
                                     }
-                                }
+                                },
                             )
                         }
                     }
-                    
+
                     1 -> {
                         // =============================================
                         // BLOCKED TOPICS PAGE
@@ -314,25 +320,30 @@ fun UserPreferencesScreen(
                                 title = stringResource(R.string.hidden_content_title),
                                 description = stringResource(R.string.hidden_content_desc),
                                 containerColor = MaterialTheme.colorScheme.errorContainer,
-                                iconTint = MaterialTheme.colorScheme.onErrorContainer
+                                iconTint = MaterialTheme.colorScheme.onErrorContainer,
                             )
                         }
-                        
+
                         item {
                             PreferencesSectionHeader(
                                 title = stringResource(R.string.block_topic_title),
-                                subtitle = stringResource(R.string.enter_keywords_to_hide)
+                                subtitle = stringResource(R.string.enter_keywords_to_hide),
                             )
                         }
-                        
+
                         item {
                             Card(
                                 modifier = Modifier.fillMaxWidth(),
                                 shape = RoundedCornerShape(20.dp),
-                                colors = CardDefaults.cardColors(
-                                    containerColor = MaterialTheme.colorScheme.surfaceColorAtElevation(2.dp)
-                                ),
-                                border = androidx.compose.foundation.BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f))
+                                colors =
+                                    CardDefaults.cardColors(
+                                        containerColor = MaterialTheme.colorScheme.surfaceColorAtElevation(2.dp),
+                                    ),
+                                border =
+                                    androidx.compose.foundation.BorderStroke(
+                                        1.dp,
+                                        MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f),
+                                    ),
                             ) {
                                 Column(modifier = Modifier.padding(16.dp)) {
                                     OutlinedTextField(
@@ -354,49 +365,66 @@ fun UserPreferencesScreen(
                                                         }
                                                     }
                                                 },
-                                                enabled = newBlockedTopic.isNotBlank()
+                                                enabled = newBlockedTopic.isNotBlank(),
                                             ) {
                                                 Icon(
                                                     Icons.Default.AddCircle,
                                                     contentDescription = stringResource(R.string.create),
-                                                    tint = if (newBlockedTopic.isNotBlank()) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant
+                                                    tint =
+                                                        if (newBlockedTopic.isNotBlank()) {
+                                                            MaterialTheme.colorScheme.primary
+                                                        } else {
+                                                            MaterialTheme.colorScheme.onSurfaceVariant
+                                                        },
                                                 )
                                             }
                                         },
                                         keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
-                                        keyboardActions = KeyboardActions(onDone = {
-                                            if (newBlockedTopic.isNotBlank()) {
-                                                coroutineScope.launch {
-                                                    FlowNeuroEngine.addBlockedTopic(context, newBlockedTopic.trim().lowercase())
-                                                    blockedTopics = FlowNeuroEngine.getBlockedTopics()
-                                                    newBlockedTopic = ""
-                                                    focusManager.clearFocus()
+                                        keyboardActions =
+                                            KeyboardActions(onDone = {
+                                                if (newBlockedTopic.isNotBlank()) {
+                                                    coroutineScope.launch {
+                                                        FlowNeuroEngine.addBlockedTopic(context, newBlockedTopic.trim().lowercase())
+                                                        blockedTopics = FlowNeuroEngine.getBlockedTopics()
+                                                        newBlockedTopic = ""
+                                                        focusManager.clearFocus()
+                                                    }
                                                 }
-                                            }
-                                        })
+                                            }),
                                     )
                                 }
                             }
                         }
-                        
+
                         item {
                             PreferencesSectionHeader(
                                 title = stringResource(R.string.quick_add),
-                                subtitle = stringResource(R.string.common_topics_to_block)
+                                subtitle = stringResource(R.string.common_topics_to_block),
                             )
                         }
-                        
+
                         item {
-                            val suggestions = listOf(
-                                "ASMR", "Unboxing", "Reaction", "Vlogs", "News", "Politics", "Gaming",
-                                "clickbait", "drama", "gossip", "challenge", "family vlog"
-                            ).filter { !blockedTopics.contains(it) }
-                            
+                            val suggestions =
+                                listOf(
+                                    "ASMR",
+                                    "Unboxing",
+                                    "Reaction",
+                                    "Vlogs",
+                                    "News",
+                                    "Politics",
+                                    "Gaming",
+                                    "clickbait",
+                                    "drama",
+                                    "gossip",
+                                    "challenge",
+                                    "family vlog",
+                                ).filter { !blockedTopics.contains(it) }
+
                             if (suggestions.isNotEmpty()) {
                                 FlowRow(
                                     modifier = Modifier.fillMaxWidth(),
                                     horizontalArrangement = Arrangement.spacedBy(8.dp),
-                                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                                    verticalArrangement = Arrangement.spacedBy(8.dp),
                                 ) {
                                     for (topic in suggestions) {
                                         SuggestionChip(
@@ -406,34 +434,44 @@ fun UserPreferencesScreen(
                                                     FlowNeuroEngine.addBlockedTopic(context, topic.lowercase())
                                                     blockedTopics = FlowNeuroEngine.getBlockedTopics()
                                                 }
-                                            }
+                                            },
                                         )
                                     }
                                 }
                             }
                         }
-                        
+
                         if (blockedTopics.isNotEmpty()) {
                             item {
                                 PreferencesSectionHeader(
                                     title = stringResource(R.string.currently_blocked),
-                                    subtitle = stringResource(R.string.topics_blocked_count_plural, blockedTopics.size, if (blockedTopics.size > 1) "s" else "")
+                                    subtitle =
+                                        stringResource(
+                                            R.string.topics_blocked_count_plural,
+                                            blockedTopics.size,
+                                            if (blockedTopics.size > 1) "s" else "",
+                                        ),
                                 )
                             }
-                            
+
                             item {
                                 Card(
                                     modifier = Modifier.fillMaxWidth(),
                                     shape = RoundedCornerShape(20.dp),
-                                    colors = CardDefaults.cardColors(
-                                        containerColor = MaterialTheme.colorScheme.surfaceColorAtElevation(2.dp)
-                                    ),
-                                    border = androidx.compose.foundation.BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f))
+                                    colors =
+                                        CardDefaults.cardColors(
+                                            containerColor = MaterialTheme.colorScheme.surfaceColorAtElevation(2.dp),
+                                        ),
+                                    border =
+                                        androidx.compose.foundation.BorderStroke(
+                                            1.dp,
+                                            MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.5f),
+                                        ),
                                 ) {
                                     FlowRow(
                                         modifier = Modifier.padding(16.dp),
                                         horizontalArrangement = Arrangement.spacedBy(8.dp),
-                                        verticalArrangement = Arrangement.spacedBy(8.dp)
+                                        verticalArrangement = Arrangement.spacedBy(8.dp),
                                     ) {
                                         for (topic in blockedTopics) {
                                             BlockedTopicChip(
@@ -443,7 +481,7 @@ fun UserPreferencesScreen(
                                                         FlowNeuroEngine.removeBlockedTopic(context, topic)
                                                         blockedTopics = FlowNeuroEngine.getBlockedTopics()
                                                     }
-                                                }
+                                                },
                                             )
                                         }
                                     }
@@ -452,7 +490,7 @@ fun UserPreferencesScreen(
                         }
                     }
                 }
-                
+
                 item {
                     Spacer(modifier = Modifier.height(32.dp))
                 }
@@ -461,37 +499,36 @@ fun UserPreferencesScreen(
     }
 }
 
-
 @Composable
 private fun InfoCard(
     icon: ImageVector,
     title: String,
     description: String,
     containerColor: Color,
-    iconTint: Color
+    iconTint: Color,
 ) {
     Surface(
         modifier = Modifier.fillMaxWidth(),
         shape = RoundedCornerShape(20.dp),
         color = containerColor.copy(alpha = 0.15f),
-        border = androidx.compose.foundation.BorderStroke(1.dp, containerColor.copy(alpha = 0.3f))
+        border = androidx.compose.foundation.BorderStroke(1.dp, containerColor.copy(alpha = 0.3f)),
     ) {
         Row(
             modifier = Modifier.padding(20.dp),
             horizontalArrangement = Arrangement.spacedBy(16.dp),
-            verticalAlignment = Alignment.CenterVertically
+            verticalAlignment = Alignment.CenterVertically,
         ) {
             Surface(
                 shape = CircleShape,
                 color = containerColor.copy(alpha = 0.2f),
-                modifier = Modifier.size(48.dp)
+                modifier = Modifier.size(48.dp),
             ) {
                 Box(contentAlignment = Alignment.Center) {
                     Icon(
                         icon,
                         contentDescription = null,
                         tint = iconTint,
-                        modifier = Modifier.size(24.dp)
+                        modifier = Modifier.size(24.dp),
                     )
                 }
             }
@@ -500,14 +537,14 @@ private fun InfoCard(
                     text = title,
                     style = MaterialTheme.typography.titleMedium,
                     fontWeight = FontWeight.Bold,
-                    color = MaterialTheme.colorScheme.onBackground
+                    color = MaterialTheme.colorScheme.onBackground,
                 )
                 Spacer(modifier = Modifier.height(2.dp))
                 Text(
                     text = description,
                     style = MaterialTheme.typography.bodySmall,
                     color = MaterialTheme.colorScheme.onSurfaceVariant,
-                    lineHeight = 16.sp
+                    lineHeight = 16.sp,
                 )
             }
         }
@@ -517,26 +554,27 @@ private fun InfoCard(
 @Composable
 private fun PreferencesSectionHeader(
     title: String,
-    subtitle: String? = null
+    subtitle: String? = null,
 ) {
     Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(top = 8.dp, bottom = 4.dp)
+        modifier =
+            Modifier
+                .fillMaxWidth()
+                .padding(top = 8.dp, bottom = 4.dp),
     ) {
         Text(
             text = title,
             style = MaterialTheme.typography.titleMedium,
             fontWeight = FontWeight.ExtraBold,
             color = MaterialTheme.colorScheme.primary,
-            letterSpacing = 0.5.sp
+            letterSpacing = 0.5.sp,
         )
         if (subtitle != null) {
             Text(
                 text = subtitle,
                 style = MaterialTheme.typography.bodySmall,
                 color = MaterialTheme.colorScheme.onSurfaceVariant,
-                fontWeight = FontWeight.Medium
+                fontWeight = FontWeight.Medium,
             )
         }
     }
@@ -547,101 +585,112 @@ private fun PreferencesSectionHeader(
 private fun TopicCategoryExpandableCard(
     category: TopicCategory,
     selectedTopics: Set<String>,
-    onTopicToggle: (String) -> Unit
+    onTopicToggle: (String) -> Unit,
 ) {
     var isExpanded by remember { mutableStateOf(false) }
     val selectedCount = category.topics.count { selectedTopics.contains(it) }
-    
+
     val rotation by animateFloatAsState(
         targetValue = if (isExpanded) 180f else 0f,
         animationSpec = spring(stiffness = Spring.StiffnessLow),
-        label = "rotation"
+        label = "rotation",
     )
 
     Card(
         modifier = Modifier.fillMaxWidth(),
         shape = RoundedCornerShape(20.dp),
-        colors = CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surfaceColorAtElevation(1.dp)
-        ),
-        border = androidx.compose.foundation.BorderStroke(
-            1.dp, 
-            if (selectedCount > 0) MaterialTheme.colorScheme.primary.copy(alpha = 0.3f) 
-            else MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.3f)
-        )
+        colors =
+            CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.surfaceColorAtElevation(1.dp),
+            ),
+        border =
+            androidx.compose.foundation.BorderStroke(
+                1.dp,
+                if (selectedCount > 0) {
+                    MaterialTheme.colorScheme.primary.copy(alpha = 0.3f)
+                } else {
+                    MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.3f)
+                },
+            ),
     ) {
         Column {
             Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .clickable { isExpanded = !isExpanded }
-                    .padding(16.dp),
-                verticalAlignment = Alignment.CenterVertically
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .clickable { isExpanded = !isExpanded }
+                        .padding(16.dp),
+                verticalAlignment = Alignment.CenterVertically,
             ) {
                 Surface(
                     shape = RoundedCornerShape(12.dp),
                     color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.5f),
-                    modifier = Modifier.size(44.dp)
+                    modifier = Modifier.size(44.dp),
                 ) {
                     Box(contentAlignment = Alignment.Center) {
                         Icon(
                             imageVector = topicCategoryIcon(category.icon),
                             contentDescription = null,
                             modifier = Modifier.size(24.dp),
-                            tint = MaterialTheme.colorScheme.primary
+                            tint = MaterialTheme.colorScheme.primary,
                         )
                     }
                 }
-                
+
                 Spacer(modifier = Modifier.width(16.dp))
-                
+
                 Column(modifier = Modifier.weight(1f)) {
                     Text(
                         text = category.name,
                         style = MaterialTheme.typography.titleMedium,
-                        fontWeight = FontWeight.Bold
+                        fontWeight = FontWeight.Bold,
                     )
                     Text(
-                        text = if (selectedCount > 0) 
-                            stringResource(R.string.selected_count_template, selectedCount) 
-                        else 
-                            stringResource(R.string.topics_count_template, category.topics.size),
+                        text =
+                            if (selectedCount > 0) {
+                                stringResource(R.string.selected_count_template, selectedCount)
+                            } else {
+                                stringResource(R.string.topics_count_template, category.topics.size)
+                            },
                         style = MaterialTheme.typography.labelSmall,
-                        color = if (selectedCount > 0) 
-                            MaterialTheme.colorScheme.primary 
-                        else 
-                            MaterialTheme.colorScheme.onSurfaceVariant,
-                        fontWeight = if (selectedCount > 0) FontWeight.Bold else FontWeight.Normal
+                        color =
+                            if (selectedCount > 0) {
+                                MaterialTheme.colorScheme.primary
+                            } else {
+                                MaterialTheme.colorScheme.onSurfaceVariant
+                            },
+                        fontWeight = if (selectedCount > 0) FontWeight.Bold else FontWeight.Normal,
                     )
                 }
-                
+
                 IconButton(onClick = { isExpanded = !isExpanded }) {
                     Icon(
                         Icons.Default.KeyboardArrowDown,
                         contentDescription = null,
                         modifier = Modifier.graphicsLayer(rotationZ = rotation),
-                        tint = MaterialTheme.colorScheme.onSurfaceVariant
+                        tint = MaterialTheme.colorScheme.onSurfaceVariant,
                     )
                 }
             }
-            
+
             AnimatedVisibility(
                 visible = isExpanded,
                 enter = expandVertically() + fadeIn(),
-                exit = shrinkVertically() + fadeOut()
+                exit = shrinkVertically() + fadeOut(),
             ) {
                 FlowRow(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(start = 16.dp, end = 16.dp, bottom = 16.dp),
+                    modifier =
+                        Modifier
+                            .fillMaxWidth()
+                            .padding(start = 16.dp, end = 16.dp, bottom = 16.dp),
                     horizontalArrangement = Arrangement.spacedBy(10.dp),
-                    verticalArrangement = Arrangement.spacedBy(10.dp)
+                    verticalArrangement = Arrangement.spacedBy(10.dp),
                 ) {
                     for (topic in category.topics) {
                         SelectableTopicChip(
                             topic = topic,
                             isSelected = selectedTopics.contains(topic),
-                            onClick = { onTopicToggle(topic) }
+                            onClick = { onTopicToggle(topic) },
                         )
                     }
                 }
@@ -654,45 +703,54 @@ private fun TopicCategoryExpandableCard(
 private fun SelectableTopicChip(
     topic: String,
     isSelected: Boolean,
-    onClick: () -> Unit
+    onClick: () -> Unit,
 ) {
     val backgroundColor by animateColorAsState(
-        if (isSelected) MaterialTheme.colorScheme.primary 
-        else MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.4f),
-        label = "bg"
+        if (isSelected) {
+            MaterialTheme.colorScheme.primary
+        } else {
+            MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.4f)
+        },
+        label = "bg",
     )
     val contentColor by animateColorAsState(
-        if (isSelected) MaterialTheme.colorScheme.onPrimary
-        else MaterialTheme.colorScheme.onSurfaceVariant,
-        label = "content"
+        if (isSelected) {
+            MaterialTheme.colorScheme.onPrimary
+        } else {
+            MaterialTheme.colorScheme.onSurfaceVariant
+        },
+        label = "content",
     )
 
     Surface(
         onClick = onClick,
         shape = RoundedCornerShape(12.dp),
         color = backgroundColor,
-        border = if (isSelected) 
-            androidx.compose.foundation.BorderStroke(1.dp, MaterialTheme.colorScheme.primary) 
-        else null
+        border =
+            if (isSelected) {
+                androidx.compose.foundation.BorderStroke(1.dp, MaterialTheme.colorScheme.primary)
+            } else {
+                null
+            },
     ) {
         Row(
             modifier = Modifier.padding(horizontal = 14.dp, vertical = 10.dp),
             verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(8.dp)
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
         ) {
             if (isSelected) {
                 Icon(
                     Icons.Default.Check,
                     contentDescription = null,
                     modifier = Modifier.size(16.dp),
-                    tint = MaterialTheme.colorScheme.primary
+                    tint = MaterialTheme.colorScheme.primary,
                 )
             }
             Text(
                 text = topic,
                 style = MaterialTheme.typography.labelLarge,
                 fontWeight = if (isSelected) FontWeight.ExtraBold else FontWeight.Medium,
-                color = contentColor
+                color = contentColor,
             )
         }
     }
@@ -701,23 +759,23 @@ private fun SelectableTopicChip(
 @Composable
 private fun PreferredTopicChip(
     topic: String,
-    onRemove: () -> Unit
+    onRemove: () -> Unit,
 ) {
     Surface(
         shape = RoundedCornerShape(12.dp),
         color = MaterialTheme.colorScheme.primary.copy(alpha = 0.1f),
-        border = androidx.compose.foundation.BorderStroke(1.dp, MaterialTheme.colorScheme.primary.copy(alpha = 0.2f))
+        border = androidx.compose.foundation.BorderStroke(1.dp, MaterialTheme.colorScheme.primary.copy(alpha = 0.2f)),
     ) {
         Row(
             modifier = Modifier.padding(start = 12.dp, end = 6.dp, top = 6.dp, bottom = 6.dp),
             verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(6.dp)
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
         ) {
             Icon(
                 Icons.Outlined.Favorite,
                 contentDescription = null,
                 modifier = Modifier.size(16.dp),
-                tint = MaterialTheme.colorScheme.primary
+                tint = MaterialTheme.colorScheme.primary,
             )
             Text(
                 text = topic,
@@ -725,17 +783,17 @@ private fun PreferredTopicChip(
                 fontWeight = FontWeight.Bold,
                 color = MaterialTheme.colorScheme.primary,
                 maxLines = 1,
-                overflow = TextOverflow.Ellipsis
+                overflow = TextOverflow.Ellipsis,
             )
             IconButton(
                 onClick = onRemove,
-                modifier = Modifier.size(24.dp)
+                modifier = Modifier.size(24.dp),
             ) {
                 Icon(
                     Icons.Default.Close,
                     contentDescription = stringResource(R.string.desc_remove_topic, topic),
                     modifier = Modifier.size(14.dp),
-                    tint = MaterialTheme.colorScheme.primary
+                    tint = MaterialTheme.colorScheme.primary,
                 )
             }
         }
@@ -745,23 +803,23 @@ private fun PreferredTopicChip(
 @Composable
 private fun BlockedTopicChip(
     topic: String,
-    onRemove: () -> Unit
+    onRemove: () -> Unit,
 ) {
     Surface(
         shape = RoundedCornerShape(12.dp),
         color = MaterialTheme.colorScheme.error.copy(alpha = 0.08f),
-        border = androidx.compose.foundation.BorderStroke(1.dp, MaterialTheme.colorScheme.error.copy(alpha = 0.2f))
+        border = androidx.compose.foundation.BorderStroke(1.dp, MaterialTheme.colorScheme.error.copy(alpha = 0.2f)),
     ) {
         Row(
             modifier = Modifier.padding(start = 12.dp, end = 6.dp, top = 6.dp, bottom = 6.dp),
             verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(6.dp)
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
         ) {
             Icon(
                 Icons.Outlined.Block,
                 contentDescription = null,
                 modifier = Modifier.size(16.dp),
-                tint = MaterialTheme.colorScheme.error
+                tint = MaterialTheme.colorScheme.error,
             )
             Text(
                 text = topic,
@@ -769,17 +827,17 @@ private fun BlockedTopicChip(
                 fontWeight = FontWeight.Bold,
                 color = MaterialTheme.colorScheme.error,
                 maxLines = 1,
-                overflow = TextOverflow.Ellipsis
+                overflow = TextOverflow.Ellipsis,
             )
             IconButton(
                 onClick = onRemove,
-                modifier = Modifier.size(24.dp)
+                modifier = Modifier.size(24.dp),
             ) {
                 Icon(
                     Icons.Default.Close,
                     contentDescription = stringResource(R.string.desc_unblock_topic, topic),
                     modifier = Modifier.size(14.dp),
-                    tint = MaterialTheme.colorScheme.error
+                    tint = MaterialTheme.colorScheme.error,
                 )
             }
         }
@@ -789,32 +847,31 @@ private fun BlockedTopicChip(
 @Composable
 private fun SuggestionChip(
     topic: String,
-    onClick: () -> Unit
+    onClick: () -> Unit,
 ) {
     Surface(
         onClick = onClick,
         shape = RoundedCornerShape(12.dp),
         color = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.3f),
-        border = androidx.compose.foundation.BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.3f))
+        border = androidx.compose.foundation.BorderStroke(1.dp, MaterialTheme.colorScheme.outlineVariant.copy(alpha = 0.3f)),
     ) {
         Row(
             modifier = Modifier.padding(horizontal = 14.dp, vertical = 8.dp),
             verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(8.dp)
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
         ) {
             Icon(
                 Icons.Default.Add,
                 contentDescription = null,
                 modifier = Modifier.size(14.dp),
-                tint = MaterialTheme.colorScheme.primary
+                tint = MaterialTheme.colorScheme.primary,
             )
             Text(
                 text = topic,
                 style = MaterialTheme.typography.labelMedium,
                 fontWeight = FontWeight.SemiBold,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
         }
     }
 }
-

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/settings/VideoQualitySettingsScreen.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/settings/VideoQualitySettingsScreen.kt
@@ -11,12 +11,14 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import io.github.aedev.flow.R
 import io.github.aedev.flow.data.local.MusicAudioQuality
 import io.github.aedev.flow.data.local.PlayerPreferences
 import io.github.aedev.flow.data.local.VideoQuality
+import io.github.aedev.flow.ui.components.layout.topbar.FlowTopBar
 import kotlinx.coroutines.launch
 
 @Composable
@@ -53,32 +55,10 @@ fun VideoQualitySettingsScreen(onNavigateBack: () -> Unit) {
     Scaffold(
         contentWindowInsets = WindowInsets(0.dp),
         topBar = {
-            Surface(
-                modifier = Modifier.fillMaxWidth(),
-                color = MaterialTheme.colorScheme.background,
-            ) {
-                Row(
-                    modifier =
-                        Modifier
-                            .fillMaxWidth()
-                            .padding(horizontal = 4.dp, vertical = 8.dp),
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    IconButton(onClick = onNavigateBack) {
-                        Icon(
-                            Icons.Default.ArrowBack,
-                            androidx.compose.ui.res
-                                .stringResource(io.github.aedev.flow.R.string.btn_back),
-                        )
-                    }
-                    Text(
-                        text =
-                            androidx.compose.ui.res
-                                .stringResource(io.github.aedev.flow.R.string.video_quality_title),
-                        style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
-                    )
-                }
-            }
+            FlowTopBar(
+                title = stringResource(R.string.video_quality_title),
+                onBack = onNavigateBack,
+            )
         },
     ) { paddingValues ->
         LazyColumn(

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/subscriptions/SubscriptionsScreen.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/subscriptions/SubscriptionsScreen.kt
@@ -124,6 +124,8 @@ import io.github.aedev.flow.ui.TabScrollEventBus
 import io.github.aedev.flow.ui.components.ShortsShelf
 import io.github.aedev.flow.ui.components.VideoCardFullWidth
 import io.github.aedev.flow.ui.components.VideoCardHorizontal
+import io.github.aedev.flow.ui.components.layout.topbar.FlowSearchTopBar
+import io.github.aedev.flow.ui.components.layout.topbar.FlowTopBar
 import io.github.aedev.flow.ui.components.rememberFeedGridLayout
 import io.github.aedev.flow.ui.theme.extendedColors
 import kotlinx.coroutines.delay
@@ -267,37 +269,16 @@ fun SubscriptionsScreen(
     Scaffold(
         topBar = {
             if (isManagingSubs) {
-                TopAppBar(
-                    title = {
-                        TextField(
-                            value = searchQuery,
-                            onValueChange = { searchQuery = it },
-                            placeholder = {
-                                Text(
-                                    androidx.compose.ui.res
-                                        .stringResource(R.string.subscriptions_search_placeholder),
-                                    style = MaterialTheme.typography.bodyLarge,
-                                )
-                            },
-                            colors =
-                                TextFieldDefaults.colors(
-                                    focusedContainerColor = Color.Transparent,
-                                    unfocusedContainerColor = Color.Transparent,
-                                    focusedIndicatorColor = Color.Transparent,
-                                    unfocusedIndicatorColor = Color.Transparent,
-                                ),
-                            singleLine = true,
-                            modifier = Modifier.fillMaxWidth(),
-                        )
+                FlowSearchTopBar(
+                    query = searchQuery,
+                    onQueryChange = { searchQuery = it },
+                    onClose = {
+                        isManagingSubs = false
+                        searchQuery = ""
                     },
-                    navigationIcon = {
-                        IconButton(onClick = {
-                            isManagingSubs = false
-                            searchQuery = ""
-                        }) {
-                            Icon(Icons.Default.ArrowBack, stringResource(R.string.close))
-                        }
-                    },
+                    placeholder = stringResource(R.string.subscriptions_search_placeholder),
+                    // Manage mode opens a browsable channel list; popping the keyboard would cover it.
+                    autoFocus = false,
                     actions = {
                         Box {
                             IconButton(onClick = { showSortMenu = true }) {
@@ -333,54 +314,25 @@ fun SubscriptionsScreen(
                             Icon(Icons.Default.Upload, stringResource(R.string.import_newpipe_backup))
                         }
                     },
-                    colors =
-                        TopAppBarDefaults.topAppBarColors(
-                            containerColor = MaterialTheme.colorScheme.background,
-                            scrolledContainerColor = MaterialTheme.colorScheme.surface,
-                        ),
-                    windowInsets = WindowInsets(0.dp),
                 )
             } else {
-                Surface(
-                    modifier = Modifier.fillMaxWidth(),
-                    color = MaterialTheme.colorScheme.background,
-                ) {
-                    Row(
-                        modifier =
-                            Modifier
-                                .fillMaxWidth()
-                                .padding(horizontal = 16.dp, vertical = 8.dp),
-                        horizontalArrangement = Arrangement.SpaceBetween,
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        Text(
-                            text = stringResource(R.string.top_bar_subscriptions_title),
-                            style = MaterialTheme.typography.titleLarge.copy(fontWeight = FontWeight.Bold),
-                        )
-                        Row {
-                            IconButton(
-                                onClick = { viewModel.toggleViewMode() },
-                                modifier = Modifier.size(40.dp),
-                            ) {
-                                Icon(
-                                    imageVector = if (uiState.isFullWidthView) Icons.Default.ViewList else Icons.Default.GridView,
-                                    contentDescription = stringResource(R.string.toggle_view_mode),
-                                    modifier = Modifier.size(24.dp),
-                                )
-                            }
-                            IconButton(
-                                onClick = { isManagingSubs = true },
-                                modifier = Modifier.size(40.dp),
-                            ) {
-                                Icon(
-                                    Icons.Outlined.Search,
-                                    stringResource(R.string.search_subscriptions),
-                                    modifier = Modifier.size(24.dp),
-                                )
-                            }
+                FlowTopBar(
+                    title = stringResource(R.string.top_bar_subscriptions_title),
+                    actions = {
+                        IconButton(onClick = { viewModel.toggleViewMode() }) {
+                            Icon(
+                                imageVector = if (uiState.isFullWidthView) Icons.Default.ViewList else Icons.Default.GridView,
+                                contentDescription = stringResource(R.string.toggle_view_mode),
+                            )
                         }
-                    }
-                }
+                        IconButton(onClick = { isManagingSubs = true }) {
+                            Icon(
+                                imageVector = Icons.Outlined.Search,
+                                contentDescription = stringResource(R.string.search_subscriptions),
+                            )
+                        }
+                    },
+                )
             }
         },
         snackbarHost = { SnackbarHost(snackbarHostState) },

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/sync/SyncScreen.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/sync/SyncScreen.kt
@@ -39,6 +39,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import io.github.aedev.flow.R
 import io.github.aedev.flow.sync.SyncState
 import io.github.aedev.flow.sync.protocol.SyncRole
+import io.github.aedev.flow.ui.components.layout.topbar.FlowTopBar
 
 /** Where the user is in the pre-session setup. Once a session starts, [SyncState] drives the UI. */
 private enum class Step { CHOOSER, SEND_SELECT, SEND_TRANSPORT, SEND_SCAN, RECEIVE_TRANSPORT, RECEIVE_SCAN }
@@ -99,7 +100,6 @@ fun SyncScreen(
     val state by viewModel.state.collectAsStateWithLifecycle()
     var step by remember { mutableStateOf(Step.CHOOSER) }
     var selected by remember { mutableStateOf(COLLECTION_KEYS.toSet()) }
-    val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior()
 
     fun restart() {
         viewModel.reset()
@@ -133,24 +133,14 @@ fun SyncScreen(
     BackHandler(onBack = ::goBack)
 
     Scaffold(
-        modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
         // The app shell's Scaffold already pads for WindowInsets.systemBars, so both this Scaffold
         // and the bar itself must consume nothing — otherwise the status-bar inset is applied twice
         // and leaves an empty band above the title.
         contentWindowInsets = WindowInsets(0.dp),
         topBar = {
-            TopAppBar(
-                title = { Text(state.title(step)) },
-                navigationIcon = {
-                    IconButton(onClick = ::goBack) {
-                        Icon(
-                            Icons.AutoMirrored.Filled.ArrowBack,
-                            contentDescription = stringResource(R.string.btn_back),
-                        )
-                    }
-                },
-                windowInsets = WindowInsets(0.dp),
-                scrollBehavior = scrollBehavior,
+            FlowTopBar(
+                title = state.title(step),
+                onBack = ::goBack,
             )
         },
     ) { padding ->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -7,6 +7,8 @@
     <string name="subscriptions_sort_name">Name (A–Z)</string>
     <string name="subscriptions_sort_recent">Recently updated</string>
     <string name="top_bar_subscriptions_title">Subscriptions</string>
+    <string name="top_bar_clear_search">Clear search</string>
+    <string name="top_bar_close_search">Close search</string>
     <string name="view_all_button_label">All</string>
     <string name="subscribed">Subscribed</string>
     <string name="no_subscriptions_yet">No Subscriptions Yet</string>

--- a/app/src/test/java/io/github/aedev/flow/ui/NavigationDestinationsTest.kt
+++ b/app/src/test/java/io/github/aedev/flow/ui/NavigationDestinationsTest.kt
@@ -1,7 +1,9 @@
 package io.github.aedev.flow.ui
 
+import io.github.aedev.flow.data.local.DEFAULT_NAV_TAB_ORDER
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class NavigationDestinationsTest {
@@ -9,11 +11,12 @@ class NavigationDestinationsTest {
     fun hiddenHomeFallsBackToFirstVisibleDestination() {
         val visibility = NavigationVisibility(home = false, shorts = false, music = false)
 
-        val resolved = resolveDefaultNavTabIndex(
-            preferredIndex = 0,
-            order = listOf(0, 4, 3, 1, 2, 5, 6),
-            visibility = visibility
-        )
+        val resolved =
+            resolveDefaultNavTabIndex(
+                preferredIndex = 0,
+                order = listOf(0, 4, 3, 1, 2, 5, 6),
+                visibility = visibility,
+            )
 
         assertEquals(4, resolved)
         assertFalse(visibleNavTabIndices(listOf(0, 4, 3), visibility).contains(0))
@@ -21,11 +24,12 @@ class NavigationDestinationsTest {
 
     @Test
     fun reEnabledHomeRestoresAHomeDefault() {
-        val resolved = resolveDefaultNavTabIndex(
-            preferredIndex = 0,
-            order = listOf(3, 0, 4),
-            visibility = NavigationVisibility(home = true)
-        )
+        val resolved =
+            resolveDefaultNavTabIndex(
+                preferredIndex = 0,
+                order = listOf(3, 0, 4),
+                visibility = NavigationVisibility(home = true),
+            )
 
         assertEquals(0, resolved)
     }
@@ -36,7 +40,7 @@ class NavigationDestinationsTest {
         assertEquals("https://www.youtube.com/@flow", youtubeChannelUrl("flow"))
         assertEquals(
             "https://www.youtube.com/channel/UC123",
-            youtubeChannelUrl("UC123")
+            youtubeChannelUrl("UC123"),
         )
     }
 
@@ -44,11 +48,11 @@ class NavigationDestinationsTest {
     fun malformedHandleChannelUrlsAreRepaired() {
         assertEquals(
             "https://www.youtube.com/@flow",
-            youtubeChannelUrl("https://youtube.com/channel/@flow")
+            youtubeChannelUrl("https://youtube.com/channel/@flow"),
         )
         assertEquals(
             "https://www.youtube.com/@flow",
-            youtubeChannelUrl("https://m.youtube.com/@flow/videos")
+            youtubeChannelUrl("https://m.youtube.com/@flow/videos"),
         )
     }
 
@@ -56,7 +60,52 @@ class NavigationDestinationsTest {
     fun channelRoutesEncodeCanonicalUrls() {
         assertEquals(
             "channel?url=https%3A%2F%2Fwww.youtube.com%2F%40flow",
-            youtubeChannelRoute("@flow")
+            youtubeChannelRoute("@flow"),
         )
+    }
+
+    /**
+     * Settings and Notifications live in the top bar of every root destination, which only works if
+     * a root destination always exists. Subscriptions (3) and Library (4) are unconditional in
+     * [visibleNavTabIndices] — this pins that down so hiding tabs can never orphan those screens.
+     */
+    @Test
+    fun everyVisibilityCombinationKeepsAnUnhideableRootDestination() {
+        val orders =
+            listOf(
+                DEFAULT_NAV_TAB_ORDER,
+                listOf(6, 5, 4, 3, 2, 1, 0),
+                listOf(4, 3),
+                emptyList(),
+            )
+
+        for (bits in 0 until 32) {
+            val visibility =
+                NavigationVisibility(
+                    home = bits and 1 != 0,
+                    shorts = bits and 2 != 0,
+                    music = bits and 4 != 0,
+                    search = bits and 8 != 0,
+                    categories = bits and 16 != 0,
+                )
+
+            for (order in orders) {
+                val visible = visibleNavTabIndices(order, visibility)
+                assertTrue(
+                    "no visible tab for $visibility / $order",
+                    visible.isNotEmpty(),
+                )
+                assertTrue(
+                    "no unhideable root destination for $visibility / $order",
+                    visible.contains(3) || visible.contains(4),
+                )
+
+                val resolved = resolveDefaultNavTabIndex(0, order, visibility)
+                assertTrue(
+                    "resolved default $resolved is not visible for $visibility / $order",
+                    visible.contains(resolved),
+                )
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

Adds a shared `FlowTopBar` component and moves 42 screens onto it.

The reason is a reachability bug: `navigate("notifications")` had exactly one call site in the whole
app — inside `composable("home")` — so turning off the home tab in navigation settings made the
Notifications screen permanently unreachable. Settings was nearly as bad: its only top-bar entry
points were Home and Music, leaving Library's buried "Manage data" list row as the fallback.

The fix is structural rather than per-screen. `FlowTopBar` renders the Notifications and Settings
actions whenever `onBack == null` — a bar with no back affordance *is* a root destination. Since
`visibleNavTabIndices()` adds Subscriptions and Library unconditionally, at least one root
destination always exists, so both screens are reachable in every navigation configuration. A new
root tab cannot forget the actions; it would have to opt out explicitly.

Two smaller defects fixed along the way:

- Categories is a root tab but its bar had a back arrow wired to `popBackStack()` — a dead end on
  that tab. The arrow and its `onBackClick` parameter are gone.
- 30 back arrows became `Icons.AutoMirrored`, so they now mirror correctly in RTL layouts.

Implementation notes worth knowing:

- `FlowTopBar` deliberately keeps `TopAppBarColors` and `TopAppBarScrollBehavior` out of its public
  signature. An experimental Material type there propagates the opt-in requirement to every caller,
  which defeats the point of a shared component. Colours are applied internally.
- `FlowGlobalActions` carries the unread `StateFlow<Int>`, not the value, in a
  `staticCompositionLocalOf`. Collecting the count in `FlowApp` would recompose the whole shell on
  every notification; this way only the badge recomposes.
- `FlowTopBarDefaults.WindowInsets` is `WindowInsets(0.dp)` because `FlowApp`'s root `Scaffold`
  already consumes `WindowInsets.systemBars`. A Material default would double the status-bar gap on
  every screen.

Deferred on purpose: five hero-image overlay bars (ArtistPage, music/PlaylistPage,
PlaylistDetailScreen, ChannelScreen, RecognitionScreen) are transparent over artwork with fixed
white tints and `onGloballyPositioned` measurement. They need a separate `FlowOverlayTopBar` with
its own design pass, not a mechanical move. `SearchScreen` and `MusicSearchScreen` are also
untouched — they are search-first screens with voice input.

## Related issue

<!-- Fill in the report about settings/notifications being unreachable, e.g. Closes #NNN -->

## Change type

- [x] Bug fix
- [ ] Feature
- [x] Refactor or maintenance
- [ ] Build, packaging, or CI
- [ ] Documentation

## Validation

All of the below were run after rebasing onto `main` at `ac8b0f57`.

- [x] `./gradlew :app:assembleGithubDebug` — BUILD SUCCESSFUL
- [x] `./gradlew :app:testGithubDebugUnitTest` — BUILD SUCCESSFUL, includes a new test asserting
      that all 32 tab-visibility combinations × 4 tab orders always leave a reachable root
      destination
- [x] I ran any additional flavor-specific build or test tasks affected by this change.
      `:app:compileFossDebugKotlin` and `:app:compileGithubDebugAndroidTestKotlin` both pass.
      Spotless/ktlint is clean on all touched files (verified with a scoped target, because a
      full `ktlintCheck` on this machine reports pre-existing CRLF noise across unrelated files).
- [ ] I manually tested the affected behavior on an Android device or emulator.
      **Not done.** The acceptance path still needs a run: disable Home/Shorts/Music/Search/
      Categories, confirm the app lands on Subscriptions or Library, and open Notifications and
      Settings from the top bar of each remaining tab. Worth checking RTL and rotation at the
      same time.

**Test device and Android version:** not tested on device.

## Screenshots or recordings

Not captured — needs a device run. Bar heights move from roughly 48 dp to the Material 3 spec
64 dp on about 30 screens, so before/after shots of a settings screen and a root tab would be the
useful ones.

## Risk and compatibility

No database, preference, permission, network, playback, background-work, or battery impact. The
change is confined to top-bar composition and navigation wiring.

Regression risk, highest first:

1. **Window insets.** Every previous bar passed `WindowInsets(0.dp)` because `FlowApp` owns the
   status-bar inset. `FlowTopBarDefaults` pins the same value, but this is the thing most likely to
   go wrong — worth a look on a notch device and in landscape/cutout mode.
2. **Bar height.** Hand-rolled bars ranged 48–64 dp; the shared bar is a real `TopAppBar` at 64 dp.
   Intended, but visible on roughly 30 screens.
3. **Title typography.** Music's `headlineMedium/ExtraBold/2sp` title and Library's plain
   `titleLarge` both become the canonical `titleLarge + Bold`. Home keeps its wordmark.
4. **SyncScreen lost its `pinnedScrollBehavior`.** It only swapped the container colour on scroll;
   the shared `scrolledContainerColor` gives every screen that behaviour without it.
5. **Large formatting diffs on four files.** `CategoriesScreen`, `AppearanceScreen`,
   `UserPreferencesScreen` and `FlowPersonalityScreen` are mostly reformat — the Spotless ratchet
   requires a whole file to pass ktlint once it is touched. A few pre-existing lines over 140
   characters had to be wrapped as a result.

Known limitation: `SearchScreen` as a root tab still has no route to Settings or Notifications,
since it has no `topBar` slot. A user who enables only Search plus the two mandatory tabs gets the
actions on Subscriptions and Library but not on Search.

- [x] The change does not introduce secrets, private data, or unexpected telemetry.
- [x] New user-facing text uses Android string resources. Two added to the default locale only:
      `top_bar_clear_search` and `top_bar_close_search`. This also replaces two hardcoded literals
      that were in `SettingsScreen`.
- [x] Dependency and lockfile changes are intentional and limited to this PR. No dependency changes.
- [x] Room schema changes include the required version bump and migration, or this PR does not
      change the Room schema. **Not applicable** — no schema change.
- [x] Breaking changes and upgrade steps are clearly documented. No breaking changes; this is
      internal UI composition only.

