### PR TITLE
Feat/neuro engine v11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ Flow-desktop/
 
 # Kotlin compiler session/daemon state
 .kotlin/
+
+# Local engine diagnostics (real exported brains - personal data, never commit)
+diagnostics/

--- a/app/src/main/assets/changelog/v2.2.5.txt
+++ b/app/src/main/assets/changelog/v2.2.5.txt
@@ -1,0 +1,39 @@
+FLOW CHANGE LOG
+VERSION: 2.2.5
+DATE: 2026-08-29
+STATUS: PRE-RELEASE
+
+NEW FEATURES
+- Serve every one of your interests in every home feed: your biggest interests are always present and your smaller ones rotate through the remaining slots, instead of the feed looping your top topic
+- Dig deeper as you scroll: each load of more videos descends one level further into every interest's branches, like walking a tree, instead of repeating the surface
+- Keep the feed going forever: when the usual sources thin out, loading more now digs fresh related-video lanes seeded from the videos on screen, your history, likes and playlists
+- Always show fresh uploads from your subscriptions: the fresh-subs slots now draw from the subscription feed covering ALL your channels, not just the handful fetched this refresh
+- Learn from everything you do: real watch time, early skips, downloads, Watch Later, playlist saves, live subscribes and the searches you type now all teach your recommendation brain
+- Learn what each channel is about from its creator-declared tags when you subscribe, and passively from its recent upload titles, improving interest grouping and recommendations
+
+IMPROVEMENTS
+- Stop showing you the same videos over and over: something you actually saw is filtered out of the next refreshes, briefly after one appearance and for days after repeats, and gently returns later
+- Pull-to-refresh now builds a genuinely fresh page instead of reshuffling what is already on screen
+- Cached reserve videos are consumed once served instead of reappearing for hours after every refresh
+- Related videos rotate their seed videos instead of fetching the same neighbours every refresh, and spread one seed per interest so the lane mirrors all your interests
+- Search queries whose results you have mostly already seen are skipped on the next round
+- Blocking a topic is now precise: it no longer silently blocks every topic in the same category, and blocking "art" no longer hides "startup"
+- Channels you interact with are no longer scored below channels you have never seen
+- Only a couple of fresh subscription uploads pin to the top of the feed, and only one per channel, so the first screen is a real mix of sources
+- A one-time brain revitalization recovers your real interests from your channel knowledge, repairing profiles hollowed out by old learning bugs
+
+PERFORMANCE
+- Feed ranking noise now scales with your actual scores instead of drowning them when the feed was stale
+
+FIXES AND STABILITY
+- Fix watch progress on normal videos never reaching your recommendation brain, so it learned almost nothing from what you actually watched
+- Fix topic-pair learning deleting every learned connection the moment it was created, which had left long-time users with zero learned topic links
+- Fix mature recommendation brains being mathematically unable to pick up new interests no matter how much you watched them
+- Fix videos dated "3 days ago" or "2 weeks ago" being treated as seconds old, which let stale subscription uploads crowd out genuinely new ones
+- Fix related videos being stamped with the current time, defeating the old-content filter and mis-sorting the Shorts shelf
+- Fix junk words like "right" leaking into your learned interests and forming meaningless topic groups
+- Fix a liked video silently failing to teach the brain when its details could not be loaded
+
+BUILD AND CI
+- Add an offline recommendation benchmark with regression floors, so feed diversity and repetition are verified by tests instead of claims
+- Add an offline brain diagnostic that inspects a real exported profile through the production clustering and discovery code

--- a/app/src/main/java/io/github/aedev/flow/data/local/HomeFeedCacheRepository.kt
+++ b/app/src/main/java/io/github/aedev/flow/data/local/HomeFeedCacheRepository.kt
@@ -8,19 +8,19 @@ import org.json.JSONArray
 data class CachedHomeVideo(
     val video: Video,
     val source: String,
-    val relatedSeedId: String? = null
+    val relatedSeedId: String? = null,
 )
 
 data class HomeFeedCacheFilters(
     val watchedVideoIds: Set<String> = emptySet(),
     val suppressedVideoIds: Set<String> = emptySet(),
     val blockedChannelIds: Set<String> = emptySet(),
-    val suppressedChannelIds: Set<String> = emptySet()
+    val suppressedChannelIds: Set<String> = emptySet(),
 )
 
 internal fun filterCachedHomeVideos(
     items: List<CachedHomeVideo>,
-    filters: HomeFeedCacheFilters
+    filters: HomeFeedCacheFilters,
 ): List<CachedHomeVideo> =
     items.filter { item ->
         val video = item.video
@@ -33,25 +33,33 @@ internal fun filterCachedHomeVideos(
 internal fun selectReservePageFromCache(
     items: List<CachedHomeVideo>,
     maxRelated: Int = 4,
-    maxDiscovery: Int = 4
+    maxDiscovery: Int = 4,
 ): List<CachedHomeVideo> {
     val related = items.filter { it.source == HomeFeedCacheRepository.SOURCE_RELATED }.take(maxRelated)
     val discovery = items.filter { it.source == HomeFeedCacheRepository.SOURCE_DISCOVERY }.take(maxDiscovery)
     return related + discovery
 }
 
-class HomeFeedCacheRepository(context: Context) {
+class HomeFeedCacheRepository(
+    context: Context,
+) {
     private val dao = AppDatabase.getDatabase(context).homeFeedCacheDao()
 
-    suspend fun loadLastFeed(filters: HomeFeedCacheFilters, now: Long = System.currentTimeMillis()): List<Video> {
+    suspend fun loadLastFeed(
+        filters: HomeFeedCacheFilters,
+        now: Long = System.currentTimeMillis(),
+    ): List<Video> {
         dao.deleteExpired(now)
         return filterCachedHomeVideos(
             dao.getFreshBucket(BUCKET_LAST_FEED, now).map { it.toCachedHomeVideo() },
-            filters
+            filters,
         ).map { it.video }
     }
 
-    suspend fun saveLastFeed(videos: List<Video>, now: Long = System.currentTimeMillis()) {
+    suspend fun saveLastFeed(
+        videos: List<Video>,
+        now: Long = System.currentTimeMillis(),
+    ) {
         dao.clearBucket(BUCKET_LAST_FEED)
         dao.insertAll(
             videos.take(LAST_FEED_CAP).mapIndexed { index, video ->
@@ -61,9 +69,9 @@ class HomeFeedCacheRepository(context: Context) {
                     relatedSeedId = null,
                     orderIndex = index,
                     cachedAt = now,
-                    expiresAt = now + LAST_FEED_TTL_MS
+                    expiresAt = now + LAST_FEED_TTL_MS,
                 )
-            }
+            },
         )
     }
 
@@ -71,22 +79,28 @@ class HomeFeedCacheRepository(context: Context) {
         filters: HomeFeedCacheFilters,
         now: Long = System.currentTimeMillis(),
         maxRelated: Int = 4,
-        maxDiscovery: Int = 4
+        maxDiscovery: Int = 4,
     ): List<CachedHomeVideo> {
         dao.deleteExpired(now)
-        val freshReserve = dao.getFreshReserve(now, RESERVE_CAP)
-            .map { it.toCachedHomeVideo() }
+        val freshReserve =
+            dao
+                .getFreshReserve(now, RESERVE_CAP)
+                .map { it.toCachedHomeVideo() }
         return selectReservePageFromCache(
             filterCachedHomeVideos(freshReserve, filters),
             maxRelated = maxRelated,
-            maxDiscovery = maxDiscovery
+            maxDiscovery = maxDiscovery,
         )
     }
 
-    suspend fun saveReserve(items: List<CachedHomeVideo>, now: Long = System.currentTimeMillis()) {
+    suspend fun saveReserve(
+        items: List<CachedHomeVideo>,
+        now: Long = System.currentTimeMillis(),
+    ) {
         if (items.isEmpty()) return
         dao.insertAll(
-            items.distinctBy { it.video.id }
+            items
+                .distinctBy { it.video.id }
                 .take(RESERVE_CAP)
                 .mapIndexed { index, item ->
                     item.video.toEntity(
@@ -95,9 +109,9 @@ class HomeFeedCacheRepository(context: Context) {
                         relatedSeedId = item.relatedSeedId,
                         orderIndex = index,
                         cachedAt = now,
-                        expiresAt = now + RESERVE_TTL_MS
+                        expiresAt = now + RESERVE_TTL_MS,
                     )
-                }
+                },
         )
         dao.trimReserve(RESERVE_CAP)
     }
@@ -105,19 +119,19 @@ class HomeFeedCacheRepository(context: Context) {
     suspend fun loadRelated(
         seedId: String,
         filters: HomeFeedCacheFilters,
-        now: Long = System.currentTimeMillis()
+        now: Long = System.currentTimeMillis(),
     ): List<Video> {
         dao.deleteExpired(now)
         return filterCachedHomeVideos(
             dao.getFreshRelated(seedId, now).map { it.toCachedHomeVideo() },
-            filters
+            filters,
         ).map { it.video }
     }
 
     suspend fun saveRelated(
         seedId: String,
         videos: List<Video>,
-        now: Long = System.currentTimeMillis()
+        now: Long = System.currentTimeMillis(),
     ) {
         if (seedId.isBlank() || videos.isEmpty()) return
         dao.clearRelated(seedId)
@@ -129,9 +143,9 @@ class HomeFeedCacheRepository(context: Context) {
                     relatedSeedId = seedId,
                     orderIndex = index,
                     cachedAt = now,
-                    expiresAt = now + RELATED_TTL_MS
+                    expiresAt = now + RELATED_TTL_MS,
                 )
-            }
+            },
         )
         dao.trimRelatedSeed(seedId, RELATED_PER_SEED_CAP)
         dao.trimRelatedSeeds(RELATED_SEED_CAP)
@@ -139,6 +153,15 @@ class HomeFeedCacheRepository(context: Context) {
 
     suspend fun deleteVideo(videoId: String) {
         if (videoId.isNotBlank()) dao.deleteVideo(videoId)
+    }
+
+    /**
+     * Removes served reserve rows so a later refresh cannot re-serve them.
+     * Without this, reserve rows stayed eligible for their full 12h TTL and
+     * reappeared after every pull-to-refresh.
+     */
+    suspend fun consumeReserve(videoIds: Collection<String>) {
+        if (videoIds.isNotEmpty()) dao.deleteReserveVideos(videoIds.toList())
     }
 
     suspend fun deleteChannel(channelId: String) {
@@ -155,7 +178,7 @@ class HomeFeedCacheRepository(context: Context) {
         relatedSeedId: String?,
         orderIndex: Int,
         cachedAt: Long,
-        expiresAt: Long
+        expiresAt: Long,
     ): HomeFeedCacheEntity {
         val seedPart = relatedSeedId.orEmpty()
         return HomeFeedCacheEntity(
@@ -183,41 +206,43 @@ class HomeFeedCacheRepository(context: Context) {
             relatedSeedId = relatedSeedId,
             cachedAt = cachedAt,
             expiresAt = expiresAt,
-            orderIndex = orderIndex
+            orderIndex = orderIndex,
         )
     }
 
     private fun HomeFeedCacheEntity.toCachedHomeVideo(): CachedHomeVideo =
         CachedHomeVideo(
-            video = Video(
-                id = videoId,
-                title = title,
-                channelName = channelName,
-                channelId = channelId,
-                thumbnailUrl = thumbnailUrl,
-                duration = duration,
-                viewCount = viewCount,
-                likeCount = likeCount,
-                uploadDate = uploadDate,
-                timestamp = timestamp,
-                description = description,
-                channelThumbnailUrl = channelThumbnailUrl,
-                tags = parseTags(tagsJson),
-                isMusic = isMusic,
-                isLive = isLive,
-                isShort = isShort,
-                isUpcoming = isUpcoming,
-                commentCountText = commentCountText
-            ),
+            video =
+                Video(
+                    id = videoId,
+                    title = title,
+                    channelName = channelName,
+                    channelId = channelId,
+                    thumbnailUrl = thumbnailUrl,
+                    duration = duration,
+                    viewCount = viewCount,
+                    likeCount = likeCount,
+                    uploadDate = uploadDate,
+                    timestamp = timestamp,
+                    description = description,
+                    channelThumbnailUrl = channelThumbnailUrl,
+                    tags = parseTags(tagsJson),
+                    isMusic = isMusic,
+                    isLive = isLive,
+                    isShort = isShort,
+                    isUpcoming = isUpcoming,
+                    commentCountText = commentCountText,
+                ),
             source = source,
-            relatedSeedId = relatedSeedId
+            relatedSeedId = relatedSeedId,
         )
 
-    private fun parseTags(raw: String): List<String> = runCatching {
-        val json = JSONArray(raw)
-        List(json.length()) { index -> json.optString(index) }
-            .filter { it.isNotBlank() }
-    }.getOrElse { emptyList() }
+    private fun parseTags(raw: String): List<String> =
+        runCatching {
+            val json = JSONArray(raw)
+            List(json.length()) { index -> json.optString(index) }
+                .filter { it.isNotBlank() }
+        }.getOrElse { emptyList() }
 
     companion object {
         const val SOURCE_SUBS = "SUBS"

--- a/app/src/main/java/io/github/aedev/flow/data/local/dao/HomeFeedCacheDao.kt
+++ b/app/src/main/java/io/github/aedev/flow/data/local/dao/HomeFeedCacheDao.kt
@@ -9,22 +9,35 @@ import io.github.aedev.flow.data.local.entity.HomeFeedCacheEntity
 @Dao
 interface HomeFeedCacheDao {
     @Query("SELECT * FROM home_feed_cache WHERE bucket = :bucket AND expiresAt > :now ORDER BY orderIndex ASC")
-    suspend fun getFreshBucket(bucket: String, now: Long): List<HomeFeedCacheEntity>
+    suspend fun getFreshBucket(
+        bucket: String,
+        now: Long,
+    ): List<HomeFeedCacheEntity>
 
-    @Query("""
+    @Query(
+        """
         SELECT * FROM home_feed_cache
         WHERE bucket = 'RELATED' AND relatedSeedId = :seedId AND expiresAt > :now
         ORDER BY orderIndex ASC
-    """)
-    suspend fun getFreshRelated(seedId: String, now: Long): List<HomeFeedCacheEntity>
+    """,
+    )
+    suspend fun getFreshRelated(
+        seedId: String,
+        now: Long,
+    ): List<HomeFeedCacheEntity>
 
-    @Query("""
+    @Query(
+        """
         SELECT * FROM home_feed_cache
         WHERE bucket = 'RESERVE' AND expiresAt > :now
         ORDER BY cachedAt DESC, orderIndex ASC
         LIMIT :limit
-    """)
-    suspend fun getFreshReserve(now: Long, limit: Int): List<HomeFeedCacheEntity>
+    """,
+    )
+    suspend fun getFreshReserve(
+        now: Long,
+        limit: Int,
+    ): List<HomeFeedCacheEntity>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertAll(items: List<HomeFeedCacheEntity>)
@@ -41,13 +54,17 @@ interface HomeFeedCacheDao {
     @Query("DELETE FROM home_feed_cache WHERE videoId = :videoId")
     suspend fun deleteVideo(videoId: String)
 
+    @Query("DELETE FROM home_feed_cache WHERE bucket = 'RESERVE' AND videoId IN (:videoIds)")
+    suspend fun deleteReserveVideos(videoIds: List<String>)
+
     @Query("DELETE FROM home_feed_cache WHERE channelId = :channelId")
     suspend fun deleteChannel(channelId: String)
 
     @Query("DELETE FROM home_feed_cache")
     suspend fun clearAll()
 
-    @Query("""
+    @Query(
+        """
         DELETE FROM home_feed_cache
         WHERE bucket = 'RESERVE'
         AND cacheKey NOT IN (
@@ -56,10 +73,12 @@ interface HomeFeedCacheDao {
             ORDER BY cachedAt DESC, orderIndex ASC
             LIMIT :maxRows
         )
-    """)
+    """,
+    )
     suspend fun trimReserve(maxRows: Int)
 
-    @Query("""
+    @Query(
+        """
         DELETE FROM home_feed_cache
         WHERE bucket = 'RELATED' AND relatedSeedId = :seedId
         AND cacheKey NOT IN (
@@ -68,10 +87,15 @@ interface HomeFeedCacheDao {
             ORDER BY orderIndex ASC
             LIMIT :maxRows
         )
-    """)
-    suspend fun trimRelatedSeed(seedId: String, maxRows: Int)
+    """,
+    )
+    suspend fun trimRelatedSeed(
+        seedId: String,
+        maxRows: Int,
+    )
 
-    @Query("""
+    @Query(
+        """
         DELETE FROM home_feed_cache
         WHERE bucket = 'RELATED'
         AND relatedSeedId NOT IN (
@@ -81,6 +105,7 @@ interface HomeFeedCacheDao {
             ORDER BY MAX(cachedAt) DESC
             LIMIT :maxSeeds
         )
-    """)
+    """,
+    )
     suspend fun trimRelatedSeeds(maxSeeds: Int)
 }

--- a/app/src/main/java/io/github/aedev/flow/data/recommendation/FlowNeuroEngine.kt
+++ b/app/src/main/java/io/github/aedev/flow/data/recommendation/FlowNeuroEngine.kt
@@ -46,8 +46,9 @@ import kotlin.math.log10
  * - NeuroStorage.kt    — DataStore persistence, export/import, migration
  * - NeuroDiscovery.kt  — smart query generation (V2)
  */
-class FlowNeuroEngine(private val appContext: Context) {
-
+class FlowNeuroEngine(
+    private val appContext: Context,
+) {
     companion object {
         private const val TAG = "FlowNeuroEngine"
 
@@ -57,12 +58,16 @@ class FlowNeuroEngine(private val appContext: Context) {
         private const val SAVE_DEBOUNCE_MS = 5000L
 
         // ── Suppression constants ──
+
         /** How long a specific video stays hard-suppressed after "not interested" */
         private const val VIDEO_SUPPRESSION_DAYS = 30L
+
         /** How long a channel stays hard-suppressed before escalating to a full block */
         private const val CHANNEL_SUPPRESSION_DAYS = 14L
+
         /** Max suppressed video entries to prevent unbounded growth */
         private const val MAX_SUPPRESSED_VIDEOS = 500
+
         /** Max suppressed channel entries to prevent unbounded growth */
         private const val MAX_SUPPRESSED_CHANNELS = 100
 
@@ -72,13 +77,12 @@ class FlowNeuroEngine(private val appContext: Context) {
         @Volatile
         private var instance: FlowNeuroEngine? = null
 
-        fun getInstance(context: Context): FlowNeuroEngine {
-            return instance ?: synchronized(this) {
+        fun getInstance(context: Context): FlowNeuroEngine =
+            instance ?: synchronized(this) {
                 instance ?: FlowNeuroEngine(context.applicationContext).also {
                     instance = it
                 }
             }
-        }
 
         private fun requireInstance(): FlowNeuroEngine =
             instance ?: error("FlowNeuroEngine not initialized. Call initialize(context) first.")
@@ -87,17 +91,19 @@ class FlowNeuroEngine(private val appContext: Context) {
 
         suspend fun initialize(context: Context) = getInstance(context).initialize()
 
-        suspend fun rank(candidates: List<Video>, userSubs: Set<String>): List<Video> =
-            requireInstance().rank(candidates, userSubs)
+        suspend fun rank(
+            candidates: List<Video>,
+            userSubs: Set<String>,
+        ): List<Video> = requireInstance().rank(candidates, userSubs)
 
-        suspend fun recordFeedImpressions(ids: List<String>) =
-            requireInstance().recordFeedImpressions(ids)
+        suspend fun recordFeedImpressions(ids: List<String>) = requireInstance().recordFeedImpressions(ids)
 
-        suspend fun generateDiscoveryQueries(): List<String> =
-            requireInstance().generateDiscoveryQueries()
+        suspend fun generateDiscoveryQueries(): List<String> = requireInstance().generateDiscoveryQueries()
 
-        suspend fun selectRelatedSeeds(candidates: List<GraphSeedInput>, maxSeeds: Int = 4): List<String> =
-            requireInstance().selectRelatedSeeds(candidates, maxSeeds)
+        suspend fun selectRelatedSeeds(
+            candidates: List<GraphSeedInput>,
+            maxSeeds: Int = 4,
+        ): List<String> = requireInstance().selectRelatedSeeds(candidates, maxSeeds)
 
         suspend fun needsOnboarding(): Boolean = requireInstance().needsOnboarding()
 
@@ -105,94 +111,143 @@ class FlowNeuroEngine(private val appContext: Context) {
 
         fun getPersona(brain: UserBrain): FlowPersona = requireInstance().getPersona(brain)
 
-        suspend fun markNotInterested(video: Video) =
-            requireInstance().markNotInterested(video)
-        suspend fun markNotInterested(context: Context, video: Video) =
-            getInstance(context).markNotInterested(video)
+        suspend fun markNotInterested(video: Video) = requireInstance().markNotInterested(video)
+
+        suspend fun markNotInterested(
+            context: Context,
+            video: Video,
+        ) = getInstance(context).markNotInterested(video)
 
         suspend fun onVideoInteraction(
             video: Video,
             interactionType: InteractionType,
-            percentWatched: Float = 0f
+            percentWatched: Float = 0f,
         ) = requireInstance().onVideoInteraction(video, interactionType, percentWatched)
+
         suspend fun onVideoInteraction(
             context: Context,
             video: Video,
             interactionType: InteractionType,
-            percentWatched: Float = 0f
+            percentWatched: Float = 0f,
         ) = getInstance(context).onVideoInteraction(video, interactionType, percentWatched)
 
-        suspend fun completeOnboarding(selectedTopics: Set<String>) =
-            requireInstance().completeOnboarding(selectedTopics)
-        suspend fun completeOnboarding(context: Context, selectedTopics: Set<String>) =
-            getInstance(context).completeOnboarding(selectedTopics)
+        /**
+         * Fire-and-forget variant on the engine's own scope. Safe to call from
+         * lifecycle teardown (e.g. ViewModel.onCleared) where viewModelScope is dead.
+         */
+        fun onVideoInteractionAsync(
+            context: Context,
+            video: Video,
+            interactionType: InteractionType,
+            percentWatched: Float = 0f,
+        ) = getInstance(context).onVideoInteractionAsync(video, interactionType, percentWatched)
 
-        suspend fun exportBrainToStream(output: OutputStream): Boolean =
-            requireInstance().exportBrainToStream(output)
-        suspend fun importBrainFromStream(input: InputStream): Boolean =
-            requireInstance().importBrainFromStream(input)
-        suspend fun importBrainFromStream(context: Context, input: InputStream): Boolean =
-            getInstance(context).importBrainFromStream(input)
+        suspend fun onChannelSubscriptionChanged(
+            context: Context,
+            channelId: String,
+            channelName: String,
+            subscribed: Boolean,
+        ) = getInstance(context).onChannelSubscriptionChanged(channelId, channelName, subscribed)
 
-        suspend fun bootstrapFromSubscriptions(channelNames: List<String>) =
-            requireInstance().bootstrapFromSubscriptions(channelNames)
-        suspend fun bootstrapFromSubscriptions(context: Context, channelNames: List<String>) =
-            getInstance(context).bootstrapFromSubscriptions(channelNames)
+        suspend fun onSearchQuery(
+            context: Context,
+            query: String,
+        ) = getInstance(context).onSearchQuery(query)
 
-        suspend fun bootstrapFromWatchHistory(videos: List<Video>) =
-            requireInstance().bootstrapFromWatchHistory(videos)
-        suspend fun bootstrapFromWatchHistory(context: Context, videos: List<Video>) =
-            getInstance(context).bootstrapFromWatchHistory(videos)
+        suspend fun completeOnboarding(selectedTopics: Set<String>) = requireInstance().completeOnboarding(selectedTopics)
+
+        suspend fun completeOnboarding(
+            context: Context,
+            selectedTopics: Set<String>,
+        ) = getInstance(context).completeOnboarding(selectedTopics)
+
+        suspend fun exportBrainToStream(output: OutputStream): Boolean = requireInstance().exportBrainToStream(output)
+
+        suspend fun importBrainFromStream(input: InputStream): Boolean = requireInstance().importBrainFromStream(input)
+
+        suspend fun importBrainFromStream(
+            context: Context,
+            input: InputStream,
+        ): Boolean = getInstance(context).importBrainFromStream(input)
+
+        suspend fun bootstrapFromSubscriptions(channelNames: List<String>) = requireInstance().bootstrapFromSubscriptions(channelNames)
+
+        suspend fun bootstrapFromSubscriptions(
+            context: Context,
+            channelNames: List<String>,
+        ) = getInstance(context).bootstrapFromSubscriptions(channelNames)
+
+        suspend fun bootstrapFromWatchHistory(videos: List<Video>) = requireInstance().bootstrapFromWatchHistory(videos)
+
+        suspend fun bootstrapFromWatchHistory(
+            context: Context,
+            videos: List<Video>,
+        ) = getInstance(context).bootstrapFromWatchHistory(videos)
 
         suspend fun resetBrain() = requireInstance().resetBrain()
+
         suspend fun resetBrain(context: Context) = getInstance(context).resetBrain()
 
-        suspend fun recordSeenShorts(shortIds: List<String>) =
-            requireInstance().recordSeenShorts(shortIds)
-        suspend fun getRecentlySeenShorts(): Set<String> =
-            requireInstance().getRecentlySeenShorts()
+        suspend fun recordSeenShorts(shortIds: List<String>) = requireInstance().recordSeenShorts(shortIds)
+
+        suspend fun getRecentlySeenShorts(): Set<String> = requireInstance().getRecentlySeenShorts()
 
         suspend fun getPreferredTopics(): Set<String> = requireInstance().getPreferredTopics()
+
         suspend fun getBlockedTopics(): Set<String> = requireInstance().getBlockedTopics()
 
         suspend fun addPreferredTopic(topic: String) = requireInstance().addPreferredTopic(topic)
-        suspend fun addPreferredTopic(context: Context, topic: String) =
-            getInstance(context).addPreferredTopic(topic)
 
-        suspend fun removePreferredTopic(topic: String) =
-            requireInstance().removePreferredTopic(topic)
-        suspend fun removePreferredTopic(context: Context, topic: String) =
-            getInstance(context).removePreferredTopic(topic)
+        suspend fun addPreferredTopic(
+            context: Context,
+            topic: String,
+        ) = getInstance(context).addPreferredTopic(topic)
+
+        suspend fun removePreferredTopic(topic: String) = requireInstance().removePreferredTopic(topic)
+
+        suspend fun removePreferredTopic(
+            context: Context,
+            topic: String,
+        ) = getInstance(context).removePreferredTopic(topic)
 
         suspend fun addBlockedTopic(topic: String) = requireInstance().addBlockedTopic(topic)
-        suspend fun addBlockedTopic(context: Context, topic: String) =
-            getInstance(context).addBlockedTopic(topic)
 
-        suspend fun removeBlockedTopic(topic: String) =
-            requireInstance().removeBlockedTopic(topic)
-        suspend fun removeBlockedTopic(context: Context, topic: String) =
-            getInstance(context).removeBlockedTopic(topic)
+        suspend fun addBlockedTopic(
+            context: Context,
+            topic: String,
+        ) = getInstance(context).addBlockedTopic(topic)
+
+        suspend fun removeBlockedTopic(topic: String) = requireInstance().removeBlockedTopic(topic)
+
+        suspend fun removeBlockedTopic(
+            context: Context,
+            topic: String,
+        ) = getInstance(context).removeBlockedTopic(topic)
 
         suspend fun restoreContentPreferences(
             context: Context,
             preferredTopics: Set<String>,
             blockedTopics: Set<String>,
-            blockedChannels: Set<String>
+            blockedChannels: Set<String>,
         ) = getInstance(context).restoreContentPreferences(
             preferredTopics,
             blockedTopics,
-            blockedChannels
+            blockedChannels,
         )
 
-        suspend fun unblockChannel(channelId: String) =
-            requireInstance().unblockChannel(channelId)
-        suspend fun unblockChannel(context: Context, channelId: String) =
-            getInstance(context).unblockChannel(channelId)
+        suspend fun unblockChannel(channelId: String) = requireInstance().unblockChannel(channelId)
 
-        suspend fun blockChannel(channelId: String) =
-            requireInstance().blockChannel(channelId)
-        suspend fun blockChannel(context: Context, channelId: String) =
-            getInstance(context).blockChannel(channelId)
+        suspend fun unblockChannel(
+            context: Context,
+            channelId: String,
+        ) = getInstance(context).unblockChannel(channelId)
+
+        suspend fun blockChannel(channelId: String) = requireInstance().blockChannel(channelId)
+
+        suspend fun blockChannel(
+            context: Context,
+            channelId: String,
+        ) = getInstance(context).blockChannel(channelId)
 
         val TOPIC_CATEGORIES: List<TopicCategory>
             get() = NeuroTopicCatalog.TOPIC_CATEGORIES
@@ -211,19 +266,21 @@ class FlowNeuroEngine(private val appContext: Context) {
     private var pendingSaveJob: Job? = null
 
     // Feature vector cache (LRU)
-    private val featureCache = object : LinkedHashMap<String, ContentVector>(
-        200, 0.75f, true
-    ) {
-        override fun removeEldestEntry(
-            eldest: MutableMap.MutableEntry<String, ContentVector>?
-        ): Boolean = size > FEATURE_CACHE_MAX
-    }
+    private val featureCache =
+        object : LinkedHashMap<String, ContentVector>(
+            200,
+            0.75f,
+            true,
+        ) {
+            override fun removeEldestEntry(eldest: MutableMap.MutableEntry<String, ContentVector>?): Boolean = size > FEATURE_CACHE_MAX
+        }
 
     // Session tracking
     private var sessionStartTime: Long = System.currentTimeMillis()
     private var sessionVideoCount: Int = 0
     private val sessionTopicHistory = mutableListOf<String>()
     private val recentInteractions = mutableListOf<MomentumEntry>()
+
     // Counts a visible item at most once per session (viewport impressions).
     private val sessionImpressed = HashSet<String>()
 
@@ -232,18 +289,23 @@ class FlowNeuroEngine(private val appContext: Context) {
     private var idfTotalDocuments = 0
 
     // Impression cache
-    private val impressionCache = object : LinkedHashMap<String, ImpressionEntry>(
-        NeuroScoring.IMPRESSION_CACHE_MAX + 50, 0.75f, true
-    ) {
-        override fun removeEldestEntry(
-            eldest: MutableMap.MutableEntry<String, ImpressionEntry>?
-        ): Boolean = size > NeuroScoring.IMPRESSION_CACHE_MAX
-    }
+    private val impressionCache =
+        object : LinkedHashMap<String, ImpressionEntry>(
+            NeuroScoring.IMPRESSION_CACHE_MAX + 50,
+            0.75f,
+            true,
+        ) {
+            override fun removeEldestEntry(eldest: MutableMap.MutableEntry<String, ImpressionEntry>?): Boolean =
+                size > NeuroScoring.IMPRESSION_CACHE_MAX
+        }
 
     // Watch history
-    private val watchHistory = LinkedHashMap<String, WatchEntry>(
-        NeuroScoring.WATCH_HISTORY_MAX + 50, 0.75f, true
-    )
+    private val watchHistory =
+        LinkedHashMap<String, WatchEntry>(
+            NeuroScoring.WATCH_HISTORY_MAX + 50,
+            0.75f,
+            true,
+        )
 
     private var currentUserBrain: UserBrain = UserBrain()
     private var isInitialized = false
@@ -292,8 +354,7 @@ class FlowNeuroEngine(private val appContext: Context) {
         saveScope.cancel()
     }
 
-    suspend fun getBrainSnapshot(): UserBrain =
-        brainMutex.withLock { currentUserBrain }
+    suspend fun getBrainSnapshot(): UserBrain = brainMutex.withLock { currentUserBrain }
 
     suspend fun resetBrain() {
         brainMutex.withLock {
@@ -323,25 +384,24 @@ class FlowNeuroEngine(private val appContext: Context) {
         sessionImpressed.clear()
     }
 
-    fun getSessionDurationMinutes(): Long =
-        (System.currentTimeMillis() - sessionStartTime) / 60_000L
+    fun getSessionDurationMinutes(): Long = (System.currentTimeMillis() - sessionStartTime) / 60_000L
 
     private fun scheduleDebouncedSave() {
         pendingSaveJob?.cancel()
-        pendingSaveJob = saveScope.launch {
-            delay(SAVE_DEBOUNCE_MS)
-            brainMutex.withLock {
-                storage.save(currentUserBrain)
+        pendingSaveJob =
+            saveScope.launch {
+                delay(SAVE_DEBOUNCE_MS)
+                brainMutex.withLock {
+                    storage.save(currentUserBrain)
+                }
             }
-        }
     }
 
     // =================================================
     // BLOCKED TOPICS & CHANNELS API
     // =================================================
 
-    suspend fun getBlockedTopics(): Set<String> =
-        brainMutex.withLock { currentUserBrain.blockedTopics }
+    suspend fun getBlockedTopics(): Set<String> = brainMutex.withLock { currentUserBrain.blockedTopics }
 
     suspend fun addBlockedTopic(topic: String) {
         val normalized = topic.trim().lowercase()
@@ -349,24 +409,30 @@ class FlowNeuroEngine(private val appContext: Context) {
         brainMutex.withLock {
             val lemma = tokenizer.normalizeLemma(normalized)
 
-            val scrubbed = scrubTopicFromVector(
-                currentUserBrain.globalVector, lemma, normalized
-            )
-            val scrubbedTimeVectors = currentUserBrain.timeVectors
-                .mapValues { (_, vector) ->
-                    scrubTopicFromVector(vector, lemma, normalized)
-                }
+            val scrubbed =
+                scrubTopicFromVector(
+                    currentUserBrain.globalVector,
+                    lemma,
+                    normalized,
+                )
+            val scrubbedTimeVectors =
+                currentUserBrain.timeVectors
+                    .mapValues { (_, vector) ->
+                        scrubTopicFromVector(vector, lemma, normalized)
+                    }
 
-            val cleanedPreferred = currentUserBrain.preferredTopics
-                .filter { it.lowercase() != normalized }
-                .toSet()
+            val cleanedPreferred =
+                currentUserBrain.preferredTopics
+                    .filter { it.lowercase() != normalized }
+                    .toSet()
 
-            currentUserBrain = currentUserBrain.copy(
-                blockedTopics = currentUserBrain.blockedTopics + normalized,
-                globalVector = scrubbed,
-                timeVectors = scrubbedTimeVectors,
-                preferredTopics = cleanedPreferred
-            )
+            currentUserBrain =
+                currentUserBrain.copy(
+                    blockedTopics = currentUserBrain.blockedTopics + normalized,
+                    globalVector = scrubbed,
+                    timeVectors = scrubbedTimeVectors,
+                    preferredTopics = cleanedPreferred,
+                )
             storage.save(currentUserBrain)
         }
     }
@@ -374,48 +440,54 @@ class FlowNeuroEngine(private val appContext: Context) {
     private fun scrubTopicFromVector(
         vector: ContentVector,
         lemma: String,
-        raw: String
+        raw: String,
     ): ContentVector {
-        val cleaned = vector.topics.filter { (key, _) ->
-            !key.contains(lemma) && !key.contains(raw)
-        }
+        val cleaned =
+            vector.topics.filter { (key, _) ->
+                !key.contains(lemma) && !key.contains(raw)
+            }
         return vector.copy(topics = cleaned)
     }
 
     suspend fun removeBlockedTopic(topic: String) {
         brainMutex.withLock {
-            currentUserBrain = currentUserBrain.copy(
-                blockedTopics = currentUserBrain.blockedTopics -
-                    topic.lowercase()
-            )
+            currentUserBrain =
+                currentUserBrain.copy(
+                    blockedTopics =
+                        currentUserBrain.blockedTopics -
+                            topic.lowercase(),
+                )
             storage.save(currentUserBrain)
         }
     }
 
-    suspend fun getBlockedChannels(): Set<String> =
-        brainMutex.withLock { currentUserBrain.blockedChannels }
+    suspend fun getBlockedChannels(): Set<String> = brainMutex.withLock { currentUserBrain.blockedChannels }
 
     suspend fun blockChannel(channelId: String) {
         if (channelId.isBlank()) return
         brainMutex.withLock {
-            val cleanedScores = currentUserBrain.channelScores
-                .toMutableMap()
+            val cleanedScores =
+                currentUserBrain.channelScores
+                    .toMutableMap()
             cleanedScores.remove(channelId)
 
-            currentUserBrain = currentUserBrain.copy(
-                blockedChannels = currentUserBrain.blockedChannels +
-                    channelId,
-                channelScores = cleanedScores
-            )
+            currentUserBrain =
+                currentUserBrain.copy(
+                    blockedChannels =
+                        currentUserBrain.blockedChannels +
+                            channelId,
+                    channelScores = cleanedScores,
+                )
             storage.save(currentUserBrain)
         }
     }
 
     suspend fun unblockChannel(channelId: String) {
         brainMutex.withLock {
-            currentUserBrain = currentUserBrain.copy(
-                blockedChannels = currentUserBrain.blockedChannels - channelId
-            )
+            currentUserBrain =
+                currentUserBrain.copy(
+                    blockedChannels = currentUserBrain.blockedChannels - channelId,
+                )
             storage.save(currentUserBrain)
         }
     }
@@ -424,17 +496,16 @@ class FlowNeuroEngine(private val appContext: Context) {
     // ONBOARDING & PREFERRED TOPICS
     // =================================================
 
-    suspend fun needsOnboarding(): Boolean = brainMutex.withLock {
-        !currentUserBrain.hasCompletedOnboarding &&
-            currentUserBrain.totalInteractions < 5 &&
-            currentUserBrain.preferredTopics.isEmpty()
-    }
+    suspend fun needsOnboarding(): Boolean =
+        brainMutex.withLock {
+            !currentUserBrain.hasCompletedOnboarding &&
+                currentUserBrain.totalInteractions < 5 &&
+                currentUserBrain.preferredTopics.isEmpty()
+        }
 
-    suspend fun hasCompletedOnboarding(): Boolean =
-        brainMutex.withLock { currentUserBrain.hasCompletedOnboarding }
+    suspend fun hasCompletedOnboarding(): Boolean = brainMutex.withLock { currentUserBrain.hasCompletedOnboarding }
 
-    suspend fun getPreferredTopics(): Set<String> =
-        brainMutex.withLock { currentUserBrain.preferredTopics }
+    suspend fun getPreferredTopics(): Set<String> = brainMutex.withLock { currentUserBrain.preferredTopics }
 
     suspend fun setPreferredTopics(topics: Set<String>) {
         brainMutex.withLock {
@@ -442,12 +513,14 @@ class FlowNeuroEngine(private val appContext: Context) {
             topics.forEach { topic ->
                 newTopics[tokenizer.normalizeLemma(topic)] = 0.5
             }
-            currentUserBrain = currentUserBrain.copy(
-                preferredTopics = topics,
-                globalVector = currentUserBrain.globalVector.copy(
-                    topics = newTopics
+            currentUserBrain =
+                currentUserBrain.copy(
+                    preferredTopics = topics,
+                    globalVector =
+                        currentUserBrain.globalVector.copy(
+                            topics = newTopics,
+                        ),
                 )
-            )
             storage.save(currentUserBrain)
         }
     }
@@ -455,37 +528,44 @@ class FlowNeuroEngine(private val appContext: Context) {
     suspend fun restoreContentPreferences(
         preferredTopics: Set<String>,
         blockedTopics: Set<String>,
-        blockedChannels: Set<String>
+        blockedChannels: Set<String>,
     ) {
         initialize()
         brainMutex.withLock {
-            val normalizedPreferred = preferredTopics
-                .map { it.trim() }
-                .filter { it.isNotBlank() }
-                .toSet()
-            val normalizedBlocked = blockedTopics
-                .map { tokenizer.normalizeLemma(it) }
-                .filter { it.isNotBlank() }
-                .toSet()
+            val normalizedPreferred =
+                preferredTopics
+                    .map { it.trim() }
+                    .filter { it.isNotBlank() }
+                    .toSet()
+            val normalizedBlocked =
+                blockedTopics
+                    .map { tokenizer.normalizeLemma(it) }
+                    .filter { it.isNotBlank() }
+                    .toSet()
             val newTopics = currentUserBrain.globalVector.topics.toMutableMap()
             normalizedPreferred.forEach { topic ->
-                newTopics[tokenizer.normalizeLemma(topic)] = maxOf(
-                    newTopics[tokenizer.normalizeLemma(topic)] ?: 0.0,
-                    0.5
-                )
+                newTopics[tokenizer.normalizeLemma(topic)] =
+                    maxOf(
+                        newTopics[tokenizer.normalizeLemma(topic)] ?: 0.0,
+                        0.5,
+                    )
             }
             normalizedBlocked.forEach { topic -> newTopics.remove(topic) }
 
-            currentUserBrain = currentUserBrain.copy(
-                preferredTopics = normalizedPreferred.filterNot {
-                    tokenizer.normalizeLemma(it) in normalizedBlocked
-                }.toSet(),
-                blockedTopics = normalizedBlocked,
-                blockedChannels = blockedChannels.filter { it.isNotBlank() }.toSet(),
-                globalVector = currentUserBrain.globalVector.copy(topics = newTopics),
-                hasCompletedOnboarding = currentUserBrain.hasCompletedOnboarding ||
-                    normalizedPreferred.isNotEmpty()
-            )
+            currentUserBrain =
+                currentUserBrain.copy(
+                    preferredTopics =
+                        normalizedPreferred
+                            .filterNot {
+                                tokenizer.normalizeLemma(it) in normalizedBlocked
+                            }.toSet(),
+                    blockedTopics = normalizedBlocked,
+                    blockedChannels = blockedChannels.filter { it.isNotBlank() }.toSet(),
+                    globalVector = currentUserBrain.globalVector.copy(topics = newTopics),
+                    hasCompletedOnboarding =
+                        currentUserBrain.hasCompletedOnboarding ||
+                            normalizedPreferred.isNotEmpty(),
+                )
             storage.save(currentUserBrain)
         }
     }
@@ -496,21 +576,24 @@ class FlowNeuroEngine(private val appContext: Context) {
         brainMutex.withLock {
             val newTopics = currentUserBrain.globalVector.topics.toMutableMap()
             newTopics[tokenizer.normalizeLemma(normalized)] = 0.5
-            currentUserBrain = currentUserBrain.copy(
-                preferredTopics = currentUserBrain.preferredTopics + normalized,
-                globalVector = currentUserBrain.globalVector.copy(
-                    topics = newTopics
+            currentUserBrain =
+                currentUserBrain.copy(
+                    preferredTopics = currentUserBrain.preferredTopics + normalized,
+                    globalVector =
+                        currentUserBrain.globalVector.copy(
+                            topics = newTopics,
+                        ),
                 )
-            )
             storage.save(currentUserBrain)
         }
     }
 
     suspend fun removePreferredTopic(topic: String) {
         brainMutex.withLock {
-            currentUserBrain = currentUserBrain.copy(
-                preferredTopics = currentUserBrain.preferredTopics - topic
-            )
+            currentUserBrain =
+                currentUserBrain.copy(
+                    preferredTopics = currentUserBrain.preferredTopics - topic,
+                )
             storage.save(currentUserBrain)
         }
     }
@@ -518,9 +601,10 @@ class FlowNeuroEngine(private val appContext: Context) {
     suspend fun completeOnboarding(selectedTopics: Set<String>) {
         brainMutex.withLock {
             if (selectedTopics.isEmpty()) {
-                currentUserBrain = currentUserBrain.copy(
-                    hasCompletedOnboarding = true
-                )
+                currentUserBrain =
+                    currentUserBrain.copy(
+                        hasCompletedOnboarding = true,
+                    )
                 storage.save(currentUserBrain)
                 Log.i(TAG, "Onboarding completed without replacing existing topics")
                 return
@@ -530,11 +614,12 @@ class FlowNeuroEngine(private val appContext: Context) {
             val newTopics = mutableMapOf<String, Double>()
 
             topicList.forEachIndexed { index, topic ->
-                val weight = when {
-                    index < 3 -> 0.55
-                    index < 6 -> 0.40
-                    else -> 0.30
-                }
+                val weight =
+                    when {
+                        index < 3 -> 0.55
+                        index < 6 -> 0.40
+                        else -> 0.30
+                    }
                 newTopics[tokenizer.normalizeLemma(topic)] = weight
             }
 
@@ -542,21 +627,25 @@ class FlowNeuroEngine(private val appContext: Context) {
             val normalizedList = topicList.map { tokenizer.normalizeLemma(it) }
             for (i in normalizedList.indices) {
                 for (j in i + 1 until normalizedList.size) {
-                    val key = NeuroScoring.makeAffinityKey(
-                        normalizedList[i], normalizedList[j]
-                    )
+                    val key =
+                        NeuroScoring.makeAffinityKey(
+                            normalizedList[i],
+                            normalizedList[j],
+                        )
                     affinities[key] = 0.3
                 }
             }
 
-            currentUserBrain = currentUserBrain.copy(
-                preferredTopics = selectedTopics,
-                globalVector = currentUserBrain.globalVector.copy(
-                    topics = newTopics
-                ),
-                topicAffinities = affinities,
-                hasCompletedOnboarding = true
-            )
+            currentUserBrain =
+                currentUserBrain.copy(
+                    preferredTopics = selectedTopics,
+                    globalVector =
+                        currentUserBrain.globalVector.copy(
+                            topics = newTopics,
+                        ),
+                    topicAffinities = affinities,
+                    hasCompletedOnboarding = true,
+                )
             storage.save(currentUserBrain)
             Log.i(TAG, "Onboarding: ${selectedTopics.size} topics")
         }
@@ -565,20 +654,37 @@ class FlowNeuroEngine(private val appContext: Context) {
     private fun calculateTopicEvidenceSignal(
         interactionType: InteractionType,
         percentWatched: Float,
-        isShort: Boolean
+        isShort: Boolean,
     ): Double {
-        val base = when (interactionType) {
-            InteractionType.CLICK -> 0.20
-            InteractionType.LIKED -> 2.0
-            InteractionType.WATCHED -> when {
-                percentWatched >= NeuroScoring.WATCHED_THRESHOLD_FULL -> 1.5
-                percentWatched >= 0.40f -> 1.0
-                percentWatched >= NeuroScoring.WATCHED_THRESHOLD_SAMPLED -> 0.35
-                else -> 0.0
+        val base =
+            when (interactionType) {
+                InteractionType.CLICK -> {
+                    0.20
+                }
+
+                InteractionType.LIKED -> {
+                    2.0
+                }
+
+                InteractionType.SAVED -> {
+                    1.2
+                }
+
+                InteractionType.WATCHED -> {
+                    when {
+                        percentWatched >= NeuroScoring.WATCHED_THRESHOLD_FULL -> 1.5
+                        percentWatched >= 0.40f -> 1.0
+                        percentWatched >= NeuroScoring.WATCHED_THRESHOLD_SAMPLED -> 0.35
+                        else -> 0.0
+                    }
+                }
+
+                InteractionType.SKIPPED,
+                InteractionType.DISLIKED,
+                -> {
+                    0.0
+                }
             }
-            InteractionType.SKIPPED,
-            InteractionType.DISLIKED -> 0.0
-        }
         return if (isShort) base * 0.35 else base
     }
 
@@ -588,17 +694,18 @@ class FlowNeuroEngine(private val appContext: Context) {
         video: Video,
         signalScore: Double,
         isWatchSignal: Boolean,
-        isExplicitSignal: Boolean
+        isExplicitSignal: Boolean,
     ): Map<String, TopicEvidence> {
         if (signalScore <= 0.0) return current
 
         val now = System.currentTimeMillis()
-        val topics = videoVector.topics.entries
-            .sortedByDescending { it.value }
-            .take(5)
-            .map { NeuroScoring.stripDomainTag(it.key) }
-            .filter { it.length >= 3 }
-            .distinct()
+        val topics =
+            videoVector.topics.entries
+                .sortedByDescending { it.value }
+                .take(5)
+                .map { NeuroScoring.stripDomainTag(it.key) }
+                .filter { it.length >= 3 }
+                .distinct()
 
         if (topics.isEmpty()) return current
 
@@ -607,16 +714,17 @@ class FlowNeuroEngine(private val appContext: Context) {
             val existing = updated[topic]
             val nextVideoIds = cappedSet(existing?.videoIds.orEmpty(), video.id)
             val nextChannelIds = cappedSet(existing?.channelIds.orEmpty(), video.channelId)
-            updated[topic] = TopicEvidence(
-                positiveSignals = (existing?.positiveSignals ?: 0) + 1,
-                watchSignals = (existing?.watchSignals ?: 0) + if (isWatchSignal) 1 else 0,
-                explicitSignals = (existing?.explicitSignals ?: 0) + if (isExplicitSignal) 1 else 0,
-                positiveScore = ((existing?.positiveScore ?: 0.0) + signalScore).coerceAtMost(50.0),
-                videoIds = nextVideoIds,
-                channelIds = nextChannelIds,
-                firstSeenAt = existing?.firstSeenAt?.takeIf { it > 0L } ?: now,
-                lastSeenAt = now
-            )
+            updated[topic] =
+                TopicEvidence(
+                    positiveSignals = (existing?.positiveSignals ?: 0) + 1,
+                    watchSignals = (existing?.watchSignals ?: 0) + if (isWatchSignal) 1 else 0,
+                    explicitSignals = (existing?.explicitSignals ?: 0) + if (isExplicitSignal) 1 else 0,
+                    positiveScore = ((existing?.positiveScore ?: 0.0) + signalScore).coerceAtMost(50.0),
+                    videoIds = nextVideoIds,
+                    channelIds = nextChannelIds,
+                    firstSeenAt = existing?.firstSeenAt?.takeIf { it > 0L } ?: now,
+                    lastSeenAt = now,
+                )
         }
 
         return capEvidence(updated)
@@ -631,38 +739,42 @@ class FlowNeuroEngine(private val appContext: Context) {
                 .sortedWith(
                     compareByDescending<Map.Entry<String, TopicEvidence>> {
                         it.value.positiveScore + it.value.negativeSignals
-                    }.thenByDescending { it.value.lastSeenAt }
-                )
-                .take(TOPIC_EVIDENCE_MAX_ENTRIES)
+                    }.thenByDescending { it.value.lastSeenAt },
+                ).take(TOPIC_EVIDENCE_MAX_ENTRIES)
                 .associate { it.key to it.value }
         }
 
     // Records a negative signal against a video's primary topics (skip/dislike/not-interested).
     private fun bumpNegativeEvidence(
         current: Map<String, TopicEvidence>,
-        videoVector: ContentVector
+        videoVector: ContentVector,
     ): Map<String, TopicEvidence> {
-        val topics = videoVector.topics.entries
-            .sortedByDescending { it.value }
-            .take(5)
-            .map { NeuroScoring.stripDomainTag(it.key) }
-            .filter { it.length >= 3 }
-            .distinct()
+        val topics =
+            videoVector.topics.entries
+                .sortedByDescending { it.value }
+                .take(5)
+                .map { NeuroScoring.stripDomainTag(it.key) }
+                .filter { it.length >= 3 }
+                .distinct()
         if (topics.isEmpty()) return current
 
         val now = System.currentTimeMillis()
         val updated = current.toMutableMap()
         topics.forEach { topic ->
             val existing = updated[topic]
-            updated[topic] = (existing ?: TopicEvidence(firstSeenAt = now)).copy(
-                negativeSignals = (existing?.negativeSignals ?: 0) + 1,
-                lastSeenAt = now
-            )
+            updated[topic] =
+                (existing ?: TopicEvidence(firstSeenAt = now)).copy(
+                    negativeSignals = (existing?.negativeSignals ?: 0) + 1,
+                    lastSeenAt = now,
+                )
         }
         return capEvidence(updated)
     }
 
-    private fun cappedSet(existing: Set<String>, value: String): Set<String> {
+    private fun cappedSet(
+        existing: Set<String>,
+        value: String,
+    ): Set<String> {
         if (value.isBlank()) return existing
         if (value in existing) return existing
         return (existing.toList() + value).takeLast(TOPIC_EVIDENCE_MAX_IDS).toSet()
@@ -690,8 +802,9 @@ class FlowNeuroEngine(private val appContext: Context) {
                 val tokens = tokenizer.tokenize(name)
                 tokens.forEach { token ->
                     val current = topicWeights[token] ?: 0.0
-                    topicWeights[token] = (current + bootstrapWeight)
-                        .coerceAtMost(0.60)
+                    topicWeights[token] =
+                        (current + bootstrapWeight)
+                            .coerceAtMost(0.60)
                 }
             }
 
@@ -706,44 +819,49 @@ class FlowNeuroEngine(private val appContext: Context) {
                 mergedTopics[key] = maxOf(existing, weight)
             }
 
-            val topKeywords = topicWeights.entries
-                .sortedByDescending { it.value }
-                .take(15)
-                .map { it.key }
+            val topKeywords =
+                topicWeights.entries
+                    .sortedByDescending { it.value }
+                    .take(15)
+                    .map { it.key }
 
             val newAffinities = currentUserBrain.topicAffinities.toMutableMap()
             for (i in topKeywords.indices) {
                 for (j in i + 1 until topKeywords.size) {
                     val key = NeuroScoring.makeAffinityKey(topKeywords[i], topKeywords[j])
                     val current = newAffinities[key] ?: 0.0
-                    newAffinities[key] = (current + 0.15)
-                        .coerceAtMost(NeuroScoring.AFFINITY_MAX)
+                    newAffinities[key] =
+                        (current + 0.15)
+                            .coerceAtMost(NeuroScoring.AFFINITY_MAX)
                 }
             }
 
-            val preferredFromSubs = topicWeights.entries
-                .sortedByDescending { it.value }
-                .take(10)
-                .map { it.key }
-                .toSet()
+            val preferredFromSubs =
+                topicWeights.entries
+                    .sortedByDescending { it.value }
+                    .take(10)
+                    .map { it.key }
+                    .toSet()
 
             val mergedPreferred = currentUserBrain.preferredTopics + preferredFromSubs
 
-            currentUserBrain = currentUserBrain.copy(
-                globalVector = currentUserBrain.globalVector.copy(
-                    topics = mergedTopics
-                ),
-                topicAffinities = newAffinities,
-                preferredTopics = mergedPreferred,
-                hasCompletedOnboarding = true
-            )
+            currentUserBrain =
+                currentUserBrain.copy(
+                    globalVector =
+                        currentUserBrain.globalVector.copy(
+                            topics = mergedTopics,
+                        ),
+                    topicAffinities = newAffinities,
+                    preferredTopics = mergedPreferred,
+                    hasCompletedOnboarding = true,
+                )
 
             storage.save(currentUserBrain)
             Log.i(
                 TAG,
                 "Bootstrap: seeded ${topicWeights.size} topics from " +
                     "${channelNames.size} subscriptions " +
-                    "(top: ${topKeywords.take(5).joinToString()})"
+                    "(top: ${topKeywords.take(5).joinToString()})",
             )
         }
     }
@@ -752,8 +870,9 @@ class FlowNeuroEngine(private val appContext: Context) {
         if (videos.isEmpty()) return
 
         brainMutex.withLock {
-            val isMatureBrain = currentUserBrain.totalInteractions > 50 &&
-                currentUserBrain.globalVector.topics.size > 10
+            val isMatureBrain =
+                currentUserBrain.totalInteractions > 50 &&
+                    currentUserBrain.globalVector.topics.size > 10
             val historyLearningRate = if (isMatureBrain) 0.015 else 0.035
 
             val idfSnapshot = takeIdfSnapshot()
@@ -762,96 +881,110 @@ class FlowNeuroEngine(private val appContext: Context) {
             val maxToProcess = 500
 
             val perChannelCounts = mutableMapOf<String, Int>()
-            val toProcess = videos
-                .asSequence()
-                .filter { it.id.isNotBlank() && it.title.isNotBlank() }
-                .distinctBy { it.id }
-                .sortedByDescending { it.timestamp }
-                .filter { video ->
-                    val channelKey = video.channelId.ifBlank { video.channelName }
-                    if (channelKey.isBlank()) return@filter true
-                    val count = perChannelCounts[channelKey] ?: 0
-                    if (count >= 20) false else {
-                        perChannelCounts[channelKey] = count + 1
-                        true
-                    }
-                }
-                .take(maxToProcess)
-                .toList()
+            val toProcess =
+                videos
+                    .asSequence()
+                    .filter { it.id.isNotBlank() && it.title.isNotBlank() }
+                    .distinctBy { it.id }
+                    .sortedByDescending { it.timestamp }
+                    .filter { video ->
+                        val channelKey = video.channelId.ifBlank { video.channelName }
+                        if (channelKey.isBlank()) return@filter true
+                        val count = perChannelCounts[channelKey] ?: 0
+                        if (count >= 20) {
+                            false
+                        } else {
+                            perChannelCounts[channelKey] = count + 1
+                            true
+                        }
+                    }.take(maxToProcess)
+                    .toList()
 
             toProcess.forEachIndexed { index, video ->
                 val videoVector = tokenizer.extractFeatures(video, idfSnapshot)
                 val indexDecay = 1.0 - (index.toDouble() / maxToProcess * 0.4)
                 val effectiveRate = historyLearningRate * indexDecay.coerceIn(0.6, 1.0)
 
-                val newGlobal = NeuroVectorMath.adjustVector(
-                    updatedBrain.globalVector, videoVector, effectiveRate
-                )
+                val newGlobal =
+                    NeuroVectorMath.adjustVector(
+                        updatedBrain.globalVector,
+                        videoVector,
+                        effectiveRate,
+                    )
 
                 val currentChScore = updatedBrain.channelScores[video.channelId] ?: 0.5
                 val newChScore = (currentChScore * 0.95) + (1.0 * 0.05)
-                val newChannelScores = updatedBrain.channelScores +
-                    (video.channelId to newChScore)
+                val newChannelScores =
+                    updatedBrain.channelScores +
+                        (video.channelId to newChScore)
 
                 var newAffinities = updatedBrain.topicAffinities
-                val topTopics = videoVector.topics.entries
-                    .sortedByDescending { it.value }
-                    .take(3)
-                    .map { it.key }
+                val topTopics =
+                    videoVector.topics.entries
+                        .sortedByDescending { it.value }
+                        .take(3)
+                        .map { it.key }
                 if (topTopics.size >= 2) {
                     val mutableAffinities = newAffinities.toMutableMap()
                     for (i in topTopics.indices) {
                         for (j in i + 1 until topTopics.size) {
                             val key = NeuroScoring.makeAffinityKey(topTopics[i], topTopics[j])
                             val current = mutableAffinities[key] ?: 0.0
-                            mutableAffinities[key] = (current + 0.01)
-                                .coerceAtMost(NeuroScoring.AFFINITY_MAX)
+                            mutableAffinities[key] =
+                                (current + 0.01)
+                                    .coerceAtMost(NeuroScoring.AFFINITY_MAX)
                         }
                     }
                     newAffinities = mutableAffinities
                 }
 
-                val newTopicEvidence = updateTopicEvidence(
-                    updatedBrain.topicEvidence,
-                    videoVector,
-                    video,
-                    signalScore = 0.25,
-                    isWatchSignal = false,
-                    isExplicitSignal = false
-                )
+                val newTopicEvidence =
+                    updateTopicEvidence(
+                        updatedBrain.topicEvidence,
+                        videoVector,
+                        video,
+                        signalScore = 0.25,
+                        isWatchSignal = false,
+                        isExplicitSignal = false,
+                    )
 
                 videoVector.topics.keys.forEach { word ->
                     idfWordFrequency[word] = (idfWordFrequency[word] ?: 0) + 1
                 }
                 idfTotalDocuments++
 
-                updatedBrain = updatedBrain.copy(
-                    globalVector = newGlobal,
-                    channelScores = newChannelScores,
-                    topicAffinities = newAffinities,
-                    topicEvidence = newTopicEvidence,
-                    totalInteractions = updatedBrain.totalInteractions + 1
-                )
+                updatedBrain =
+                    updatedBrain.copy(
+                        globalVector = newGlobal,
+                        channelScores = newChannelScores,
+                        topicAffinities = newAffinities,
+                        topicEvidence = newTopicEvidence,
+                        totalInteractions = updatedBrain.totalInteractions + 1,
+                    )
             }
 
             toProcess.forEach { video ->
                 watchHistory[video.id] = WatchEntry(0.5f, System.currentTimeMillis())
             }
 
-            currentUserBrain = updatedBrain.copy(
-                idfWordFrequency = idfWordFrequency.toMap(),
-                idfTotalDocuments = idfTotalDocuments,
-                watchHistoryMap = watchHistory.mapValues { it.value.percentWatched },
-                hasCompletedOnboarding = true
-            )
+            currentUserBrain =
+                updatedBrain.copy(
+                    idfWordFrequency = idfWordFrequency.toMap(),
+                    idfTotalDocuments = idfTotalDocuments,
+                    watchHistoryMap = watchHistory.mapValues { it.value.percentWatched },
+                    hasCompletedOnboarding = true,
+                )
 
             compactIdfIfNeeded()
 
             storage.save(currentUserBrain)
             featureCache.clear()
 
-            Log.i(TAG, "History bootstrap: processed ${toProcess.size} videos, " +
-                "${updatedBrain.globalVector.topics.size} topics learned")
+            Log.i(
+                TAG,
+                "History bootstrap: processed ${toProcess.size} videos, " +
+                    "${updatedBrain.globalVector.topics.size} topics learned",
+            )
         }
     }
 
@@ -897,10 +1030,11 @@ class FlowNeuroEngine(private val appContext: Context) {
 
             rejectionKeys.forEach { key ->
                 val existing = updatedPatterns[key]
-                updatedPatterns[key] = RejectionSignal(
-                    count = (existing?.count ?: 0) + 1,
-                    lastRejectedAt = now
-                )
+                updatedPatterns[key] =
+                    RejectionSignal(
+                        count = (existing?.count ?: 0) + 1,
+                        lastRejectedAt = now,
+                    )
             }
 
             // Prune expired patterns
@@ -911,19 +1045,26 @@ class FlowNeuroEngine(private val appContext: Context) {
             // Size cap
             if (updatedPatterns.size > NeuroScoring.REJECTION_MEMORY_MAX) {
                 val sorted = updatedPatterns.entries.sortedBy { it.value.lastRejectedAt }
-                val toRemove = sorted.take(
-                    updatedPatterns.size - NeuroScoring.REJECTION_MEMORY_MAX
-                )
+                val toRemove =
+                    sorted.take(
+                        updatedPatterns.size - NeuroScoring.REJECTION_MEMORY_MAX,
+                    )
                 toRemove.forEach { updatedPatterns.remove(it.key) }
             }
 
             // 4. Aggressive vector adjustment — scales with rejection count
-            val aggressionFactor = NeuroScoring.getRejectionAggressionFactor(
-                videoVector, updatedPatterns, now
-            )
-            val newGlobal = adjustVectorByRejection(
-                currentUserBrain.globalVector, videoVector, aggressionFactor
-            )
+            val aggressionFactor =
+                NeuroScoring.getRejectionAggressionFactor(
+                    videoVector,
+                    updatedPatterns,
+                    now,
+                )
+            val newGlobal =
+                adjustVectorByRejection(
+                    currentUserBrain.globalVector,
+                    videoVector,
+                    aggressionFactor,
+                )
 
             // 5. Channel score — scales with rejection aggression
             val newChannelScores = currentUserBrain.channelScores.toMutableMap()
@@ -936,26 +1077,32 @@ class FlowNeuroEngine(private val appContext: Context) {
             // 6. Time bucket adjustment
             val bucket = TimeBucket.current()
             val currentBucketVec = currentUserBrain.timeVectors[bucket] ?: ContentVector()
-            val newBucketVec = NeuroVectorMath.adjustVector(
-                currentBucketVec, videoVector, NeuroScoring.NOT_INTERESTED_TIME_RATE
-            )
+            val newBucketVec =
+                NeuroVectorMath.adjustVector(
+                    currentBucketVec,
+                    videoVector,
+                    NeuroScoring.NOT_INTERESTED_TIME_RATE,
+                )
 
             // 7. Consecutive skips
-            val newSkips = (currentUserBrain.consecutiveSkips +
-                NeuroScoring.NOT_INTERESTED_SKIP_INCREMENT)
-                .coerceAtMost(NeuroScoring.MAX_CONSECUTIVE_SKIPS)
+            val newSkips =
+                (
+                    currentUserBrain.consecutiveSkips +
+                        NeuroScoring.NOT_INTERESTED_SKIP_INCREMENT
+                ).coerceAtMost(NeuroScoring.MAX_CONSECUTIVE_SKIPS)
 
-            currentUserBrain = currentUserBrain.copy(
-                globalVector = newGlobal,
-                timeVectors = currentUserBrain.timeVectors + (bucket to newBucketVec),
-                channelScores = newChannelScores,
-                totalInteractions = currentUserBrain.totalInteractions + 1,
-                consecutiveSkips = newSkips,
-                suppressedVideoIds = newSuppressedVideos,
-                suppressedChannels = newSuppressedChannels,
-                rejectionPatterns = updatedPatterns,
-                topicEvidence = bumpNegativeEvidence(currentUserBrain.topicEvidence, videoVector)
-            )
+            currentUserBrain =
+                currentUserBrain.copy(
+                    globalVector = newGlobal,
+                    timeVectors = currentUserBrain.timeVectors + (bucket to newBucketVec),
+                    channelScores = newChannelScores,
+                    totalInteractions = currentUserBrain.totalInteractions + 1,
+                    consecutiveSkips = newSkips,
+                    suppressedVideoIds = newSuppressedVideos,
+                    suppressedChannels = newSuppressedChannels,
+                    rejectionPatterns = updatedPatterns,
+                    topicEvidence = bumpNegativeEvidence(currentUserBrain.topicEvidence, videoVector),
+                )
             storage.save(currentUserBrain)
         }
     }
@@ -963,14 +1110,15 @@ class FlowNeuroEngine(private val appContext: Context) {
     private fun adjustVectorByRejection(
         current: ContentVector,
         target: ContentVector,
-        aggressionFactor: Double
+        aggressionFactor: Double,
     ): ContentVector {
         val newTopics = current.topics.toMutableMap()
         target.topics.forEach { (key, _) ->
             val currentVal = newTopics[key] ?: 0.0
             if (currentVal > 0) {
-                newTopics[key] = (currentVal * aggressionFactor)
-                    .coerceAtMost(0.3)
+                newTopics[key] =
+                    (currentVal * aggressionFactor)
+                        .coerceAtMost(0.3)
             }
         }
         newTopics.entries.removeAll { it.value < NeuroVectorMath.TOPIC_PRUNE_THRESHOLD }
@@ -982,75 +1130,86 @@ class FlowNeuroEngine(private val appContext: Context) {
     // =================================================
 
     suspend fun generateDiscoveryQueries(): List<String> =
-        withContext(Dispatchers.Default) { brainMutex.withLock {
-            val brain = currentUserBrain
-            val blocked = brain.blockedTopics
+        withContext(Dispatchers.Default) {
+            brainMutex.withLock {
+                val brain = currentUserBrain
+                val blocked = brain.blockedTopics
 
-            // V3 discovery engine
-            val discoveryQueries = discovery.generateQueries(brain) { b -> getPersona(b) }
+                // V3 discovery engine
+                val discoveryQueries = discovery.generateQueries(brain) { b -> getPersona(b) }
 
-            var candidates = if (discoveryQueries.isNotEmpty()) {
-                discoveryQueries
-                    .map { it.query }
-                    .filter { query ->
-                        !blocked.any { blockedTerm ->
-                            query.lowercase().contains(blockedTerm)
+                var candidates =
+                    if (discoveryQueries.isNotEmpty()) {
+                        discoveryQueries
+                            .map { it.query }
+                            .filter { query ->
+                                !blocked.any { blockedTerm ->
+                                    query.lowercase().contains(blockedTerm)
+                                }
+                            }
+                    } else {
+                        val preferred = brain.preferredTopics.toList()
+                        if (preferred.isNotEmpty()) {
+                            preferred.shuffled().take(5)
+                        } else {
+                            listOf("Music", "Science", "Technology", "Education", "Nature")
                         }
                     }
-            } else {
-                val preferred = brain.preferredTopics.toList()
-                if (preferred.isNotEmpty()) preferred.shuffled().take(5)
-                else listOf("Music", "Science", "Technology", "Education", "Nature")
-            }
 
-            // ── Query rotation: filter queries too similar to recently used ones ──
-            if (brain.recentQueryTokens.isNotEmpty() && candidates.size > 3) {
-                val rotated = candidates.filter { query ->
-                    val tokens = tokenizer.tokenize(query).toSet()
-                    if (tokens.isEmpty()) return@filter true
-                    brain.recentQueryTokens.none { recent ->
-                        if (recent.isEmpty()) return@none false
-                        val intersection = tokens.intersect(recent).size
-                        val union = tokens.union(recent).size
-                        intersection.toDouble() / union >
-                            NeuroScoring.QUERY_OVERLAP_THRESHOLD
+                // ── Query rotation: filter queries too similar to recently used ones ──
+                if (brain.recentQueryTokens.isNotEmpty() && candidates.size > 3) {
+                    val rotated =
+                        candidates.filter { query ->
+                            val tokens = tokenizer.tokenize(query).toSet()
+                            if (tokens.isEmpty()) return@filter true
+                            brain.recentQueryTokens.none { recent ->
+                                if (recent.isEmpty()) return@none false
+                                val intersection = tokens.intersect(recent).size
+                                val union = tokens.union(recent).size
+                                intersection.toDouble() / union >
+                                    NeuroScoring.QUERY_OVERLAP_THRESHOLD
+                            }
+                        }
+                    if (rotated.size >= candidates.size / 3) {
+                        candidates = rotated
                     }
                 }
-                if (rotated.size >= candidates.size / 3) {
-                    candidates = rotated
-                }
+
+                // ── Track used queries for future rotation ──
+                val newQueryTokens = candidates.map { tokenizer.tokenize(it).toSet() }
+                val updatedRecentTokens =
+                    (brain.recentQueryTokens + newQueryTokens)
+                        .takeLast(NeuroScoring.RECENT_QUERY_TOKENS_MAX)
+
+                currentUserBrain =
+                    currentUserBrain.copy(
+                        recentQueryTokens = updatedRecentTokens,
+                    )
+                scheduleDebouncedSave()
+
+                Log.d(TAG, "Discovery queries (${candidates.size}): ${candidates.take(6)}")
+
+                candidates
             }
-
-            // ── Track used queries for future rotation ──
-            val newQueryTokens = candidates.map { tokenizer.tokenize(it).toSet() }
-            val updatedRecentTokens = (brain.recentQueryTokens + newQueryTokens)
-                .takeLast(NeuroScoring.RECENT_QUERY_TOKENS_MAX)
-
-            currentUserBrain = currentUserBrain.copy(
-                recentQueryTokens = updatedRecentTokens
-            )
-            scheduleDebouncedSave()
-
-            Log.d(TAG, "Discovery queries (${candidates.size}): ${candidates.take(6)}")
-
-            candidates
-        } }
+        }
 
     suspend fun selectRelatedSeeds(
         candidates: List<GraphSeedInput>,
-        maxSeeds: Int = 4
-    ): List<String> = withContext(Dispatchers.Default) {
-        if (candidates.isEmpty()) return@withContext emptyList()
-        val now = System.currentTimeMillis()
-        val excludedChannelIds = brainMutex.withLock {
-            val channelSuppressionCutoff = now - (CHANNEL_SUPPRESSION_DAYS * 24 * 60 * 60 * 1000L)
-            currentUserBrain.blockedChannels +
-                currentUserBrain.suppressedChannels
-                    .filter { (_, ts) -> ts > channelSuppressionCutoff }
-                    .keys
+        maxSeeds: Int = 4,
+    ): List<String> =
+        withContext(Dispatchers.Default) {
+            if (candidates.isEmpty()) return@withContext emptyList()
+            val now = System.currentTimeMillis()
+            val excludedChannelIds =
+                brainMutex.withLock {
+                    val channelSuppressionCutoff = now - (CHANNEL_SUPPRESSION_DAYS * 24 * 60 * 60 * 1000L)
+                    currentUserBrain.blockedChannels +
+                        currentUserBrain.suppressedChannels
+                            .filter { (_, ts) -> ts > channelSuppressionCutoff }
+                            .keys
+                }
+            GraphSeedSelector.select(candidates, maxSeeds, now, excludedChannelIds)
         }
-        GraphSeedSelector.select(candidates, maxSeeds, now, excludedChannelIds)
-    }
 
     // =================================================
     // MAIN RANKING FUNCTION
@@ -1058,187 +1217,221 @@ class FlowNeuroEngine(private val appContext: Context) {
 
     suspend fun rank(
         candidates: List<Video>,
-        userSubs: Set<String>
-    ): List<Video> = withContext(Dispatchers.Default) {
-        if (candidates.isEmpty()) return@withContext emptyList()
+        userSubs: Set<String>,
+    ): List<Video> =
+        withContext(Dispatchers.Default) {
+            if (candidates.isEmpty()) return@withContext emptyList()
 
-        // Session staleness auto-reset
-        val sessionAgeMinutes = getSessionDurationMinutes()
-        if (sessionAgeMinutes > NeuroScoring.SESSION_RESET_IDLE_MINUTES ||
-            (sessionAgeMinutes > NeuroScoring.SESSION_RESET_EMPTY_MINUTES &&
-                sessionVideoCount == 0)
-        ) {
-            brainMutex.withLock { resetSessionInternal() }
-        }
-
-        // Take consistent snapshots under the lock
-        val brain: UserBrain
-        val idfSnapshot: IdfSnapshot
-        val sessionTopics: List<String>
-        val impressionSnapshot: Map<String, ImpressionEntry>
-        val watchHistorySnapshot: Map<String, WatchEntry>
-        val recentInteractionsSnapshot: List<MomentumEntry>
-
-        brainMutex.withLock {
-            brain = currentUserBrain
-            idfSnapshot = takeIdfSnapshot()
-            sessionTopics = sessionTopicHistory.toList()
-            impressionSnapshot = impressionCache.toMap()
-            watchHistorySnapshot = watchHistory.toMap()
-            recentInteractionsSnapshot = recentInteractions.toList()
-        }
-
-        val random = java.util.Random()
-        val now = System.currentTimeMillis()
-
-        // Hard suppression sets (time-bounded)
-        val videoSuppressionCutoff = now - (VIDEO_SUPPRESSION_DAYS * 24 * 60 * 60 * 1000L)
-        val channelSuppressionCutoff = now - (CHANNEL_SUPPRESSION_DAYS * 24 * 60 * 60 * 1000L)
-        val activeSuppressedVideos = brain.suppressedVideoIds
-            .filter { (_, ts) -> ts > videoSuppressionCutoff }.keys
-        val activeSuppressedChannels = brain.suppressedChannels
-            .filter { (_, ts) -> ts > channelSuppressionCutoff }.keys
-
-        // Precompute blocked topic expansion ONCE
-        val expandedBlockedKeywords: Set<String> = brain.blockedTopics.flatMapTo(
-            mutableSetOf()
-        ) { blocked ->
-            val blockedLower = blocked.lowercase()
-            val matchingCategory = NeuroTopicCatalog.TOPIC_CATEGORIES.find { cat ->
-                cat.topics.any { it.lowercase() == blockedLower }
+            // Session staleness auto-reset
+            val sessionAgeMinutes = getSessionDurationMinutes()
+            if (sessionAgeMinutes > NeuroScoring.SESSION_RESET_IDLE_MINUTES ||
+                (
+                    sessionAgeMinutes > NeuroScoring.SESSION_RESET_EMPTY_MINUTES &&
+                        sessionVideoCount == 0
+                )
+            ) {
+                brainMutex.withLock { resetSessionInternal() }
             }
-            val keywords = if (matchingCategory != null) {
-                matchingCategory.topics.mapTo(mutableListOf()) { it.lowercase() }
-                    .also { it.add(blockedLower) }
-            } else {
-                mutableListOf(blockedLower)
+
+            // Take consistent snapshots under the lock
+            val brain: UserBrain
+            val idfSnapshot: IdfSnapshot
+            val sessionTopics: List<String>
+            val impressionSnapshot: Map<String, ImpressionEntry>
+            val watchHistorySnapshot: Map<String, WatchEntry>
+            val recentInteractionsSnapshot: List<MomentumEntry>
+
+            brainMutex.withLock {
+                brain = currentUserBrain
+                idfSnapshot = takeIdfSnapshot()
+                sessionTopics = sessionTopicHistory.toList()
+                impressionSnapshot = impressionCache.toMap()
+                watchHistorySnapshot = watchHistory.toMap()
+                recentInteractionsSnapshot = recentInteractions.toList()
             }
-            keywords
-        }
 
-        val expandedWithLemmas: Set<String> = expandedBlockedKeywords.flatMapTo(
-            mutableSetOf()
-        ) { keyword ->
-            setOf(keyword, tokenizer.normalizeLemma(keyword))
-        }
+            val random = java.util.Random()
+            val now = System.currentTimeMillis()
 
-        // ── Feed overlap ratio (for adaptive jitter + feed history penalty) ──
-        val feedOverlapRatio = if (candidates.isEmpty() || brain.feedHistory.isEmpty()) {
-            0.0
-        } else {
-            val candidateIds = candidates.map { it.id }.toSet()
-            val recentHistoryIds = brain.feedHistory
-                .filter { (_, entry) ->
-                    (now - entry.lastShown) < 48L * 60 * 60 * 1000
-                }.keys
-            val overlap = candidateIds.intersect(recentHistoryIds).size
-            (overlap.toDouble() / candidateIds.size).coerceIn(0.0, 1.0)
-        }
+            // Hard suppression sets (time-bounded)
+            val videoSuppressionCutoff = now - (VIDEO_SUPPRESSION_DAYS * 24 * 60 * 60 * 1000L)
+            val channelSuppressionCutoff = now - (CHANNEL_SUPPRESSION_DAYS * 24 * 60 * 60 * 1000L)
+            val activeSuppressedVideos =
+                brain.suppressedVideoIds
+                    .filter { (_, ts) -> ts > videoSuppressionCutoff }
+                    .keys
+            val activeSuppressedChannels =
+                brain.suppressedChannels
+                    .filter { (_, ts) -> ts > channelSuppressionCutoff }
+                    .keys
 
-        // Pre-filter blocked content
-        val filtered = candidates.filter { video ->
-            if (video.id in activeSuppressedVideos) return@filter false
-            if (video.channelId in activeSuppressedChannels) return@filter false
-            if (brain.blockedChannels.contains(video.channelId)) {
-                return@filter false
-            }
-            val titleLower = video.title.lowercase()
-            val channelLower = video.channelName.lowercase()
+            // Precompute blocked topic expansion ONCE
+            val expandedBlockedKeywords: Set<String> =
+                brain.blockedTopics.flatMapTo(
+                    mutableSetOf(),
+                ) { blocked ->
+                    val blockedLower = blocked.lowercase()
+                    val matchingCategory =
+                        NeuroTopicCatalog.TOPIC_CATEGORIES.find { cat ->
+                            cat.topics.any { it.lowercase() == blockedLower }
+                        }
+                    val keywords =
+                        if (matchingCategory != null) {
+                            matchingCategory.topics
+                                .mapTo(mutableListOf()) { it.lowercase() }
+                                .also { it.add(blockedLower) }
+                        } else {
+                            mutableListOf(blockedLower)
+                        }
+                    keywords
+                }
 
-            !expandedWithLemmas.any { blocked ->
-                titleLower.contains(blocked) || channelLower.contains(blocked)
-            }
-        }
+            val expandedWithLemmas: Set<String> =
+                expandedBlockedKeywords.flatMapTo(
+                    mutableSetOf(),
+                ) { keyword ->
+                    setOf(keyword, tokenizer.normalizeLemma(keyword))
+                }
 
-        if (filtered.isEmpty()) return@withContext emptyList()
+            // ── Feed overlap ratio (for adaptive jitter + feed history penalty) ──
+            val feedOverlapRatio =
+                if (candidates.isEmpty() || brain.feedHistory.isEmpty()) {
+                    0.0
+                } else {
+                    val candidateIds = candidates.map { it.id }.toSet()
+                    val recentHistoryIds =
+                        brain.feedHistory
+                            .filter { (_, entry) ->
+                                (now - entry.lastShown) < 48L * 60 * 60 * 1000
+                            }.keys
+                    val overlap = candidateIds.intersect(recentHistoryIds).size
+                    (overlap.toDouble() / candidateIds.size).coerceIn(0.0, 1.0)
+                }
 
-        // Extract all features with consistent IDF snapshot
-        val videoVectors = filtered.map { video ->
-            val channelProfile = brain.channelTopicProfiles[video.channelId]
-            video to getOrExtractFeatures(video, idfSnapshot, channelProfile)
-        }
+            // Pre-filter blocked content
+            val filtered =
+                candidates.filter { video ->
+                    if (video.id in activeSuppressedVideos) return@filter false
+                    if (video.channelId in activeSuppressedChannels) return@filter false
+                    if (brain.blockedChannels.contains(video.channelId)) {
+                        return@filter false
+                    }
+                    val titleLower = video.title.lowercase()
+                    val channelLower = video.channelName.lowercase()
 
-        // Vector-level topic blocking: remove videos whose top topics match blocked topics
-        val blockedTopicLemmas = brain.blockedTopics.map { tokenizer.normalizeLemma(it) }.toSet()
-        val vectorFiltered = if (blockedTopicLemmas.isEmpty()) videoVectors else {
-            videoVectors.filter { (_, vector) ->
-                val topVideoTopics = vector.topics.entries
-                    .sortedByDescending { it.value }.take(3).map { it.key }
-                !topVideoTopics.any { topic ->
-                    blockedTopicLemmas.any { blocked ->
-                        topic.contains(blocked) || blocked.contains(topic)
+                    !expandedWithLemmas.any { blocked ->
+                        titleLower.contains(blocked) || channelLower.contains(blocked)
                     }
                 }
-            }
+
+            if (filtered.isEmpty()) return@withContext emptyList()
+
+            // Extract all features with consistent IDF snapshot
+            val videoVectors =
+                filtered.map { video ->
+                    val channelProfile = brain.channelTopicProfiles[video.channelId]
+                    video to getOrExtractFeatures(video, idfSnapshot, channelProfile)
+                }
+
+            // Vector-level topic blocking: remove videos whose top topics match blocked topics
+            val blockedTopicLemmas = brain.blockedTopics.map { tokenizer.normalizeLemma(it) }.toSet()
+            val vectorFiltered =
+                if (blockedTopicLemmas.isEmpty()) {
+                    videoVectors
+                } else {
+                    videoVectors.filter { (_, vector) ->
+                        val topVideoTopics =
+                            vector.topics.entries
+                                .sortedByDescending { it.value }
+                                .take(3)
+                                .map { it.key }
+                        !topVideoTopics.any { topic ->
+                            blockedTopicLemmas.any { blocked ->
+                                topic.contains(blocked) || blocked.contains(topic)
+                            }
+                        }
+                    }
+                }
+
+            // Time context
+            val bucket = TimeBucket.current()
+            val timeContextVector = brain.timeVectors[bucket] ?: ContentVector()
+
+            // Dynamic temperature (boredom detection)
+            val boredomFactor =
+                (brain.consecutiveSkips / 20.0)
+                    .coerceIn(0.0, 0.5)
+            val wPersonality = 0.4 - (boredomFactor * 0.5)
+            val wContext = 0.4 - (boredomFactor * 0.5)
+            val wNovelty = 0.2 + boredomFactor
+
+            // Onboarding warmup factor
+            val isColdStart = brain.totalInteractions < NeuroScoring.COLD_START_THRESHOLD
+            val isOnboarding = brain.totalInteractions < NeuroScoring.ONBOARDING_WARMUP_INTERACTIONS
+            val onboardingWarmup =
+                if (isOnboarding) {
+                    1.0 - (
+                        brain.totalInteractions /
+                            NeuroScoring.ONBOARDING_WARMUP_INTERACTIONS.toDouble()
+                    ) * 0.5
+                } else {
+                    0.5
+                }
+
+            // Precompute lemmatized preferred topics once (was per-candidate)
+            val lemmatizedPreferred =
+                brain.preferredTopics
+                    .mapTo(HashSet()) { tokenizer.normalizeLemma(it) }
+
+            // Persona sets exploration appetite: explorers roam, specialists stay focused.
+            val exploreWeight =
+                when (getPersona(brain)) {
+                    FlowPersona.EXPLORER -> 1.0
+                    FlowPersona.SPECIALIST -> 0.3
+                    FlowPersona.INITIATE -> 0.0
+                    else -> 0.6
+                }
+
+            val scoringParams =
+                ScoringParams(
+                    brain = brain,
+                    userSubs = userSubs,
+                    timeContextVector = timeContextVector,
+                    wPersonality = wPersonality,
+                    wContext = wContext,
+                    wNovelty = wNovelty,
+                    isColdStart = isColdStart,
+                    isOnboarding = isOnboarding,
+                    onboardingWarmup = onboardingWarmup,
+                    lemmatizedPreferred = lemmatizedPreferred,
+                    sessionTopics = sessionTopics,
+                    sessionVideoCount = sessionVideoCount,
+                    impressions = impressionSnapshot,
+                    watchHistory = watchHistorySnapshot,
+                    recentInteractions = recentInteractionsSnapshot,
+                    candidatePoolSize = filtered.size,
+                    now = now,
+                    exploreWeight = exploreWeight,
+                )
+
+            // Jitter magnitude is invariant across candidates in a single rank() call
+            val jitterMagnitude =
+                NeuroScoring.calculateAdaptiveJitter(
+                    brain.totalInteractions,
+                    feedOverlapRatio,
+                )
+
+            val scored =
+                vectorFiltered
+                    .map { (video, videoVector) ->
+                        val base = NeuroScoring.scoreCandidate(video, videoVector, scoringParams)
+                        val jitter = random.nextDouble() * jitterMagnitude
+                        ScoredVideo(video, base + jitter, videoVector)
+                    }.toMutableList()
+
+            // Apply diversity reranking
+            return@withContext NeuroScoring.applySmartDiversity(scored, tokenizer)
         }
-
-        // Time context
-        val bucket = TimeBucket.current()
-        val timeContextVector = brain.timeVectors[bucket] ?: ContentVector()
-
-        // Dynamic temperature (boredom detection)
-        val boredomFactor = (brain.consecutiveSkips / 20.0)
-            .coerceIn(0.0, 0.5)
-        val wPersonality = 0.4 - (boredomFactor * 0.5)
-        val wContext = 0.4 - (boredomFactor * 0.5)
-        val wNovelty = 0.2 + boredomFactor
-
-        // Onboarding warmup factor
-        val isColdStart = brain.totalInteractions < NeuroScoring.COLD_START_THRESHOLD
-        val isOnboarding = brain.totalInteractions < NeuroScoring.ONBOARDING_WARMUP_INTERACTIONS
-        val onboardingWarmup = if (isOnboarding) {
-            1.0 - (brain.totalInteractions /
-                NeuroScoring.ONBOARDING_WARMUP_INTERACTIONS.toDouble()) * 0.5
-        } else 0.5
-
-        // Precompute lemmatized preferred topics once (was per-candidate)
-        val lemmatizedPreferred = brain.preferredTopics
-            .mapTo(HashSet()) { tokenizer.normalizeLemma(it) }
-
-        // Persona sets exploration appetite: explorers roam, specialists stay focused.
-        val exploreWeight = when (getPersona(brain)) {
-            FlowPersona.EXPLORER -> 1.0
-            FlowPersona.SPECIALIST -> 0.3
-            FlowPersona.INITIATE -> 0.0
-            else -> 0.6
-        }
-
-        val scoringParams = ScoringParams(
-            brain = brain,
-            userSubs = userSubs,
-            timeContextVector = timeContextVector,
-            wPersonality = wPersonality,
-            wContext = wContext,
-            wNovelty = wNovelty,
-            isColdStart = isColdStart,
-            isOnboarding = isOnboarding,
-            onboardingWarmup = onboardingWarmup,
-            lemmatizedPreferred = lemmatizedPreferred,
-            sessionTopics = sessionTopics,
-            sessionVideoCount = sessionVideoCount,
-            impressions = impressionSnapshot,
-            watchHistory = watchHistorySnapshot,
-            recentInteractions = recentInteractionsSnapshot,
-            candidatePoolSize = filtered.size,
-            now = now,
-            exploreWeight = exploreWeight
-        )
-
-        // Jitter magnitude is invariant across candidates in a single rank() call
-        val jitterMagnitude = NeuroScoring.calculateAdaptiveJitter(
-            brain.totalInteractions, feedOverlapRatio
-        )
-
-        val scored = vectorFiltered.map { (video, videoVector) ->
-            val base = NeuroScoring.scoreCandidate(video, videoVector, scoringParams)
-            val jitter = random.nextDouble() * jitterMagnitude
-            ScoredVideo(video, base + jitter, videoVector)
-        }.toMutableList()
-
-        // Apply diversity reranking
-        return@withContext NeuroScoring.applySmartDiversity(scored, tokenizer)
-
-    }
 
     suspend fun recordFeedImpressions(ids: List<String>) {
         if (ids.isEmpty()) return
@@ -1263,24 +1456,27 @@ class FlowNeuroEngine(private val appContext: Context) {
             val updatedHistory = currentUserBrain.feedHistory.toMutableMap()
             fresh.forEach { id ->
                 val prev = updatedHistory[id]
-                updatedHistory[id] = FeedEntry(
-                    lastShown = now,
-                    showCount = (prev?.showCount ?: 0) + 1
-                )
+                updatedHistory[id] =
+                    FeedEntry(
+                        lastShown = now,
+                        showCount = (prev?.showCount ?: 0) + 1,
+                    )
             }
 
-            val expiryCutoff = now - (
-                NeuroScoring.FEED_HISTORY_EXPIRY_DAYS * 24 * 60 * 60 * 1000
-            )
-            val pruned = if (updatedHistory.size > NeuroScoring.FEED_HISTORY_MAX) {
-                updatedHistory.entries
-                    .filter { it.value.lastShown > expiryCutoff }
-                    .sortedByDescending { it.value.lastShown }
-                    .take(NeuroScoring.FEED_HISTORY_MAX)
-                    .associate { it.key to it.value }
-            } else {
-                updatedHistory.filter { it.value.lastShown > expiryCutoff }
-            }
+            val expiryCutoff =
+                now - (
+                    NeuroScoring.FEED_HISTORY_EXPIRY_DAYS * 24 * 60 * 60 * 1000
+                )
+            val pruned =
+                if (updatedHistory.size > NeuroScoring.FEED_HISTORY_MAX) {
+                    updatedHistory.entries
+                        .filter { it.value.lastShown > expiryCutoff }
+                        .sortedByDescending { it.value.lastShown }
+                        .take(NeuroScoring.FEED_HISTORY_MAX)
+                        .associate { it.key to it.value }
+                } else {
+                    updatedHistory.filter { it.value.lastShown > expiryCutoff }
+                }
 
             currentUserBrain = currentUserBrain.copy(feedHistory = pruned)
             scheduleDebouncedSave()
@@ -1294,7 +1490,7 @@ class FlowNeuroEngine(private val appContext: Context) {
     suspend fun onVideoInteraction(
         video: Video,
         interactionType: InteractionType,
-        percentWatched: Float = 0f
+        percentWatched: Float = 0f,
     ) {
         // Deep Flow mode: freeze vector learning while active and not yet expired
         if (PlayerPreferences(appContext).isDeepFlowCurrentlyActive()) return
@@ -1302,24 +1498,46 @@ class FlowNeuroEngine(private val appContext: Context) {
         val idfSnapshot = brainMutex.withLock { takeIdfSnapshot() }
         val videoVector = getOrExtractFeatures(video, idfSnapshot)
 
-        val absoluteMinutesWatched = if (
-            interactionType == InteractionType.WATCHED && video.duration > 0
-        ) {
-            (video.duration * percentWatched / 60.0).coerceAtLeast(0.0)
-        } else 0.0
-
-        var learningRate = when (interactionType) {
-            InteractionType.CLICK -> 0.03
-            InteractionType.LIKED -> 0.30
-            InteractionType.WATCHED -> {
-                val baseWatchRate = 0.15 * percentWatched
-                val timeBonus = (ln(1.0 + absoluteMinutesWatched) /
-                    ln(1.0 + 60.0) * 0.08)
-                baseWatchRate + timeBonus
+        val absoluteMinutesWatched =
+            if (
+                interactionType == InteractionType.WATCHED && video.duration > 0
+            ) {
+                (video.duration * percentWatched / 60.0).coerceAtLeast(0.0)
+            } else {
+                0.0
             }
-            InteractionType.SKIPPED -> -0.15
-            InteractionType.DISLIKED -> -0.40
-        }
+
+        var learningRate =
+            when (interactionType) {
+                InteractionType.CLICK -> {
+                    0.03
+                }
+
+                InteractionType.LIKED -> {
+                    0.30
+                }
+
+                InteractionType.SAVED -> {
+                    0.22
+                }
+
+                InteractionType.WATCHED -> {
+                    val baseWatchRate = 0.15 * percentWatched
+                    val timeBonus = (
+                        ln(1.0 + absoluteMinutesWatched) /
+                            ln(1.0 + 60.0) * 0.08
+                    )
+                    baseWatchRate + timeBonus
+                }
+
+                InteractionType.SKIPPED -> {
+                    -0.15
+                }
+
+                InteractionType.DISLIKED -> {
+                    -0.40
+                }
+            }
 
         if (video.isShort) {
             learningRate *= NeuroScoring.SHORTS_LEARNING_PENALTY
@@ -1328,8 +1546,11 @@ class FlowNeuroEngine(private val appContext: Context) {
         brainMutex.withLock {
             // Maturity-scaled learning: slow down positive learning as brain matures.
             if (learningRate > 0) {
-                val maturityDamping = 1.0 / (1.0 +
-                    ln(1.0 + currentUserBrain.totalInteractions / 50.0))
+                val maturityDamping =
+                    1.0 / (
+                        1.0 +
+                            ln(1.0 + currentUserBrain.totalInteractions / 50.0)
+                    )
                 learningRate *= maturityDamping.coerceIn(0.25, 1.0)
             }
 
@@ -1339,53 +1560,74 @@ class FlowNeuroEngine(private val appContext: Context) {
                 if (impression != null) {
                     val secondsSinceImpression =
                         (System.currentTimeMillis() - impression.lastSeen) / 1000.0
-                    val clickVelocity = when {
-                        secondsSinceImpression < 5.0 -> 1.5   // instant click
-                        secondsSinceImpression < 30.0 -> 1.0  // normal
-                        secondsSinceImpression < 120.0 -> 0.8 // delayed
-                        else -> 0.6                            // much later
-                    }
+                    val clickVelocity =
+                        when {
+                            secondsSinceImpression < 5.0 -> 1.5
+
+                            // instant click
+                            secondsSinceImpression < 30.0 -> 1.0
+
+                            // normal
+                            secondsSinceImpression < 120.0 -> 0.8
+
+                            // delayed
+                            else -> 0.6 // much later
+                        }
                     learningRate *= clickVelocity
                 }
             }
 
             // 1. Update global vector
-            val newGlobal = NeuroVectorMath.adjustVector(
-                currentUserBrain.globalVector, videoVector, learningRate
-            )
+            val newGlobal =
+                NeuroVectorMath.adjustVector(
+                    currentUserBrain.globalVector,
+                    videoVector,
+                    learningRate,
+                )
 
             // 1b. Shorts-specific vector (not dampened by SHORTS_LEARNING_PENALTY)
-            val newShortsVector = if (video.isShort) {
-                val shortsRate = when (interactionType) {
-                    InteractionType.CLICK -> 0.08
-                    InteractionType.LIKED -> 0.20
-                    InteractionType.WATCHED -> 0.10 * percentWatched
-                    InteractionType.SKIPPED -> -0.12
-                    InteractionType.DISLIKED -> -0.30
+            val newShortsVector =
+                if (video.isShort) {
+                    val shortsRate =
+                        when (interactionType) {
+                            InteractionType.CLICK -> 0.08
+                            InteractionType.LIKED -> 0.20
+                            InteractionType.SAVED -> 0.15
+                            InteractionType.WATCHED -> 0.10 * percentWatched
+                            InteractionType.SKIPPED -> -0.12
+                            InteractionType.DISLIKED -> -0.30
+                        }
+                    NeuroVectorMath.adjustVector(
+                        currentUserBrain.shortsVector,
+                        videoVector,
+                        shortsRate,
+                    )
+                } else {
+                    currentUserBrain.shortsVector
                 }
-                NeuroVectorMath.adjustVector(
-                    currentUserBrain.shortsVector, videoVector, shortsRate
-                )
-            } else {
-                currentUserBrain.shortsVector
-            }
 
             // 2. Update time bucket
             val bucket = TimeBucket.current()
-            val currentBucketVec = currentUserBrain.timeVectors[bucket]
-                ?: ContentVector()
-            val newBucketVec = NeuroVectorMath.adjustVector(
-                currentBucketVec, videoVector, learningRate
-            )
+            val currentBucketVec =
+                currentUserBrain.timeVectors[bucket]
+                    ?: ContentVector()
+            val newBucketVec =
+                NeuroVectorMath.adjustVector(
+                    currentBucketVec,
+                    videoVector,
+                    learningRate,
+                )
 
             // 3. Channel score
             val currentChScore =
                 currentUserBrain.channelScores[video.channelId] ?: 0.5
             val outcome = if (learningRate > 0) 1.0 else 0.0
-            val newChScore = (currentChScore * NeuroScoring.CHANNEL_EMA_DECAY) +
-                (outcome * NeuroScoring.CHANNEL_EMA_ALPHA)
-            var newChannelScores = currentUserBrain.channelScores +
-                (video.channelId to newChScore)
+            val newChScore =
+                (currentChScore * NeuroScoring.CHANNEL_EMA_DECAY) +
+                    (outcome * NeuroScoring.CHANNEL_EMA_ALPHA)
+            var newChannelScores =
+                currentUserBrain.channelScores +
+                    (video.channelId to newChScore)
 
             // Channel pruning
             if (newChannelScores.size > NeuroScoring.MAX_CHANNEL_SCORES) {
@@ -1393,73 +1635,91 @@ class FlowNeuroEngine(private val appContext: Context) {
                 val keepLow = sorted.take(NeuroScoring.CHANNEL_KEEP_LOW)
                 val keepHigh = sorted.takeLast(NeuroScoring.CHANNEL_KEEP_HIGH)
                 val keepSet = (keepLow + keepHigh).map { it.key }.toSet()
-                newChannelScores = newChannelScores
-                    .filter { it.key in keepSet }
+                newChannelScores =
+                    newChannelScores
+                        .filter { it.key in keepSet }
             }
 
             // 4. Consecutive skips
-            val newSkips = when (interactionType) {
-                InteractionType.CLICK, InteractionType.LIKED,
-                InteractionType.WATCHED -> 0
-                InteractionType.SKIPPED, InteractionType.DISLIKED ->
-                    (currentUserBrain.consecutiveSkips + 1)
-                        .coerceAtMost(NeuroScoring.MAX_CONSECUTIVE_SKIPS)
-            }
+            val newSkips =
+                when (interactionType) {
+                    InteractionType.CLICK, InteractionType.LIKED,
+                    InteractionType.WATCHED, InteractionType.SAVED,
+                    -> {
+                        0
+                    }
+
+                    InteractionType.SKIPPED, InteractionType.DISLIKED -> {
+                        (currentUserBrain.consecutiveSkips + 1)
+                            .coerceAtMost(NeuroScoring.MAX_CONSECUTIVE_SKIPS)
+                    }
+                }
 
             // 5. Topic co-occurrence
             var newAffinities = currentUserBrain.topicAffinities
             if (learningRate > 0) {
-                val topTopics = videoVector.topics.entries
-                    .sortedByDescending { it.value }
-                    .take(3)
-                    .map { NeuroScoring.stripDomainTag(it.key) }
-                    .distinct()
+                val topTopics =
+                    videoVector.topics.entries
+                        .sortedByDescending { it.value }
+                        .take(3)
+                        .map { NeuroScoring.stripDomainTag(it.key) }
+                        .distinct()
                 if (topTopics.size >= 2) {
                     val mutableAffinities = newAffinities.toMutableMap()
                     for (i in topTopics.indices) {
                         for (j in i + 1 until topTopics.size) {
-                            val key = NeuroScoring.makeAffinityKey(
-                                topTopics[i], topTopics[j]
-                            )
+                            val key =
+                                NeuroScoring.makeAffinityKey(
+                                    topTopics[i],
+                                    topTopics[j],
+                                )
                             val current = mutableAffinities[key] ?: 0.0
                             mutableAffinities[key] =
                                 (current + NeuroScoring.AFFINITY_INCREMENT)
                                     .coerceAtMost(NeuroScoring.AFFINITY_MAX)
                         }
                     }
-                    newAffinities = mutableAffinities
-                        .filter { it.value > NeuroScoring.AFFINITY_PRUNE_THRESHOLD }
+                    newAffinities =
+                        mutableAffinities
+                            .filter { it.value > NeuroScoring.AFFINITY_PRUNE_THRESHOLD }
                     if (newAffinities.size > NeuroScoring.AFFINITY_MAX_ENTRIES) {
-                        newAffinities = newAffinities.entries
-                            .sortedByDescending { it.value }
-                            .take(NeuroScoring.AFFINITY_KEEP_TOP)
-                            .associate { it.key to it.value }
+                        newAffinities =
+                            newAffinities.entries
+                                .sortedByDescending { it.value }
+                                .take(NeuroScoring.AFFINITY_KEEP_TOP)
+                                .associate { it.key to it.value }
                     }
                 }
             }
 
-            val topicEvidenceSignal = calculateTopicEvidenceSignal(
-                interactionType,
-                percentWatched,
-                video.isShort
-            )
-            val positiveEvidence = updateTopicEvidence(
-                currentUserBrain.topicEvidence,
-                videoVector,
-                video,
-                signalScore = topicEvidenceSignal,
-                isWatchSignal = interactionType == InteractionType.WATCHED &&
-                    percentWatched >= 0.40f,
-                isExplicitSignal = interactionType == InteractionType.LIKED
-            )
-            val newTopicEvidence = if (
-                interactionType == InteractionType.SKIPPED ||
-                interactionType == InteractionType.DISLIKED
-            ) {
-                bumpNegativeEvidence(positiveEvidence, videoVector)
-            } else {
-                positiveEvidence
-            }
+            val topicEvidenceSignal =
+                calculateTopicEvidenceSignal(
+                    interactionType,
+                    percentWatched,
+                    video.isShort,
+                )
+            val positiveEvidence =
+                updateTopicEvidence(
+                    currentUserBrain.topicEvidence,
+                    videoVector,
+                    video,
+                    signalScore = topicEvidenceSignal,
+                    isWatchSignal =
+                        interactionType == InteractionType.WATCHED &&
+                            percentWatched >= 0.40f,
+                    isExplicitSignal =
+                        interactionType == InteractionType.LIKED ||
+                            interactionType == InteractionType.SAVED,
+                )
+            val newTopicEvidence =
+                if (
+                    interactionType == InteractionType.SKIPPED ||
+                    interactionType == InteractionType.DISLIKED
+                ) {
+                    bumpNegativeEvidence(positiveEvidence, videoVector)
+                } else {
+                    positiveEvidence
+                }
 
             // 6. Update IDF counters on interaction
             if (learningRate > 0) {
@@ -1479,14 +1739,19 @@ class FlowNeuroEngine(private val appContext: Context) {
             // 7. Persona tracking
             val rawPersona = getPersona(currentUserBrain)
             val lastPersonaName = currentUserBrain.lastPersona
-            val newStability = if (rawPersona.name == lastPersonaName) {
-                (currentUserBrain.personaStability + 1)
-                    .coerceAtMost(NeuroScoring.PERSONA_MAX_STABILITY)
-            } else 1
+            val newStability =
+                if (rawPersona.name == lastPersonaName) {
+                    (currentUserBrain.personaStability + 1)
+                        .coerceAtMost(NeuroScoring.PERSONA_MAX_STABILITY)
+                } else {
+                    1
+                }
 
             // 8. Session tracking
-            val primaryTopic = videoVector.topics
-                .maxByOrNull { it.value }?.key
+            val primaryTopic =
+                videoVector.topics
+                    .maxByOrNull { it.value }
+                    ?.key
             if (primaryTopic != null) {
                 sessionTopicHistory.add(primaryTopic)
                 while (sessionTopicHistory.size > SESSION_TOPIC_HISTORY_MAX) {
@@ -1499,8 +1764,9 @@ class FlowNeuroEngine(private val appContext: Context) {
             var newChannelProfiles = currentUserBrain.channelTopicProfiles
             if (learningRate > 0) {
                 val channelId = video.channelId
-                val existingProfile = newChannelProfiles[channelId]?.toMutableMap()
-                    ?: mutableMapOf()
+                val existingProfile =
+                    newChannelProfiles[channelId]?.toMutableMap()
+                        ?: mutableMapOf()
 
                 videoVector.topics.forEach { (topic, weight) ->
                     val current = existingProfile[topic] ?: 0.0
@@ -1519,24 +1785,29 @@ class FlowNeuroEngine(private val appContext: Context) {
                     }
                 }
 
-                val pruned = if (existingProfile.size > NeuroScoring.CHANNEL_PROFILE_MAX_TOPICS) {
-                    existingProfile.entries
-                        .sortedByDescending { it.value }
-                        .take(NeuroScoring.CHANNEL_PROFILE_MAX_TOPICS)
-                        .associate { it.key to it.value }
-                } else existingProfile.toMap()
+                val pruned =
+                    if (existingProfile.size > NeuroScoring.CHANNEL_PROFILE_MAX_TOPICS) {
+                        existingProfile.entries
+                            .sortedByDescending { it.value }
+                            .take(NeuroScoring.CHANNEL_PROFILE_MAX_TOPICS)
+                            .associate { it.key to it.value }
+                    } else {
+                        existingProfile.toMap()
+                    }
 
                 val mutableProfiles = newChannelProfiles.toMutableMap()
                 mutableProfiles[channelId] = pruned
 
                 if (mutableProfiles.size > NeuroScoring.CHANNEL_PROFILE_MAX_CHANNELS) {
                     val channelScoreMap = currentUserBrain.channelScores
-                    val sorted = mutableProfiles.entries.sortedBy { (id, _) ->
-                        channelScoreMap[id] ?: 0.0
-                    }
-                    val toRemove = sorted.take(
-                        mutableProfiles.size - NeuroScoring.CHANNEL_PROFILE_MAX_CHANNELS
-                    )
+                    val sorted =
+                        mutableProfiles.entries.sortedBy { (id, _) ->
+                            channelScoreMap[id] ?: 0.0
+                        }
+                    val toRemove =
+                        sorted.take(
+                            mutableProfiles.size - NeuroScoring.CHANNEL_PROFILE_MAX_CHANNELS,
+                        )
                     toRemove.forEach { mutableProfiles.remove(it.key) }
                 }
 
@@ -1562,9 +1833,11 @@ class FlowNeuroEngine(private val appContext: Context) {
                 if (existing == null ||
                     percentWatched > existing.percentWatched
                 ) {
-                    watchHistory[video.id] = WatchEntry(
-                        percentWatched, System.currentTimeMillis()
-                    )
+                    watchHistory[video.id] =
+                        WatchEntry(
+                            percentWatched,
+                            System.currentTimeMillis(),
+                        )
                     while (watchHistory.size > NeuroScoring.WATCH_HISTORY_MAX) {
                         val oldestKey = watchHistory.keys.first()
                         watchHistory.remove(oldestKey)
@@ -1572,28 +1845,133 @@ class FlowNeuroEngine(private val appContext: Context) {
                 }
             }
 
-            val watchHistoryMap = watchHistory.mapValues { (_, entry) ->
-                entry.percentWatched
+            val watchHistoryMap =
+                watchHistory.mapValues { (_, entry) ->
+                    entry.percentWatched
+                }
+
+            currentUserBrain =
+                currentUserBrain.copy(
+                    globalVector = newGlobal,
+                    timeVectors =
+                        currentUserBrain.timeVectors +
+                            (bucket to newBucketVec),
+                    channelScores = newChannelScores,
+                    topicAffinities = newAffinities,
+                    totalInteractions = currentUserBrain.totalInteractions + 1,
+                    consecutiveSkips = newSkips,
+                    lastPersona = rawPersona.name,
+                    personaStability = newStability,
+                    idfWordFrequency = idfWordFrequency.toMap(),
+                    idfTotalDocuments = idfTotalDocuments,
+                    watchHistoryMap = watchHistoryMap,
+                    channelTopicProfiles = newChannelProfiles,
+                    shortsVector = newShortsVector,
+                    topicEvidence = newTopicEvidence,
+                )
+
+            scheduleDebouncedSave()
+        }
+    }
+
+    /** Fire-and-forget interaction on the engine's own scope (survives ViewModel teardown). */
+    fun onVideoInteractionAsync(
+        video: Video,
+        interactionType: InteractionType,
+        percentWatched: Float = 0f,
+    ) {
+        saveScope.launch {
+            try {
+                onVideoInteraction(video, interactionType, percentWatched)
+            } catch (e: Exception) {
+                Log.w(TAG, "Async interaction dispatch failed for ${video.id}", e)
             }
+        }
+    }
 
-            currentUserBrain = currentUserBrain.copy(
-                globalVector = newGlobal,
-                timeVectors = currentUserBrain.timeVectors +
-                    (bucket to newBucketVec),
-                channelScores = newChannelScores,
-                topicAffinities = newAffinities,
-                totalInteractions = currentUserBrain.totalInteractions + 1,
-                consecutiveSkips = newSkips,
-                lastPersona = rawPersona.name,
-                personaStability = newStability,
-                idfWordFrequency = idfWordFrequency.toMap(),
-                idfTotalDocuments = idfTotalDocuments,
-                watchHistoryMap = watchHistoryMap,
-                channelTopicProfiles = newChannelProfiles,
-                shortsVector = newShortsVector,
-                topicEvidence = newTopicEvidence
-            )
+    /**
+     * Live subscription changes are strong channel-intent signals. Subscribing lifts
+     * the channel's quality floor and clears any inferred suppression; unsubscribing
+     * caps it back to neutral (it is not a dislike).
+     */
+    suspend fun onChannelSubscriptionChanged(
+        channelId: String,
+        channelName: String,
+        subscribed: Boolean,
+    ) {
+        if (channelId.isBlank()) return
+        brainMutex.withLock {
+            val scores = currentUserBrain.channelScores.toMutableMap()
+            val current = scores[channelId] ?: 0.5
+            if (subscribed) {
+                scores[channelId] = maxOf(current, 0.65)
+                val nameTokens = tokenizer.tokenizeChannelName(channelName)
+                val newGlobal =
+                    if (nameTokens.isNotEmpty()) {
+                        NeuroVectorMath.adjustVector(
+                            currentUserBrain.globalVector,
+                            ContentVector(topics = nameTokens.associateWith { 0.5 }),
+                            0.08,
+                        )
+                    } else {
+                        currentUserBrain.globalVector
+                    }
+                currentUserBrain =
+                    currentUserBrain.copy(
+                        channelScores = scores,
+                        suppressedChannels = currentUserBrain.suppressedChannels - channelId,
+                        globalVector = newGlobal,
+                    )
+            } else {
+                scores[channelId] = minOf(current, 0.5)
+                currentUserBrain = currentUserBrain.copy(channelScores = scores)
+            }
+            scheduleDebouncedSave()
+        }
+    }
 
+    /**
+     * A typed search is the most explicit interest statement in the product.
+     * Records explicit topic evidence and nudges the global vector so searched
+     * topics can seed discovery — without counting as a full interaction.
+     */
+    suspend fun onSearchQuery(rawQuery: String) {
+        val query = rawQuery.trim()
+        if (query.isBlank()) return
+        val tokens = tokenizer.tokenize(query).distinct().take(4)
+        if (tokens.isEmpty()) return
+        brainMutex.withLock {
+            val blocked = currentUserBrain.blockedTopics
+            val usable = tokens.filter { token -> blocked.none { b -> token == b || token == tokenizer.normalizeLemma(b) } }
+            if (usable.isEmpty()) return
+            val now = System.currentTimeMillis()
+            val updated = currentUserBrain.topicEvidence.toMutableMap()
+            usable.forEach { topic ->
+                val existing = updated[topic]
+                updated[topic] =
+                    TopicEvidence(
+                        positiveSignals = (existing?.positiveSignals ?: 0) + 1,
+                        negativeSignals = existing?.negativeSignals ?: 0,
+                        watchSignals = existing?.watchSignals ?: 0,
+                        explicitSignals = (existing?.explicitSignals ?: 0) + 1,
+                        positiveScore = ((existing?.positiveScore ?: 0.0) + 0.5).coerceAtMost(50.0),
+                        videoIds = existing?.videoIds.orEmpty(),
+                        channelIds = existing?.channelIds.orEmpty(),
+                        firstSeenAt = existing?.firstSeenAt?.takeIf { it > 0L } ?: now,
+                        lastSeenAt = now,
+                    )
+            }
+            val queryVector = ContentVector(topics = usable.associateWith { 1.0 / usable.size })
+            currentUserBrain =
+                currentUserBrain.copy(
+                    globalVector =
+                        NeuroVectorMath.adjustVector(
+                            currentUserBrain.globalVector,
+                            queryVector,
+                            0.05,
+                        ),
+                    topicEvidence = capEvidence(updated),
+                )
             scheduleDebouncedSave()
         }
     }
@@ -1605,7 +1983,7 @@ class FlowNeuroEngine(private val appContext: Context) {
     private fun getOrExtractFeatures(
         video: Video,
         idfSnapshot: IdfSnapshot,
-        channelProfile: Map<String, Double>? = null
+        channelProfile: Map<String, Double>? = null,
     ): ContentVector {
         val cacheKey = video.id
         val hasTags = video.tags.isNotEmpty()
@@ -1623,16 +2001,13 @@ class FlowNeuroEngine(private val appContext: Context) {
         return vector
     }
 
-    private fun takeIdfSnapshot(): IdfSnapshot {
-        return IdfSnapshot(
+    private fun takeIdfSnapshot(): IdfSnapshot =
+        IdfSnapshot(
             wordFrequency = idfWordFrequency.toMap(),
-            totalDocs = idfTotalDocuments
+            totalDocs = idfTotalDocuments,
         )
-    }
 
-    private suspend fun takeIdfSnapshotSafe(): IdfSnapshot {
-        return brainMutex.withLock { takeIdfSnapshot() }
-    }
+    private suspend fun takeIdfSnapshotSafe(): IdfSnapshot = brainMutex.withLock { takeIdfSnapshot() }
 
     // =================================================
     // SEEN SHORTS
@@ -1647,9 +2022,10 @@ class FlowNeuroEngine(private val appContext: Context) {
                 if (!updated.containsKey(id)) updated[id] = now
             }
             if (updated.size > NeuroScoring.SEEN_SHORTS_MAX) {
-                val toRemove = updated.entries
-                    .sortedBy { it.value }
-                    .take(updated.size - NeuroScoring.SEEN_SHORTS_MAX)
+                val toRemove =
+                    updated.entries
+                        .sortedBy { it.value }
+                        .take(updated.size - NeuroScoring.SEEN_SHORTS_MAX)
                 toRemove.forEach { updated.remove(it.key) }
             }
             currentUserBrain = currentUserBrain.copy(seenShortsHistory = updated)
@@ -1657,57 +2033,54 @@ class FlowNeuroEngine(private val appContext: Context) {
         }
     }
 
-    suspend fun getRecentlySeenShorts(): Set<String> {
-        return brainMutex.withLock {
+    suspend fun getRecentlySeenShorts(): Set<String> =
+        brainMutex.withLock {
             val now = System.currentTimeMillis()
             val expiryMs = NeuroScoring.SEEN_SHORT_EXPIRY_DAYS * 24L * 60 * 60 * 1000
             currentUserBrain.seenShortsHistory
                 .filter { (_, ts) -> (now - ts) < expiryMs }
                 .keys
         }
-    }
 
     // =================================================
     // EXPORT / IMPORT (delegates to NeuroStorage)
     // =================================================
 
-    suspend fun exportBrainToStream(
-        output: OutputStream
-    ): Boolean {
+    suspend fun exportBrainToStream(output: OutputStream): Boolean {
         val brainCopy = brainMutex.withLock { currentUserBrain }
         return storage.exportToStream(brainCopy, output)
     }
 
-    suspend fun importBrainFromStream(
-        input: InputStream
-    ): Boolean = withContext(Dispatchers.IO) {
-        try {
-            val finalBrain = storage.importFromStream(input)
-                ?: return@withContext false
+    suspend fun importBrainFromStream(input: InputStream): Boolean =
+        withContext(Dispatchers.IO) {
+            try {
+                val finalBrain =
+                    storage.importFromStream(input)
+                        ?: return@withContext false
 
-            brainMutex.withLock {
-                currentUserBrain = finalBrain
-                idfWordFrequency = finalBrain.idfWordFrequency.toMutableMap()
-                idfTotalDocuments = finalBrain.idfTotalDocuments
-                watchHistory.clear()
-                finalBrain.watchHistoryMap.forEach { (id, pct) ->
-                    watchHistory[id] = WatchEntry(pct, System.currentTimeMillis())
+                brainMutex.withLock {
+                    currentUserBrain = finalBrain
+                    idfWordFrequency = finalBrain.idfWordFrequency.toMutableMap()
+                    idfTotalDocuments = finalBrain.idfTotalDocuments
+                    watchHistory.clear()
+                    finalBrain.watchHistoryMap.forEach { (id, pct) ->
+                        watchHistory[id] = WatchEntry(pct, System.currentTimeMillis())
+                    }
+                    storage.save(currentUserBrain)
                 }
-                storage.save(currentUserBrain)
+                Log.i(
+                    TAG,
+                    "Brain imported (${finalBrain.totalInteractions} " +
+                        "interactions, ${finalBrain.timeVectors.count {
+                            it.value.topics.isNotEmpty()
+                        }} active time buckets)",
+                )
+                true
+            } catch (e: Exception) {
+                Log.e(TAG, "Import failed", e)
+                false
             }
-            Log.i(
-                TAG,
-                "Brain imported (${finalBrain.totalInteractions} " +
-                    "interactions, ${finalBrain.timeVectors.count {
-                        it.value.topics.isNotEmpty()
-                    }} active time buckets)"
-            )
-            true
-        } catch (e: Exception) {
-            Log.e(TAG, "Import failed", e)
-            false
         }
-    }
 
     // =================================================
     // PERSONA ENGINE
@@ -1720,55 +2093,82 @@ class FlowNeuroEngine(private val appContext: Context) {
 
         val sortedTopics = v.topics.values.sortedDescending()
         val topScore = sortedTopics.firstOrNull() ?: 0.0
-        val diversityIndex = if (sortedTopics.size >= 5 && topScore > 0) {
-            sortedTopics[4] / topScore
-        } else 0.0
-
-        val musicKeywords = setOf(
-            "music", "song", "lyrics", "remix", "lofi",
-            "playlist", "official audio"
-        )
-        val musicScore = v.topics.entries
-            .filter {
-                musicKeywords.contains(it.key) ||
-                    it.key.contains("feat")
+        val diversityIndex =
+            if (sortedTopics.size >= 5 && topScore > 0) {
+                sortedTopics[4] / topScore
+            } else {
+                0.0
             }
-            .sumOf { it.value }
+
+        val musicKeywords =
+            setOf(
+                "music",
+                "song",
+                "lyrics",
+                "remix",
+                "lofi",
+                "playlist",
+                "official audio",
+            )
+        val musicScore =
+            v.topics.entries
+                .filter {
+                    musicKeywords.contains(it.key) ||
+                        it.key.contains("feat")
+                }.sumOf { it.value }
         val totalScore = v.topics.values.sum()
 
         fun mag(cv: ContentVector) = cv.topics.values.sum()
         val nightMag = (
-            mag(brain.timeVectors[TimeBucket.WEEKDAY_NIGHT]
-                ?: ContentVector()) +
-                mag(brain.timeVectors[TimeBucket.WEEKEND_NIGHT]
-                    ?: ContentVector())
-            )
+            mag(
+                brain.timeVectors[TimeBucket.WEEKDAY_NIGHT]
+                    ?: ContentVector(),
+            ) +
+                mag(
+                    brain.timeVectors[TimeBucket.WEEKEND_NIGHT]
+                        ?: ContentVector(),
+                )
+        )
         val morningMag = (
-            mag(brain.timeVectors[TimeBucket.WEEKDAY_MORNING]
-                ?: ContentVector()) +
-                mag(brain.timeVectors[TimeBucket.WEEKEND_MORNING]
-                    ?: ContentVector())
-            )
+            mag(
+                brain.timeVectors[TimeBucket.WEEKDAY_MORNING]
+                    ?: ContentVector(),
+            ) +
+                mag(
+                    brain.timeVectors[TimeBucket.WEEKEND_MORNING]
+                        ?: ContentVector(),
+                )
+        )
         val isNocturnal = nightMag > (morningMag * 1.5) && nightMag > 5.0
 
-        val rawPersona = when {
-            totalScore > 0 &&
-                musicScore > (totalScore * 0.4) -> FlowPersona.AUDIOPHILE
-            v.isLive > 0.6 -> FlowPersona.LIVEWIRE
-            isNocturnal -> FlowPersona.NIGHT_OWL
-            brain.totalInteractions > 500 &&
-                v.pacing > 0.65 -> FlowPersona.BINGER
-            v.complexity > 0.75 -> FlowPersona.SCHOLAR
-            v.duration > 0.70 -> FlowPersona.DEEP_DIVER
-            v.duration < 0.35 &&
-                v.pacing > 0.60 -> FlowPersona.SKIMMER
-            diversityIndex < 0.25 -> FlowPersona.SPECIALIST
-            else -> FlowPersona.EXPLORER
-        }
+        val rawPersona =
+            when {
+                totalScore > 0 &&
+                    musicScore > (totalScore * 0.4) -> FlowPersona.AUDIOPHILE
 
-        val lastPersona = brain.lastPersona?.let { name ->
-            FlowPersona.entries.find { it.name == name }
-        }
+                v.isLive > 0.6 -> FlowPersona.LIVEWIRE
+
+                isNocturnal -> FlowPersona.NIGHT_OWL
+
+                brain.totalInteractions > 500 &&
+                    v.pacing > 0.65 -> FlowPersona.BINGER
+
+                v.complexity > 0.75 -> FlowPersona.SCHOLAR
+
+                v.duration > 0.70 -> FlowPersona.DEEP_DIVER
+
+                v.duration < 0.35 &&
+                    v.pacing > 0.60 -> FlowPersona.SKIMMER
+
+                diversityIndex < 0.25 -> FlowPersona.SPECIALIST
+
+                else -> FlowPersona.EXPLORER
+            }
+
+        val lastPersona =
+            brain.lastPersona?.let { name ->
+                FlowPersona.entries.find { it.name == name }
+            }
 
         return if (lastPersona != null &&
             rawPersona != lastPersona &&
@@ -1779,5 +2179,4 @@ class FlowNeuroEngine(private val appContext: Context) {
             rawPersona
         }
     }
-
 }

--- a/app/src/main/java/io/github/aedev/flow/data/recommendation/FlowNeuroEngine.kt
+++ b/app/src/main/java/io/github/aedev/flow/data/recommendation/FlowNeuroEngine.kt
@@ -266,6 +266,7 @@ class FlowNeuroEngine(
     private val tokenizer = NeuroTokenizer()
     private val storage = NeuroStorage(appContext)
     private val contentStore = NeuroContentStore(appContext)
+    private val playerPreferences by lazy { PlayerPreferences(appContext) }
     private val discovery by lazy {
         NeuroDiscovery(NeuroTopicCatalog.TOPIC_CATEGORIES, tokenizer)
     }
@@ -1637,7 +1638,7 @@ class FlowNeuroEngine(
         percentWatched: Float = 0f,
     ) {
         // Deep Flow mode: freeze vector learning while active and not yet expired
-        if (PlayerPreferences(appContext).isDeepFlowCurrentlyActive()) return
+        if (playerPreferences.isDeepFlowCurrentlyActive()) return
 
         val idfSnapshot = brainMutex.withLock { takeIdfSnapshot() }
         val videoVector = getOrExtractFeatures(video, idfSnapshot)

--- a/app/src/main/java/io/github/aedev/flow/data/recommendation/FlowNeuroEngine.kt
+++ b/app/src/main/java/io/github/aedev/flow/data/recommendation/FlowNeuroEngine.kt
@@ -263,6 +263,7 @@ class FlowNeuroEngine(
     // ── Module Instances ──
     private val tokenizer = NeuroTokenizer()
     private val storage = NeuroStorage(appContext)
+    private val contentStore = NeuroContentStore(appContext)
     private val discovery by lazy {
         NeuroDiscovery(NeuroTopicCatalog.TOPIC_CATEGORIES, tokenizer)
     }
@@ -351,6 +352,8 @@ class FlowNeuroEngine(
                 watchHistory[id] = WatchEntry(pct, System.currentTimeMillis())
             }
 
+            contentStore.load()
+
             resetSessionInternal()
             isInitialized = true
         }
@@ -373,6 +376,7 @@ class FlowNeuroEngine(
             watchHistory.clear()
             resetSessionInternal()
             storage.save(currentUserBrain)
+            contentStore.clear()
         }
     }
 
@@ -401,6 +405,7 @@ class FlowNeuroEngine(
                 brainMutex.withLock {
                     storage.save(currentUserBrain)
                 }
+                contentStore.persistIfDirty()
             }
     }
 
@@ -1253,6 +1258,7 @@ class FlowNeuroEngine(
             val seedCooldownCutoff = now - (NeuroScoring.RELATED_SEED_COOLDOWN_HOURS * 60 * 60 * 1000L)
             val excludedChannelIds: Set<String>
             val recentSeedIds: Set<String>
+            val topicScores: Map<String, Double>
             brainMutex.withLock {
                 val channelSuppressionCutoff = now - (CHANNEL_SUPPRESSION_DAYS * 24 * 60 * 60 * 1000L)
                 excludedChannelIds = currentUserBrain.blockedChannels +
@@ -1263,6 +1269,7 @@ class FlowNeuroEngine(
                     currentUserBrain.recentRelatedSeeds
                         .filter { (_, ts) -> ts > seedCooldownCutoff }
                         .keys
+                topicScores = currentUserBrain.globalVector.topics
             }
 
             // Seed rotation: newest-first selection kept picking the same seeds every
@@ -1271,7 +1278,7 @@ class FlowNeuroEngine(
             val rotated = candidates.filterNot { it.id in recentSeedIds }
             val pool = if (rotated.size >= maxSeeds) rotated else candidates
 
-            val selected = GraphSeedSelector.select(pool, maxSeeds, now, excludedChannelIds)
+            val selected = GraphSeedSelector.select(pool, maxSeeds, now, excludedChannelIds, topicScores = topicScores)
             if (selected.isNotEmpty()) {
                 brainMutex.withLock {
                     val updated = currentUserBrain.recentRelatedSeeds.toMutableMap()
@@ -1821,6 +1828,42 @@ class FlowNeuroEngine(
                 }
             }
 
+            // 5b. Tag-grounded knowledge: persist the tag-rich vector so this video
+            // is scored on real content when it reappears as a bare-title candidate,
+            // and record tag co-occurrence edges for interest clustering.
+            var newTagAffinities = currentUserBrain.tagAffinities
+            if (learningRate > 0 && video.tags.isNotEmpty()) {
+                contentStore.put(video.id, videoVector.topics)
+
+                val tagTokens =
+                    video.tags
+                        .asSequence()
+                        .flatMap { tokenizer.tokenize(it) }
+                        .distinct()
+                        .take(NeuroScoring.TAG_AFFINITY_TOKENS)
+                        .toList()
+                if (tagTokens.size >= 2) {
+                    val mutableTags = newTagAffinities.toMutableMap()
+                    for (i in tagTokens.indices) {
+                        for (j in i + 1 until tagTokens.size) {
+                            val key = NeuroScoring.makeAffinityKey(tagTokens[i], tagTokens[j])
+                            mutableTags[key] =
+                                ((mutableTags[key] ?: 0.0) + NeuroScoring.TAG_AFFINITY_INCREMENT)
+                                    .coerceAtMost(NeuroScoring.AFFINITY_MAX)
+                        }
+                    }
+                    newTagAffinities =
+                        if (mutableTags.size > NeuroScoring.TAG_AFFINITY_MAX_ENTRIES) {
+                            mutableTags.entries
+                                .sortedByDescending { it.value }
+                                .take(NeuroScoring.TAG_AFFINITY_KEEP_TOP)
+                                .associate { it.key to it.value }
+                        } else {
+                            mutableTags
+                        }
+                }
+            }
+
             val topicEvidenceSignal =
                 calculateTopicEvidenceSignal(
                     interactionType,
@@ -1997,6 +2040,7 @@ class FlowNeuroEngine(
                     channelTopicProfiles = newChannelProfiles,
                     shortsVector = newShortsVector,
                     topicEvidence = newTopicEvidence,
+                    tagAffinities = newTagAffinities,
                 )
 
             scheduleDebouncedSave()
@@ -2121,8 +2165,13 @@ class FlowNeuroEngine(
                 featureCache[cacheKey]?.let { return it }
             }
         }
-        val vector = tokenizer.extractFeatures(video, idfSnapshot, channelProfile)
+        var vector = tokenizer.extractFeatures(video, idfSnapshot, channelProfile)
         if (!hasTags) {
+            // A bare-title candidate we have watched before: score it on the
+            // tag-rich vector stored at watch time instead of its title alone.
+            contentStore.topicsFor(video.id)?.let { storedTopics ->
+                vector = vector.copy(topics = storedTopics)
+            }
             synchronized(featureCache) {
                 featureCache[cacheKey] = vector
             }

--- a/app/src/main/java/io/github/aedev/flow/data/recommendation/FlowNeuroEngine.kt
+++ b/app/src/main/java/io/github/aedev/flow/data/recommendation/FlowNeuroEngine.kt
@@ -164,6 +164,15 @@ class FlowNeuroEngine(
 
         suspend fun getExcludedChannelIds(): Set<String> = requireInstance().getExcludedChannelIds()
 
+        suspend fun onChannelTagsLearned(
+            context: Context,
+            channelId: String,
+            tags: List<String>,
+            description: String?,
+        ) = getInstance(context).onChannelTagsLearned(channelId, tags, description)
+
+        suspend fun onChannelUploadsObserved(uploads: List<Video>) = requireInstance().onChannelUploadsObserved(uploads)
+
         suspend fun completeOnboarding(selectedTopics: Set<String>) = requireInstance().completeOnboarding(selectedTopics)
 
         suspend fun completeOnboarding(
@@ -294,6 +303,9 @@ class FlowNeuroEngine(
     // Discovery tree depth: 0 on refresh, +1 per load-more regeneration —
     // each round digs one level deeper into every cluster's branches.
     private var discoveryRound: Int = 0
+
+    // Channels passively profiled from upload titles this session (once each).
+    private val passiveProfiledChannels = HashSet<String>()
     private val sessionTopicHistory = mutableListOf<String>()
     private val recentInteractions = mutableListOf<MomentumEntry>()
 
@@ -422,6 +434,7 @@ class FlowNeuroEngine(
         recentInteractions.clear()
         sessionImpressed.clear()
         discoveryRound = 0
+        passiveProfiledChannels.clear()
     }
 
     fun getSessionDurationMinutes(): Long = (System.currentTimeMillis() - sessionStartTime) / 60_000L
@@ -1293,7 +1306,9 @@ class FlowNeuroEngine(
             val excludedChannelIds: Set<String>
             val recentSeedIds: Set<String>
             val topicScores: Map<String, Double>
+            val brainSnapshot: UserBrain
             brainMutex.withLock {
+                brainSnapshot = currentUserBrain
                 val channelSuppressionCutoff = now - (CHANNEL_SUPPRESSION_DAYS * 24 * 60 * 60 * 1000L)
                 excludedChannelIds = currentUserBrain.blockedChannels +
                     currentUserBrain.suppressedChannels
@@ -1306,13 +1321,36 @@ class FlowNeuroEngine(
                 topicScores = currentUserBrain.globalVector.topics
             }
 
+            // Map seed topic keys to interest communities so the spread-first pick
+            // allocates one related seed per MAJOR interest (mma, android, anime…)
+            // before any interest gets a second one.
+            val topicToCommunity =
+                NeuroClusters
+                    .buildClusters(
+                        topicScores = brainSnapshot.globalVector.topics,
+                        affinities = brainSnapshot.topicAffinities,
+                        channelTopicProfiles = brainSnapshot.channelTopicProfiles,
+                        categories = NeuroTopicCatalog.TOPIC_CATEGORIES,
+                        normalizeLemma = tokenizer::normalizeLemma,
+                        tagAffinities = brainSnapshot.tagAffinities,
+                    ).flatMap { cluster -> cluster.topics.map { it to cluster.representative } }
+                    .toMap()
+
             // Seed rotation: newest-first selection kept picking the same seeds every
             // refresh, making the RELATED lane byte-identical. Cool recently used seeds
             // down unless that would starve the selection.
             val rotated = candidates.filterNot { it.id in recentSeedIds }
             val pool = if (rotated.size >= maxSeeds) rotated else candidates
 
-            val selected = GraphSeedSelector.select(pool, maxSeeds, now, excludedChannelIds, topicScores = topicScores)
+            val selected =
+                GraphSeedSelector.select(
+                    pool,
+                    maxSeeds,
+                    now,
+                    excludedChannelIds,
+                    topicScores = topicScores,
+                    communityOf = { key -> topicToCommunity[NeuroScoring.stripDomainTag(key)] ?: key },
+                )
             if (selected.isNotEmpty()) {
                 brainMutex.withLock {
                     val updated = currentUserBrain.recentRelatedSeeds.toMutableMap()
@@ -1343,6 +1381,95 @@ class FlowNeuroEngine(
                     .filter { (_, ts) -> ts > cutoff }
                     .keys
         }
+
+    /**
+     * Learns a channel's creator-declared keyword tags (+ description lead) into
+     * its topic profile and the tag-affinity graph. Authored identity — the
+     * strongest channel-level signal available; fetched on subscribe.
+     */
+    suspend fun onChannelTagsLearned(
+        channelId: String,
+        tags: List<String>,
+        description: String?,
+    ) {
+        if (channelId.isBlank()) return
+        val additions = NeuroChannelKnowledge.profileFromChannelTags(tags, description, tokenizer)
+        if (additions.isEmpty()) return
+        brainMutex.withLock {
+            val profiles = currentUserBrain.channelTopicProfiles.toMutableMap()
+            profiles[channelId] = NeuroChannelKnowledge.mergeProfile(profiles[channelId].orEmpty(), additions)
+
+            // Creator-authored co-occurrence: declared tags belong together.
+            val tagAffinities = currentUserBrain.tagAffinities.toMutableMap()
+            val tokens = additions.keys.take(5).toList()
+            for (i in tokens.indices) {
+                for (j in i + 1 until tokens.size) {
+                    val key = NeuroScoring.makeAffinityKey(tokens[i], tokens[j])
+                    tagAffinities[key] =
+                        ((tagAffinities[key] ?: 0.0) + NeuroScoring.TAG_AFFINITY_INCREMENT)
+                            .coerceAtMost(NeuroScoring.AFFINITY_MAX)
+                }
+            }
+            val cappedTagAffinities =
+                if (tagAffinities.size > NeuroScoring.TAG_AFFINITY_MAX_ENTRIES) {
+                    tagAffinities.entries
+                        .sortedByDescending { it.value }
+                        .take(NeuroScoring.TAG_AFFINITY_KEEP_TOP)
+                        .associate { it.key to it.value }
+                } else {
+                    tagAffinities
+                }
+
+            currentUserBrain =
+                currentUserBrain.copy(
+                    channelTopicProfiles = capChannelProfiles(profiles),
+                    tagAffinities = cappedTagAffinities,
+                )
+            scheduleDebouncedSave()
+        }
+    }
+
+    /**
+     * Passive channel profiling from upload titles the subs lane already fetched.
+     * Low weight, once per channel per session — teaches what each subscribed
+     * channel is about without waiting for the user to click anything.
+     */
+    suspend fun onChannelUploadsObserved(uploads: List<Video>) {
+        if (uploads.isEmpty()) return
+        val byChannel = uploads.filter { it.channelId.isNotBlank() }.groupBy { it.channelId }
+        if (byChannel.isEmpty()) return
+        brainMutex.withLock {
+            var profiles: MutableMap<String, Map<String, Double>>? = null
+            byChannel.forEach { (channelId, videos) ->
+                if (!passiveProfiledChannels.add(channelId)) return@forEach
+                val additions =
+                    NeuroChannelKnowledge.profileFromUploadTitles(
+                        videos.take(6).map { it.title },
+                        tokenizer,
+                    )
+                if (additions.isEmpty()) return@forEach
+                val target =
+                    profiles ?: currentUserBrain.channelTopicProfiles.toMutableMap().also { profiles = it }
+                target[channelId] = NeuroChannelKnowledge.mergeProfile(target[channelId].orEmpty(), additions)
+            }
+            profiles?.let {
+                currentUserBrain = currentUserBrain.copy(channelTopicProfiles = capChannelProfiles(it))
+                scheduleDebouncedSave()
+            }
+        }
+    }
+
+    // Evicts the lowest-quality channels' profiles when over the cap. Call under brainMutex.
+    private fun capChannelProfiles(profiles: MutableMap<String, Map<String, Double>>): Map<String, Map<String, Double>> {
+        if (profiles.size <= NeuroScoring.CHANNEL_PROFILE_MAX_CHANNELS) return profiles
+        val channelScores = currentUserBrain.channelScores
+        profiles.entries
+            .sortedBy { (id, _) -> channelScores[id] ?: 0.0 }
+            .take(profiles.size - NeuroScoring.CHANNEL_PROFILE_MAX_CHANNELS)
+            .map { it.key }
+            .forEach { profiles.remove(it) }
+        return profiles.toMap()
+    }
 
     /** Feed-history ids shown within the window — for assembly-time exclusion sets. */
     suspend fun getRecentlyShownVideoIds(withinHours: Long = 48L): Set<String> =

--- a/app/src/main/java/io/github/aedev/flow/data/recommendation/FlowNeuroEngine.kt
+++ b/app/src/main/java/io/github/aedev/flow/data/recommendation/FlowNeuroEngine.kt
@@ -98,7 +98,8 @@ class FlowNeuroEngine(
 
         suspend fun recordFeedImpressions(ids: List<String>) = requireInstance().recordFeedImpressions(ids)
 
-        suspend fun generateDiscoveryQueries(): List<String> = requireInstance().generateDiscoveryQueries()
+        suspend fun generateDiscoveryQueries(resetDepth: Boolean = false): List<String> =
+            requireInstance().generateDiscoveryQueries(resetDepth)
 
         suspend fun selectRelatedSeeds(
             candidates: List<GraphSeedInput>,
@@ -289,6 +290,10 @@ class FlowNeuroEngine(
     // Session tracking
     private var sessionStartTime: Long = System.currentTimeMillis()
     private var sessionVideoCount: Int = 0
+
+    // Discovery tree depth: 0 on refresh, +1 per load-more regeneration —
+    // each round digs one level deeper into every cluster's branches.
+    private var discoveryRound: Int = 0
     private val sessionTopicHistory = mutableListOf<String>()
     private val recentInteractions = mutableListOf<MomentumEntry>()
 
@@ -348,6 +353,12 @@ class FlowNeuroEngine(
                 storage.deleteLegacyFile()
             }
 
+            val maintained = runV15MaintenanceIfNeeded(currentUserBrain)
+            if (maintained !== currentUserBrain) {
+                currentUserBrain = maintained
+                storage.save(currentUserBrain)
+            }
+
             idfWordFrequency = currentUserBrain.idfWordFrequency.toMutableMap()
             idfTotalDocuments = currentUserBrain.idfTotalDocuments
 
@@ -365,6 +376,20 @@ class FlowNeuroEngine(
     fun shutdown() {
         pendingSaveJob?.cancel()
         saveScope.cancel()
+    }
+
+    /** One-time V15 maintenance — see NeuroMaintenance for the rationale. */
+    private fun runV15MaintenanceIfNeeded(brain: UserBrain): UserBrain {
+        val updated = NeuroMaintenance.runV15IfNeeded(brain, tokenizer)
+        if (updated !== brain) {
+            Log.i(
+                TAG,
+                "V15 maintenance: topics ${brain.globalVector.topics.size} → " +
+                    "${updated.globalVector.topics.size}, affinities ${brain.topicAffinities.size} → " +
+                    "${updated.topicAffinities.size}",
+            )
+        }
+        return updated
     }
 
     suspend fun getBrainSnapshot(): UserBrain = brainMutex.withLock { currentUserBrain }
@@ -396,6 +421,7 @@ class FlowNeuroEngine(
         impressionCache.clear()
         recentInteractions.clear()
         sessionImpressed.clear()
+        discoveryRound = 0
     }
 
     fun getSessionDurationMinutes(): Long = (System.currentTimeMillis() - sessionStartTime) / 60_000L
@@ -1144,14 +1170,19 @@ class FlowNeuroEngine(
     // DISCOVERY QUERY GENERATION
     // =================================================
 
-    suspend fun generateDiscoveryQueries(): List<String> =
+    suspend fun generateDiscoveryQueries(resetDepth: Boolean = false): List<String> =
         withContext(Dispatchers.Default) {
             brainMutex.withLock {
                 val brain = currentUserBrain
                 val blocked = brain.blockedTopics
 
-                // V3 discovery engine
-                val discoveryQueries = discovery.generateQueries(brain) { b -> getPersona(b) }
+                // Tree depth: a refresh starts broad (depth 0); each load-more
+                // regeneration digs one level deeper into every cluster's branches.
+                if (resetDepth) discoveryRound = 0
+                val depth = discoveryRound
+                discoveryRound++
+
+                val discoveryQueries = discovery.generateQueries(brain, depth = depth) { b -> getPersona(b) }
 
                 var candidates =
                     if (discoveryQueries.isNotEmpty()) {
@@ -1723,12 +1754,29 @@ class FlowNeuroEngine(
             }
 
             // 1. Update global vector
-            val newGlobal =
+            var newGlobal =
                 NeuroVectorMath.adjustVector(
                     currentUserBrain.globalVector,
                     videoVector,
                     learningRate,
                 )
+
+            // 1a. Acquisition floor: a real watch, like, or save is proof of interest —
+            // plant its top topics at a survivable weight so mature brains can still
+            // pick up NEW interests (see NeuroVectorMath.plantTopics).
+            val isStrongSignal =
+                interactionType == InteractionType.LIKED ||
+                    interactionType == InteractionType.SAVED ||
+                    (interactionType == InteractionType.WATCHED && percentWatched >= 0.40f)
+            if (isStrongSignal && !video.isShort) {
+                newGlobal =
+                    NeuroVectorMath.plantTopics(
+                        newGlobal,
+                        videoVector,
+                        NeuroScoring.TOPIC_ACQUISITION_FLOOR,
+                        NeuroScoring.TOPIC_ACQUISITION_TOP_K,
+                    )
+            }
 
             // 1b. Shorts-specific vector (not dampened by SHORTS_LEARNING_PENALTY)
             val newShortsVector =
@@ -1824,9 +1872,11 @@ class FlowNeuroEngine(
                                     .coerceAtMost(NeuroScoring.AFFINITY_MAX)
                         }
                     }
-                    newAffinities =
-                        mutableAffinities
-                            .filter { it.value > NeuroScoring.AFFINITY_PRUNE_THRESHOLD }
+                    // No per-update value pruning: the old filter (> 0.05) deleted every
+                    // newborn edge in the same update that created it (+0.01), so no pair
+                    // could EVER accumulate organically. The size cap alone bounds growth —
+                    // it evicts the weakest pairs first, which is the pruning we wanted.
+                    newAffinities = mutableAffinities
                     if (newAffinities.size > NeuroScoring.AFFINITY_MAX_ENTRIES) {
                         newAffinities =
                             newAffinities.entries
@@ -2144,13 +2194,22 @@ class FlowNeuroEngine(
                     )
             }
             val queryVector = ContentVector(topics = usable.associateWith { 1.0 / usable.size })
+            val learned =
+                NeuroVectorMath.adjustVector(
+                    currentUserBrain.globalVector,
+                    queryVector,
+                    0.05,
+                )
             currentUserBrain =
                 currentUserBrain.copy(
+                    // Typing a query is explicit intent — plant its topics so they
+                    // survive pruning and can seed discovery immediately.
                     globalVector =
-                        NeuroVectorMath.adjustVector(
-                            currentUserBrain.globalVector,
+                        NeuroVectorMath.plantTopics(
+                            learned,
                             queryVector,
-                            0.05,
+                            NeuroScoring.TOPIC_ACQUISITION_FLOOR,
+                            NeuroScoring.TOPIC_ACQUISITION_TOP_K,
                         ),
                     topicEvidence = capEvidence(updated),
                 )
@@ -2246,7 +2305,8 @@ class FlowNeuroEngine(
                         ?: return@withContext false
 
                 brainMutex.withLock {
-                    currentUserBrain = finalBrain
+                    // Imported brains may pre-date V15 — run the same maintenance.
+                    currentUserBrain = runV15MaintenanceIfNeeded(finalBrain)
                     idfWordFrequency = finalBrain.idfWordFrequency.toMutableMap()
                     idfTotalDocuments = finalBrain.idfTotalDocuments
                     watchHistory.clear()

--- a/app/src/main/java/io/github/aedev/flow/data/recommendation/FlowNeuroEngine.kt
+++ b/app/src/main/java/io/github/aedev/flow/data/recommendation/FlowNeuroEngine.kt
@@ -1206,9 +1206,34 @@ class FlowNeuroEngine(
                     (brain.recentQueryTokens + newQueryTokens)
                         .takeLast(NeuroScoring.RECENT_QUERY_TOKENS_MAX)
 
+                // ── Advance cluster rotation for the interest clusters actually served ──
+                val candidateSet = candidates.toHashSet()
+                val servedClusters =
+                    discoveryQueries
+                        .asSequence()
+                        .filter { it.query in candidateSet }
+                        .mapNotNull { it.clusterKey }
+                        .toSet()
+                val rotationNow = System.currentTimeMillis()
+                val updatedRotation =
+                    if (servedClusters.isEmpty()) {
+                        brain.clusterRotation
+                    } else {
+                        val merged = brain.clusterRotation + servedClusters.associateWith { rotationNow }
+                        if (merged.size > NeuroScoring.CLUSTER_ROTATION_MAX) {
+                            merged.entries
+                                .sortedByDescending { it.value }
+                                .take(NeuroScoring.CLUSTER_ROTATION_MAX)
+                                .associate { it.key to it.value }
+                        } else {
+                            merged
+                        }
+                    }
+
                 currentUserBrain =
                     currentUserBrain.copy(
                         recentQueryTokens = updatedRecentTokens,
+                        clusterRotation = updatedRotation,
                     )
                 scheduleDebouncedSave()
 

--- a/app/src/main/java/io/github/aedev/flow/data/recommendation/FlowNeuroEngine.kt
+++ b/app/src/main/java/io/github/aedev/flow/data/recommendation/FlowNeuroEngine.kt
@@ -161,6 +161,8 @@ class FlowNeuroEngine(
 
         suspend fun getRecentlyShownVideoIds(withinHours: Long = 48L): Set<String> = requireInstance().getRecentlyShownVideoIds(withinHours)
 
+        suspend fun getExcludedChannelIds(): Set<String> = requireInstance().getExcludedChannelIds()
+
         suspend fun completeOnboarding(selectedTopics: Set<String>) = requireInstance().completeOnboarding(selectedTopics)
 
         suspend fun completeOnboarding(
@@ -1300,6 +1302,16 @@ class FlowNeuroEngine(
             selected
         }
 
+    /** Blocked + actively suppressed channels, for assembly paths that bypass rank(). */
+    suspend fun getExcludedChannelIds(): Set<String> =
+        brainMutex.withLock {
+            val cutoff = System.currentTimeMillis() - (CHANNEL_SUPPRESSION_DAYS * 24 * 60 * 60 * 1000L)
+            currentUserBrain.blockedChannels +
+                currentUserBrain.suppressedChannels
+                    .filter { (_, ts) -> ts > cutoff }
+                    .keys
+        }
+
     /** Feed-history ids shown within the window — for assembly-time exclusion sets. */
     suspend fun getRecentlyShownVideoIds(withinHours: Long = 48L): Set<String> =
         brainMutex.withLock {
@@ -1397,33 +1409,13 @@ class FlowNeuroEngine(
                     .filter { (_, ts) -> ts > channelSuppressionCutoff }
                     .keys
 
-            // Precompute blocked topic expansion ONCE
-            val expandedBlockedKeywords: Set<String> =
-                brain.blockedTopics.flatMapTo(
-                    mutableSetOf(),
-                ) { blocked ->
-                    val blockedLower = blocked.lowercase()
-                    val matchingCategory =
-                        NeuroTopicCatalog.TOPIC_CATEGORIES.find { cat ->
-                            cat.topics.any { it.lowercase() == blockedLower }
-                        }
-                    val keywords =
-                        if (matchingCategory != null) {
-                            matchingCategory.topics
-                                .mapTo(mutableListOf()) { it.lowercase() }
-                                .also { it.add(blockedLower) }
-                        } else {
-                            mutableListOf(blockedLower)
-                        }
-                    keywords
-                }
-
-            val expandedWithLemmas: Set<String> =
-                expandedBlockedKeywords.flatMapTo(
-                    mutableSetOf(),
-                ) { keyword ->
-                    setOf(keyword, tokenizer.normalizeLemma(keyword))
-                }
+            // Precompute blocked matchers ONCE (precision blocking — see NeuroScoring).
+            val blockedMatchers =
+                NeuroScoring.buildBlockedMatchers(
+                    brain.blockedTopics,
+                    NeuroTopicCatalog.TOPIC_CATEGORIES,
+                    tokenizer::normalizeLemma,
+                )
 
             // ── Feed overlap ratio (for adaptive jitter + feed history penalty) ──
             val feedOverlapRatio =
@@ -1448,12 +1440,12 @@ class FlowNeuroEngine(
                     if (brain.blockedChannels.contains(video.channelId)) {
                         return@filter false
                     }
-                    val titleLower = video.title.lowercase()
-                    val channelLower = video.channelName.lowercase()
-
-                    !expandedWithLemmas.any { blocked ->
-                        titleLower.contains(blocked) || channelLower.contains(blocked)
-                    }
+                    !NeuroScoring.isBlockedByText(
+                        video.title,
+                        video.channelName,
+                        blockedMatchers,
+                        tokenizer::normalizeLemma,
+                    )
                 }
 
             if (filtered.isEmpty()) return@withContext emptyList()
@@ -1481,9 +1473,12 @@ class FlowNeuroEngine(
                                 .sortedByDescending { it.value }
                                 .take(3)
                                 .map { it.key }
+                        // Token-precise: "art" must block "art", not "startup".
                         !topVideoTopics.any { topic ->
+                            val base = NeuroScoring.stripDomainTag(topic)
+                            val parts = base.split(' ')
                             blockedTopicLemmas.any { blocked ->
-                                topic.contains(blocked) || blocked.contains(topic)
+                                base == blocked || parts.contains(blocked)
                             }
                         }
                     }
@@ -1557,12 +1552,25 @@ class FlowNeuroEngine(
                     feedOverlapRatio,
                 )
 
+            // Score first, then jitter RELATIVE to the live score distribution.
+            // Absolute jitter (0.12-0.20) frequently exceeded typical post-penalty
+            // scores, degrading ranking to a shuffle exactly when the feed was stale.
+            val baseScored =
+                vectorFiltered.map { (video, videoVector) ->
+                    Triple(video, videoVector, NeuroScoring.scoreCandidate(video, videoVector, scoringParams))
+                }
+            val medianScore =
+                baseScored
+                    .map { it.third }
+                    .sorted()
+                    .let { sortedScores ->
+                        if (sortedScores.isEmpty()) 0.0 else sortedScores[sortedScores.size / 2]
+                    }.coerceAtLeast(0.05)
+            val jitterUnit = jitterMagnitude * medianScore
             val scored =
-                vectorFiltered
-                    .map { (video, videoVector) ->
-                        val base = NeuroScoring.scoreCandidate(video, videoVector, scoringParams)
-                        val jitter = random.nextDouble() * jitterMagnitude
-                        ScoredVideo(video, base + jitter, videoVector)
+                baseScored
+                    .map { (video, videoVector, base) ->
+                        ScoredVideo(video, base + random.nextDouble() * jitterUnit, videoVector)
                     }.toMutableList()
 
             // Apply diversity reranking

--- a/app/src/main/java/io/github/aedev/flow/data/recommendation/FlowNeuroEngine.kt
+++ b/app/src/main/java/io/github/aedev/flow/data/recommendation/FlowNeuroEngine.kt
@@ -154,6 +154,13 @@ class FlowNeuroEngine(
             query: String,
         ) = getInstance(context).onSearchQuery(query)
 
+        suspend fun reportQueryResultNovelty(
+            query: String,
+            novelRatio: Double,
+        ) = requireInstance().reportQueryResultNovelty(query, novelRatio)
+
+        suspend fun getRecentlyShownVideoIds(withinHours: Long = 48L): Set<String> = requireInstance().getRecentlyShownVideoIds(withinHours)
+
         suspend fun completeOnboarding(selectedTopics: Set<String>) = requireInstance().completeOnboarding(selectedTopics)
 
         suspend fun completeOnboarding(
@@ -1175,6 +1182,24 @@ class FlowNeuroEngine(
                     }
                 }
 
+                // ── Skip queries whose recent RESULTS were mostly already shown ──
+                val staleExpiryCutoff =
+                    System.currentTimeMillis() -
+                        NeuroScoring.STALE_QUERY_EXPIRY_HOURS * 60 * 60 * 1000L
+                val activeStaleKeys =
+                    brain.staleQueries
+                        .filter { (_, ts) -> ts > staleExpiryCutoff }
+                        .keys
+                if (activeStaleKeys.isNotEmpty()) {
+                    val fresh =
+                        candidates.filter { query ->
+                            queryStaleKey(query)?.let { it !in activeStaleKeys } ?: true
+                        }
+                    if (fresh.size >= 3) {
+                        candidates = fresh
+                    }
+                }
+
                 // ── Track used queries for future rotation ──
                 val newQueryTokens = candidates.map { tokenizer.tokenize(it).toSet() }
                 val updatedRecentTokens =
@@ -1200,16 +1225,91 @@ class FlowNeuroEngine(
         withContext(Dispatchers.Default) {
             if (candidates.isEmpty()) return@withContext emptyList()
             val now = System.currentTimeMillis()
-            val excludedChannelIds =
+            val seedCooldownCutoff = now - (NeuroScoring.RELATED_SEED_COOLDOWN_HOURS * 60 * 60 * 1000L)
+            val excludedChannelIds: Set<String>
+            val recentSeedIds: Set<String>
+            brainMutex.withLock {
+                val channelSuppressionCutoff = now - (CHANNEL_SUPPRESSION_DAYS * 24 * 60 * 60 * 1000L)
+                excludedChannelIds = currentUserBrain.blockedChannels +
+                    currentUserBrain.suppressedChannels
+                        .filter { (_, ts) -> ts > channelSuppressionCutoff }
+                        .keys
+                recentSeedIds =
+                    currentUserBrain.recentRelatedSeeds
+                        .filter { (_, ts) -> ts > seedCooldownCutoff }
+                        .keys
+            }
+
+            // Seed rotation: newest-first selection kept picking the same seeds every
+            // refresh, making the RELATED lane byte-identical. Cool recently used seeds
+            // down unless that would starve the selection.
+            val rotated = candidates.filterNot { it.id in recentSeedIds }
+            val pool = if (rotated.size >= maxSeeds) rotated else candidates
+
+            val selected = GraphSeedSelector.select(pool, maxSeeds, now, excludedChannelIds)
+            if (selected.isNotEmpty()) {
                 brainMutex.withLock {
-                    val channelSuppressionCutoff = now - (CHANNEL_SUPPRESSION_DAYS * 24 * 60 * 60 * 1000L)
-                    currentUserBrain.blockedChannels +
-                        currentUserBrain.suppressedChannels
-                            .filter { (_, ts) -> ts > channelSuppressionCutoff }
-                            .keys
+                    val updated = currentUserBrain.recentRelatedSeeds.toMutableMap()
+                    updated.entries.removeAll { it.value < seedCooldownCutoff }
+                    selected.forEach { updated[it] = now }
+                    val capped =
+                        if (updated.size > NeuroScoring.RECENT_RELATED_SEEDS_MAX) {
+                            updated.entries
+                                .sortedByDescending { it.value }
+                                .take(NeuroScoring.RECENT_RELATED_SEEDS_MAX)
+                                .associate { it.key to it.value }
+                        } else {
+                            updated
+                        }
+                    currentUserBrain = currentUserBrain.copy(recentRelatedSeeds = capped)
+                    scheduleDebouncedSave()
                 }
-            GraphSeedSelector.select(candidates, maxSeeds, now, excludedChannelIds)
+            }
+            selected
         }
+
+    /** Feed-history ids shown within the window — for assembly-time exclusion sets. */
+    suspend fun getRecentlyShownVideoIds(withinHours: Long = 48L): Set<String> =
+        brainMutex.withLock {
+            val cutoff = System.currentTimeMillis() - withinHours * 60 * 60 * 1000L
+            currentUserBrain.feedHistory.filter { it.value.lastShown > cutoff }.keys
+        }
+
+    /**
+     * Marks a discovery query stale when its RESULTS were mostly already shown —
+     * a stronger repetition signal than query-wording overlap. Stale queries are
+     * skipped by generateDiscoveryQueries for STALE_QUERY_EXPIRY_HOURS; a query
+     * that comes back with fresh results clears its mark.
+     */
+    suspend fun reportQueryResultNovelty(
+        query: String,
+        novelRatio: Double,
+    ) {
+        val key = queryStaleKey(query) ?: return
+        brainMutex.withLock {
+            val now = System.currentTimeMillis()
+            val expiryCutoff = now - NeuroScoring.STALE_QUERY_EXPIRY_HOURS * 60 * 60 * 1000L
+            val updated = currentUserBrain.staleQueries.toMutableMap()
+            updated.entries.removeAll { it.value < expiryCutoff }
+            if (novelRatio < NeuroScoring.STALE_QUERY_NOVELTY_THRESHOLD) {
+                updated[key] = now
+                if (updated.size > NeuroScoring.STALE_QUERY_MAX) {
+                    val oldest = updated.entries.minByOrNull { it.value }
+                    oldest?.let { updated.remove(it.key) }
+                }
+            } else {
+                updated.remove(key)
+            }
+            currentUserBrain = currentUserBrain.copy(staleQueries = updated)
+            scheduleDebouncedSave()
+        }
+    }
+
+    private fun queryStaleKey(query: String): String? {
+        val tokens = tokenizer.tokenize(query)
+        if (tokens.isEmpty()) return null
+        return tokens.sorted().joinToString("|")
+    }
 
     // =================================================
     // MAIN RANKING FUNCTION
@@ -1326,9 +1426,13 @@ class FlowNeuroEngine(
 
             if (filtered.isEmpty()) return@withContext emptyList()
 
+            // Hard seen-gate: recently over-shown items are removed, not just
+            // penalized — score penalties let high-scoring repeats punch back in.
+            val gated = NeuroScoring.applySeenGate(filtered, brain.feedHistory, now) { it.id }
+
             // Extract all features with consistent IDF snapshot
             val videoVectors =
-                filtered.map { video ->
+                gated.map { video ->
                     val channelProfile = brain.channelTopicProfiles[video.channelId]
                     video to getOrExtractFeatures(video, idfSnapshot, channelProfile)
                 }
@@ -1409,7 +1513,7 @@ class FlowNeuroEngine(
                     impressions = impressionSnapshot,
                     watchHistory = watchHistorySnapshot,
                     recentInteractions = recentInteractionsSnapshot,
-                    candidatePoolSize = filtered.size,
+                    candidatePoolSize = gated.size,
                     now = now,
                     exploreWeight = exploreWeight,
                 )

--- a/app/src/main/java/io/github/aedev/flow/data/recommendation/GraphSeedSelector.kt
+++ b/app/src/main/java/io/github/aedev/flow/data/recommendation/GraphSeedSelector.kt
@@ -11,6 +11,7 @@ internal object GraphSeedSelector {
         excludedChannelIds: Set<String> = emptySet(),
         maxPerCluster: Int = 2,
         topicScores: Map<String, Double> = emptyMap(),
+        communityOf: ((String) -> String)? = null,
     ): List<String> {
         if (candidates.isEmpty() || maxSeeds <= 0) return emptyList()
         val tokenizer = NeuroTokenizer()
@@ -19,9 +20,12 @@ internal object GraphSeedSelector {
                 .asSequence()
                 .filter { it.isEligible(excludedChannelIds) }
                 .map { seed ->
+                    val rawKey = clusterKey(seed.title, tokenizer, topicScores)
                     ScoredSeed(
                         id = seed.id,
-                        clusterKey = clusterKey(seed.title, tokenizer, topicScores),
+                        // Mapping topic keys to interest COMMUNITIES makes the
+                        // spread-first pick allocate one seed per major interest.
+                        clusterKey = communityOf?.invoke(rawKey) ?: rawKey,
                         weight = seed.score(now),
                     )
                 }.filter { it.weight > 0.0 }

--- a/app/src/main/java/io/github/aedev/flow/data/recommendation/GraphSeedSelector.kt
+++ b/app/src/main/java/io/github/aedev/flow/data/recommendation/GraphSeedSelector.kt
@@ -9,35 +9,37 @@ internal object GraphSeedSelector {
         maxSeeds: Int,
         now: Long = System.currentTimeMillis(),
         excludedChannelIds: Set<String> = emptySet(),
-        maxPerCluster: Int = 2
+        maxPerCluster: Int = 2,
+        topicScores: Map<String, Double> = emptyMap(),
     ): List<String> {
         if (candidates.isEmpty() || maxSeeds <= 0) return emptyList()
         val tokenizer = NeuroTokenizer()
-        val ranked = candidates
-            .asSequence()
-            .filter { it.isEligible(excludedChannelIds) }
-            .map { seed ->
-                ScoredSeed(
-                    id = seed.id,
-                    clusterKey = clusterKey(seed.title, tokenizer),
-                    weight = seed.score(now)
-                )
-            }
-            .filter { it.weight > 0.0 }
-            .groupBy { it.id }
-            .values
-            .mapNotNull { seeds -> seeds.maxByOrNull { it.weight } }
-            .map { SeedRank(it.id, it.clusterKey, it.weight) }
-            .toList()
+        val ranked =
+            candidates
+                .asSequence()
+                .filter { it.isEligible(excludedChannelIds) }
+                .map { seed ->
+                    ScoredSeed(
+                        id = seed.id,
+                        clusterKey = clusterKey(seed.title, tokenizer, topicScores),
+                        weight = seed.score(now),
+                    )
+                }.filter { it.weight > 0.0 }
+                .groupBy { it.id }
+                .values
+                .mapNotNull { seeds -> seeds.maxByOrNull { it.weight } }
+                .map { SeedRank(it.id, it.clusterKey, it.weight) }
+                .toList()
 
         return NeuroScoring.pickDiverseSeeds(ranked, maxSeeds, maxPerCluster)
     }
 
-    fun scoreSeed(seed: GraphSeedInput, now: Long = System.currentTimeMillis()): Double =
-        seed.score(now)
+    fun scoreSeed(
+        seed: GraphSeedInput,
+        now: Long = System.currentTimeMillis(),
+    ): Double = seed.score(now)
 
-    fun clusterKey(seed: GraphSeedInput): String =
-        clusterKey(seed.title, NeuroTokenizer())
+    fun clusterKey(seed: GraphSeedInput): String = clusterKey(seed.title, NeuroTokenizer())
 
     private fun GraphSeedInput.isEligible(excludedChannelIds: Set<String>): Boolean {
         if (id.isBlank() || isShort) return false
@@ -52,13 +54,17 @@ internal object GraphSeedSelector {
     private fun GraphSeedInput.score(now: Long): Double =
         engagementWeight.coerceAtLeast(0.0) * sourceWeight() * recencyWeight(timestamp, now)
 
-    private fun GraphSeedInput.sourceWeight(): Double = when (source) {
-        GraphSeedSource.LIKED -> 1.4
-        GraphSeedSource.PLAYLIST -> 1.0
-        GraphSeedSource.WATCH_HISTORY -> if (percentWatched >= 70.0) 1.2 else 0.8
-    }
+    private fun GraphSeedInput.sourceWeight(): Double =
+        when (source) {
+            GraphSeedSource.LIKED -> 1.4
+            GraphSeedSource.PLAYLIST -> 1.0
+            GraphSeedSource.WATCH_HISTORY -> if (percentWatched >= 70.0) 1.2 else 0.8
+        }
 
-    private fun recencyWeight(timestamp: Long, now: Long): Double {
+    private fun recencyWeight(
+        timestamp: Long,
+        now: Long,
+    ): Double {
         if (timestamp <= 0L) return 0.85
         val ageDays = ((now - timestamp).coerceAtLeast(0L) / DAY_MS).toInt()
         return when {
@@ -70,13 +76,34 @@ internal object GraphSeedSelector {
         }
     }
 
-    private fun clusterKey(title: String, tokenizer: NeuroTokenizer): String {
+    private fun clusterKey(
+        title: String,
+        tokenizer: NeuroTokenizer,
+        topicScores: Map<String, Double> = emptyMap(),
+    ): String {
         val tokens = tokenizer.tokenize(title)
+
+        // Prefer the token the user's interest vector knows best — seeds then
+        // cluster by INTEREST, not by whichever word happened to come first.
+        if (topicScores.isNotEmpty()) {
+            val best =
+                tokens
+                    .map { tokenizer.normalizeLemma(it) }
+                    .mapNotNull { lemma ->
+                        val score =
+                            topicScores[lemma]
+                                ?: topicScores.entries.firstOrNull { NeuroScoring.stripDomainTag(it.key) == lemma }?.value
+                        score?.let { lemma to it }
+                    }.maxByOrNull { it.second }
+            if (best != null && best.second >= 0.05) return best.first
+        }
+
         for (token in tokens) {
             val lemma = tokenizer.normalizeLemma(token)
-            val category = NeuroTopicCatalog.TOPIC_CATEGORIES.firstOrNull { c ->
-                c.topics.any { tokenizer.normalizeLemma(it) == lemma }
-            }
+            val category =
+                NeuroTopicCatalog.TOPIC_CATEGORIES.firstOrNull { c ->
+                    c.topics.any { tokenizer.normalizeLemma(it) == lemma }
+                }
             if (category != null) return "cat:${category.name}"
         }
         return tokens.firstOrNull()?.let { tokenizer.normalizeLemma(it) } ?: "misc"
@@ -85,6 +112,6 @@ internal object GraphSeedSelector {
     private data class ScoredSeed(
         val id: String,
         val clusterKey: String,
-        val weight: Double
+        val weight: Double,
     )
 }

--- a/app/src/main/java/io/github/aedev/flow/data/recommendation/GraphSeedSelector.kt
+++ b/app/src/main/java/io/github/aedev/flow/data/recommendation/GraphSeedSelector.kt
@@ -61,8 +61,13 @@ internal object GraphSeedSelector {
     private fun GraphSeedInput.sourceWeight(): Double =
         when (source) {
             GraphSeedSource.LIKED -> 1.4
+
             GraphSeedSource.PLAYLIST -> 1.0
+
             GraphSeedSource.WATCH_HISTORY -> if (percentWatched >= 70.0) 1.2 else 0.8
+
+            // Feed items were engine-picked but not user-confirmed — usable, weakest.
+            GraphSeedSource.FEED -> 0.7
         }
 
     private fun recencyWeight(

--- a/app/src/main/java/io/github/aedev/flow/data/recommendation/NeuroChannelKnowledge.kt
+++ b/app/src/main/java/io/github/aedev/flow/data/recommendation/NeuroChannelKnowledge.kt
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2025-2026 Flow | A-EDev
+ *
+ * This file is part of Flow (https://github.com/A-EDev/Flow).
+ *
+ * This recommendation algorithm (FlowNeuroEngine) is the intellectual property
+ * of the Flow project. Any use of this code in other projects must
+ * explicitly credit "Flow Android Client" and link back to the original repository.
+ */
+
+package io.github.aedev.flow.data.recommendation
+
+/**
+ * Channel-level knowledge extraction — pure functions the engine applies.
+ *
+ * Channels carry two under-used signals: creator-declared keyword tags
+ * (NewPipe ChannelInfo.tags — authored identity, fetched on subscribe) and
+ * their recent upload titles (already downloaded for the subs lane, previously
+ * discarded for learning). Both feed channelTopicProfiles, which drive
+ * candidate priors, interest clustering, and brain rehydration.
+ */
+internal object NeuroChannelKnowledge {
+    /** Seed weight for creator-declared tags — authored, so trusted more. */
+    const val TAG_SEED_WEIGHT = 0.35
+
+    /** Ceiling for passively observed upload-title topics — inferred, so modest. */
+    const val PASSIVE_MAX_WEIGHT = 0.25
+
+    const val MAX_TOKENS = 8
+
+    /** Creator-declared channel keywords (+ description lead) → profile seed weights. */
+    fun profileFromChannelTags(
+        tags: List<String>,
+        description: String?,
+        tokenizer: NeuroTokenizer,
+    ): Map<String, Double> {
+        val fromTags = tags.flatMap { tokenizer.tokenize(it) }
+        val fromDescription =
+            description
+                ?.lineSequence()
+                ?.take(2)
+                ?.joinToString(" ")
+                ?.let { tokenizer.tokenize(it) }
+                .orEmpty()
+        val counts =
+            (fromTags + fromDescription)
+                .filterNot { tokenizer.isNoiseTopic(it) }
+                .groupingBy { it }
+                .eachCount()
+        if (counts.isEmpty()) return emptyMap()
+        val max = counts.values.max().toDouble()
+        return counts.entries
+            .sortedByDescending { it.value }
+            .take(MAX_TOKENS)
+            .associate { (token, count) -> token to TAG_SEED_WEIGHT * (0.6 + 0.4 * count / max) }
+    }
+
+    /**
+     * Passive profile from a channel's recent upload titles. Tokens must repeat
+     * across titles (when there are 3+) — a word from a single video is usually
+     * video-specific, not channel identity.
+     */
+    fun profileFromUploadTitles(
+        titles: List<String>,
+        tokenizer: NeuroTokenizer,
+    ): Map<String, Double> {
+        if (titles.isEmpty()) return emptyMap()
+        val counts =
+            titles
+                .flatMap { tokenizer.tokenize(it).distinct() }
+                .filterNot { tokenizer.isNoiseTopic(it) }
+                .groupingBy { it }
+                .eachCount()
+        if (counts.isEmpty()) return emptyMap()
+        val minCount = if (titles.size >= 3) 2 else 1
+        val identity = counts.filterValues { it >= minCount }
+        if (identity.isEmpty()) return emptyMap()
+        val max = identity.values.max().toDouble()
+        return identity.entries
+            .sortedByDescending { it.value }
+            .take(MAX_TOKENS)
+            .associate { (token, count) -> token to PASSIVE_MAX_WEIGHT * count / max }
+    }
+
+    /** Max-merge additions into a profile — never lowers learned weights. */
+    fun mergeProfile(
+        existing: Map<String, Double>,
+        additions: Map<String, Double>,
+    ): Map<String, Double> {
+        if (additions.isEmpty()) return existing
+        val merged = existing.toMutableMap()
+        additions.forEach { (topic, weight) -> merged.merge(topic, weight, ::maxOf) }
+        return if (merged.size > NeuroScoring.CHANNEL_PROFILE_MAX_TOPICS) {
+            merged.entries
+                .sortedByDescending { it.value }
+                .take(NeuroScoring.CHANNEL_PROFILE_MAX_TOPICS)
+                .associate { it.key to it.value }
+        } else {
+            merged
+        }
+    }
+}

--- a/app/src/main/java/io/github/aedev/flow/data/recommendation/NeuroClusters.kt
+++ b/app/src/main/java/io/github/aedev/flow/data/recommendation/NeuroClusters.kt
@@ -63,6 +63,7 @@ internal object NeuroClusters {
         channelTopicProfiles: Map<String, Map<String, Double>>,
         categories: List<TopicCategory>,
         normalizeLemma: (String) -> String,
+        tagAffinities: Map<String, Double> = emptyMap(),
     ): List<TopicCluster> {
         // Nodes: strip domain tags, keep the strongest score per base word.
         val scores = HashMap<String, Double>()
@@ -87,6 +88,12 @@ internal object NeuroClusters {
 
         // (a) Co-watch affinities — the strongest user evidence.
         affinities.forEach { (key, weight) ->
+            val parts = key.split("|")
+            if (parts.size == 2) addEdge(parts[0], parts[1], weight)
+        }
+
+        // (a2) Creator-declared tag co-occurrence from opened videos.
+        tagAffinities.forEach { (key, weight) ->
             val parts = key.split("|")
             if (parts.size == 2) addEdge(parts[0], parts[1], weight)
         }

--- a/app/src/main/java/io/github/aedev/flow/data/recommendation/NeuroClusters.kt
+++ b/app/src/main/java/io/github/aedev/flow/data/recommendation/NeuroClusters.kt
@@ -1,0 +1,187 @@
+/*
+ * Copyright (C) 2025-2026 Flow | A-EDev
+ *
+ * This file is part of Flow (https://github.com/A-EDev/Flow).
+ *
+ * This recommendation algorithm (FlowNeuroEngine) is the intellectual property
+ * of the Flow project. Any use of this code in other projects must
+ * explicitly credit "Flow Android Client" and link back to the original repository.
+ */
+
+package io.github.aedev.flow.data.recommendation
+
+import kotlin.math.pow
+
+/**
+ * Interest clustering + rotation scheduling — SimClusters miniaturized.
+ *
+ * Groups the user's learned topics into interest communities using ONLY
+ * user-grounded evidence (co-watch affinities, channel topic profiles, and
+ * catalog co-membership of topics the user already has — the catalog links
+ * existing topics, it never injects new ones). A weighted round-robin
+ * scheduler then guarantees every community cycles into discovery over
+ * successive refreshes instead of the top interests monopolizing every slot.
+ *
+ * Everything here is pure and deterministic — no clock reads, no state.
+ */
+internal object NeuroClusters {
+    /**
+     * Mass exponent < 1 flattens dominance so big clusters can't monopolize.
+     * sqrt is deliberate: with max staleness 4x, even a mass-0.15 tail cluster
+     * outranks a mass-1.5 giant that was just served (0.39*4 > 1.22*1).
+     */
+    private const val MASS_EXPONENT = 0.5
+
+    /** Staleness doubles priority every this-many hours since last served. */
+    private const val STALENESS_HALF_LIFE_HOURS = 12.0
+
+    /** Never-served and long-unserved clusters get this max staleness boost. */
+    private const val STALENESS_MAX = 4.0
+
+    /** Weakest link admitted into the topic graph. */
+    private const val MIN_EDGE_WEIGHT = 0.02
+
+    private const val CHANNEL_PROFILE_TOP_TOPICS = 6
+    private const val CHANNEL_EDGE_SCALE = 0.5
+    private const val CATALOG_EDGE_WEIGHT = 0.3
+    private const val PROPAGATION_ITERATIONS = 5
+    private const val SELF_WEIGHT_SCALE = 0.5
+
+    data class TopicCluster(
+        val representative: String,
+        val topics: List<String>,
+        val mass: Double,
+    )
+
+    /**
+     * Builds interest clusters from the brain's own graph. Topic node ids are
+     * domain-stripped ("metal:music" → "metal") so evidence sources agree.
+     */
+    fun buildClusters(
+        topicScores: Map<String, Double>,
+        affinities: Map<String, Double>,
+        channelTopicProfiles: Map<String, Map<String, Double>>,
+        categories: List<TopicCategory>,
+        normalizeLemma: (String) -> String,
+    ): List<TopicCluster> {
+        // Nodes: strip domain tags, keep the strongest score per base word.
+        val scores = HashMap<String, Double>()
+        topicScores.forEach { (topic, score) ->
+            val base = NeuroScoring.stripDomainTag(topic)
+            if (base.length >= 3) scores.merge(base, score, ::maxOf)
+        }
+        if (scores.isEmpty()) return emptyList()
+
+        val adjacency = HashMap<String, HashMap<String, Double>>()
+
+        fun addEdge(
+            a: String,
+            b: String,
+            weight: Double,
+        ) {
+            if (a == b || weight < MIN_EDGE_WEIGHT) return
+            if (a !in scores || b !in scores) return
+            adjacency.getOrPut(a) { HashMap() }.merge(b, weight, Double::plus)
+            adjacency.getOrPut(b) { HashMap() }.merge(a, weight, Double::plus)
+        }
+
+        // (a) Co-watch affinities — the strongest user evidence.
+        affinities.forEach { (key, weight) ->
+            val parts = key.split("|")
+            if (parts.size == 2) addEdge(parts[0], parts[1], weight)
+        }
+
+        // (b) Topics taught by the same channel belong together.
+        channelTopicProfiles.values.forEach { profile ->
+            val top =
+                profile.entries
+                    .sortedByDescending { it.value }
+                    .take(CHANNEL_PROFILE_TOP_TOPICS)
+                    .map { NeuroScoring.stripDomainTag(it.key) to it.value }
+            for (i in top.indices) {
+                for (j in i + 1 until top.size) {
+                    addEdge(top[i].first, top[j].first, minOf(top[i].second, top[j].second) * CHANNEL_EDGE_SCALE)
+                }
+            }
+        }
+
+        // (c) Catalog co-membership — links only topics the user already has.
+        categories.forEach { category ->
+            val present = category.topics.map(normalizeLemma).filter { it in scores }
+            for (i in present.indices) {
+                for (j in i + 1 until present.size) {
+                    addEdge(present[i], present[j], CATALOG_EDGE_WEIGHT)
+                }
+            }
+        }
+
+        // Deterministic label propagation: visit strong topics first; ties break
+        // lexicographically so the outcome is stable across runs.
+        val nodes = scores.keys.sortedWith(compareByDescending<String> { scores.getValue(it) }.thenBy { it })
+        val labels = HashMap<String, String>(nodes.size)
+        nodes.forEach { labels[it] = it }
+
+        var iteration = 0
+        while (iteration < PROPAGATION_ITERATIONS) {
+            var changed = false
+            for (node in nodes) {
+                val weightByLabel = HashMap<String, Double>()
+                weightByLabel[labels.getValue(node)] = scores.getValue(node) * SELF_WEIGHT_SCALE
+                adjacency[node]?.forEach { (neighbor, weight) ->
+                    val label = labels.getValue(neighbor)
+                    weightByLabel.merge(label, weight, Double::plus)
+                }
+                val best =
+                    weightByLabel.entries
+                        .sortedWith(compareByDescending<Map.Entry<String, Double>> { it.value }.thenBy { it.key })
+                        .first()
+                        .key
+                if (best != labels[node]) {
+                    labels[node] = best
+                    changed = true
+                }
+            }
+            if (!changed) break
+            iteration++
+        }
+
+        return labels.entries
+            .groupBy({ it.value }, { it.key })
+            .values
+            .map { members ->
+                val sorted = members.sortedWith(compareByDescending<String> { scores.getValue(it) }.thenBy { it })
+                TopicCluster(
+                    representative = sorted.first(),
+                    topics = sorted,
+                    mass = members.sumOf { scores.getValue(it) },
+                )
+            }.sortedWith(compareByDescending<TopicCluster> { it.mass }.thenBy { it.representative })
+    }
+
+    /**
+     * Orders clusters for serving: weight = mass^0.7 × staleness. Flattened mass
+     * stops the top cluster monopolizing; staleness guarantees the tail cycles in.
+     * A cluster never served (or long unserved) gets the max boost, so every
+     * saved interest reaches the feed within a bounded number of refreshes.
+     */
+    fun schedule(
+        clusters: List<TopicCluster>,
+        rotation: Map<String, Long>,
+        now: Long,
+    ): List<TopicCluster> =
+        clusters
+            .map { cluster ->
+                val lastServed = rotation[cluster.representative]
+                val staleness =
+                    if (lastServed == null || lastServed <= 0L) {
+                        STALENESS_MAX
+                    } else {
+                        val hoursSince = (now - lastServed) / 3_600_000.0
+                        (1.0 + hoursSince / STALENESS_HALF_LIFE_HOURS).coerceAtMost(STALENESS_MAX)
+                    }
+                cluster to cluster.mass.pow(MASS_EXPONENT) * staleness
+            }.sortedWith(
+                compareByDescending<Pair<TopicCluster, Double>> { it.second }
+                    .thenBy { it.first.representative },
+            ).map { it.first }
+}

--- a/app/src/main/java/io/github/aedev/flow/data/recommendation/NeuroContentStore.kt
+++ b/app/src/main/java/io/github/aedev/flow/data/recommendation/NeuroContentStore.kt
@@ -1,0 +1,160 @@
+/*
+ * Copyright (C) 2025-2026 Flow | A-EDev
+ *
+ * This file is part of Flow (https://github.com/A-EDev/Flow).
+ *
+ * This recommendation algorithm (FlowNeuroEngine) is the intellectual property
+ * of the Flow project. Any use of this code in other projects must
+ * explicitly credit "Flow Android Client" and link back to the original repository.
+ */
+
+package io.github.aedev.flow.data.recommendation
+
+import android.content.Context
+import android.util.Log
+import androidx.datastore.core.DataStore
+import androidx.datastore.core.Serializer
+import androidx.datastore.dataStore
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import java.io.InputStream
+import java.io.OutputStream
+
+/**
+ * Persistent per-video content index. Tags are only available when a video is
+ * OPENED (full StreamInfo) — feed candidates arrive with bare titles. This store
+ * keeps the tag-rich topic vector computed at watch time so that when the same
+ * video reappears as a candidate it is scored on real content, not its title.
+ * Representations accumulate from engagement — the SimClusters tweet-embedding
+ * idea, miniaturized.
+ */
+internal class NeuroContentStore(
+    private val appContext: Context,
+) {
+    companion object {
+        private const val TAG = "FlowNeuroEngine"
+        private const val MAX_ENTRIES = 1500
+        private const val TOPICS_PER_ENTRY = 12
+    }
+
+    @Serializable
+    data class StoredVector(
+        val topics: Map<String, Double> = emptyMap(),
+        val at: Long = 0L,
+    )
+
+    @Serializable
+    data class ContentIndex(
+        val vectors: Map<String, StoredVector> = emptyMap(),
+    )
+
+    private object ContentSerializer : Serializer<ContentIndex> {
+        override val defaultValue: ContentIndex = ContentIndex()
+
+        override suspend fun readFrom(input: InputStream): ContentIndex =
+            try {
+                val text = input.bufferedReader().readText()
+                if (text.isBlank()) {
+                    defaultValue
+                } else {
+                    Json { ignoreUnknownKeys = true }.decodeFromString<ContentIndex>(text)
+                }
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to read content index", e)
+                defaultValue
+            }
+
+        override suspend fun writeTo(
+            t: ContentIndex,
+            output: OutputStream,
+        ) {
+            output.write(Json.encodeToString(t).toByteArray())
+        }
+    }
+
+    private val Context.contentDataStore: DataStore<ContentIndex>
+        by dataStore(
+            fileName = "flow_neuro_content_v1.json",
+            serializer = ContentSerializer,
+        )
+
+    @Volatile
+    private var vectors: Map<String, StoredVector> = emptyMap()
+
+    @Volatile
+    private var dirty = false
+
+    suspend fun load() {
+        withContext(Dispatchers.IO) {
+            try {
+                vectors =
+                    appContext.contentDataStore.data
+                        .first()
+                        .vectors
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to load content index", e)
+            }
+        }
+    }
+
+    /** Fast, non-suspending read for the ranking hot path. */
+    fun topicsFor(videoId: String): Map<String, Double>? = vectors[videoId]?.topics
+
+    fun size(): Int = vectors.size
+
+    /** Records the tag-rich vector of an opened video, LRU-pruned by write time. */
+    fun put(
+        videoId: String,
+        topics: Map<String, Double>,
+        now: Long = System.currentTimeMillis(),
+    ) {
+        if (videoId.isBlank() || topics.isEmpty()) return
+        val trimmed =
+            topics.entries
+                .sortedByDescending { it.value }
+                .take(TOPICS_PER_ENTRY)
+                .associate { it.key to it.value }
+        val updated = vectors.toMutableMap()
+        updated[videoId] = StoredVector(trimmed, now)
+        vectors =
+            if (updated.size > MAX_ENTRIES) {
+                updated.entries
+                    .sortedByDescending { it.value.at }
+                    .take(MAX_ENTRIES)
+                    .associate { it.key to it.value }
+            } else {
+                updated
+            }
+        dirty = true
+    }
+
+    /** Persists the in-memory index if it changed; callers debounce. */
+    suspend fun persistIfDirty() {
+        if (!dirty) return
+        dirty = false
+        withContext(Dispatchers.IO) {
+            try {
+                val snapshot = vectors
+                appContext.contentDataStore.updateData { ContentIndex(snapshot) }
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to persist content index", e)
+            }
+        }
+    }
+
+    suspend fun clear() {
+        vectors = emptyMap()
+        dirty = false
+        withContext(Dispatchers.IO) {
+            try {
+                appContext.contentDataStore.updateData { ContentIndex() }
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to clear content index", e)
+            }
+        }
+    }
+}

--- a/app/src/main/java/io/github/aedev/flow/data/recommendation/NeuroDiscovery.kt
+++ b/app/src/main/java/io/github/aedev/flow/data/recommendation/NeuroDiscovery.kt
@@ -34,9 +34,8 @@ import java.util.Calendar
  */
 internal class NeuroDiscovery(
     private val topicCategories: List<TopicCategory>,
-    private val tokenizer: NeuroTokenizer
+    private val tokenizer: NeuroTokenizer,
 ) {
-
     // ═══════════════════════════════════════════════
     // TOPIC MATURITY SYSTEM
     // A topic needs sustained engagement to be considered
@@ -49,19 +48,21 @@ internal class NeuroDiscovery(
         val maturityLevel: TopicMaturity,
         val categorySupport: Int,
         val hasTimeContext: Boolean,
-        val hasDiscoveryEvidence: Boolean
+        val hasDiscoveryEvidence: Boolean,
+        /** Interest-cluster representative this topic belongs to (set during selection). */
+        val clusterKey: String? = null,
     )
 
     private enum class TopicMaturity {
         EMERGING,
         DEVELOPING,
         ESTABLISHED,
-        CORE
+        CORE,
     }
 
     private fun analyzeMatureTopics(
         brain: UserBrain,
-        timeTopics: Set<String>
+        timeTopics: Set<String>,
     ): List<MatureTopic> {
         val allTopics = brain.globalVector.topics
         if (allTopics.isEmpty()) return emptyList()
@@ -69,18 +70,20 @@ internal class NeuroDiscovery(
         return allTopics.entries
             .filter { isSubstantialTopic(it.key) }
             .map { (name, score) ->
-                val maturity = when {
-                    score >= 0.70 -> TopicMaturity.CORE
-                    score >= 0.40 -> TopicMaturity.ESTABLISHED
-                    score >= 0.20 -> TopicMaturity.DEVELOPING
-                    else -> TopicMaturity.EMERGING
-                }
+                val maturity =
+                    when {
+                        score >= 0.70 -> TopicMaturity.CORE
+                        score >= 0.40 -> TopicMaturity.ESTABLISHED
+                        score >= 0.20 -> TopicMaturity.DEVELOPING
+                        else -> TopicMaturity.EMERGING
+                    }
 
-                val categorySupport = topicCategories.count { cat ->
-                    val catTopics = cat.topics.map { tokenizer.normalizeLemma(it) }
-                    catTopics.contains(name) &&
-                        catTopics.count { it in allTopics } >= 2
-                }
+                val categorySupport =
+                    topicCategories.count { cat ->
+                        val catTopics = cat.topics.map { tokenizer.normalizeLemma(it) }
+                        catTopics.contains(name) &&
+                            catTopics.count { it in allTopics } >= 2
+                    }
 
                 MatureTopic(
                     name = name,
@@ -88,152 +91,107 @@ internal class NeuroDiscovery(
                     maturityLevel = maturity,
                     categorySupport = categorySupport,
                     hasTimeContext = name in timeTopics,
-                    hasDiscoveryEvidence = hasDiscoveryEvidence(name, brain)
+                    hasDiscoveryEvidence = hasDiscoveryEvidence(name, brain),
                 )
-            }
-            .sortedWith(
+            }.sortedWith(
                 compareByDescending<MatureTopic> { it.maturityLevel.ordinal }
                     .thenByDescending { it.score }
-                    .thenByDescending { it.categorySupport }
+                    .thenByDescending { it.categorySupport },
             )
     }
 
     // ═══════════════════════════════════════════════
-    // TOPIC CLUSTERING — GROUP CO-OCCURRING TOPICS
-    // ═══════════════════════════════════════════════
-
-    private fun clusterTopics(
-        topics: List<MatureTopic>,
-        brain: UserBrain
-    ): List<List<MatureTopic>> {
-        if (topics.isEmpty()) return emptyList()
-
-        val parent = IntArray(topics.size) { it }
-        fun find(x: Int): Int {
-            var r = x
-            while (parent[r] != r) r = parent[r]
-            parent[x] = r
-            return r
-        }
-        fun union(a: Int, b: Int) { parent[find(a)] = find(b) }
-
-        val nameToIndex = topics.mapIndexed { i, t -> t.name to i }.toMap()
-
-        for (cat in topicCategories) {
-            val catLemmas = cat.topics.map { tokenizer.normalizeLemma(it) }
-            val indicesInCat = catLemmas.mapNotNull { nameToIndex[it] }
-            for (i in 1 until indicesInCat.size) {
-                union(indicesInCat[0], indicesInCat[i])
-            }
-        }
-
-        brain.topicAffinities.entries
-            .filter { it.value > 0.12 }
-            .forEach { (key, _) ->
-                val parts = key.split("|")
-                if (parts.size == 2) {
-                    val ia = nameToIndex[parts[0]]
-                    val ib = nameToIndex[parts[1]]
-                    if (ia != null && ib != null) union(ia, ib)
-                }
-            }
-
-        return topics.indices
-            .groupBy { find(it) }
-            .values
-            .map { indices -> indices.map { topics[it] } }
-            .sortedByDescending { cluster ->
-                cluster.maxOf { it.maturityLevel.ordinal * 100 + (it.score * 100).toInt() }
-            }
-    }
-
-    // ═══════════════════════════════════════════════
-    // TOPIC SELECTION — DIVERSITY ACROSS CLUSTERS
+    // TOPIC SELECTION — CLUSTER ROTATION
+    // Interest communities come from NeuroClusters (label propagation
+    // over the user's own co-watch/channel/catalog graph) and are served
+    // in staleness-weighted order, so EVERY saved interest cycles into
+    // the feed across sessions instead of the top topics monopolizing.
     // ═══════════════════════════════════════════════
 
     private data class TopicSelection(
         val primary: List<MatureTopic>,
         val secondary: List<MatureTopic>,
         val emerging: List<MatureTopic>,
-        val crossCategory: List<MatureTopic>
+        val crossCategory: List<MatureTopic>,
     ) {
-        fun allTopics(): List<MatureTopic> =
-            (primary + secondary + emerging + crossCategory).distinctBy { it.name }
+        fun allTopics(): List<MatureTopic> = (primary + secondary + emerging + crossCategory).distinctBy { it.name }
 
         fun uniqueTopicCount(): Int = allTopics().map { it.name }.distinct().size
     }
 
+    private fun emptySelection() = TopicSelection(emptyList(), emptyList(), emptyList(), emptyList())
+
     private fun selectDiverseTopics(
         matureTopics: List<MatureTopic>,
-        brain: UserBrain
+        brain: UserBrain,
+        now: Long,
     ): TopicSelection {
-        if (matureTopics.isEmpty()) return TopicSelection(
-            emptyList(), emptyList(), emptyList(), emptyList()
-        )
+        if (matureTopics.isEmpty()) return emptySelection()
 
-        val clusters = clusterTopics(matureTopics, brain)
-
-        val clusterReps = clusters.map { cluster ->
-            cluster.maxByOrNull {
-                it.maturityLevel.ordinal * 1000 + (it.score * 1000).toInt()
-            }!!
-        }
-
-        val primary = clusterReps.firstOrNull {
-            it.maturityLevel >= TopicMaturity.ESTABLISHED
-        } ?: clusterReps.first()
-
-        val primaryClusterIdx = clusters.indexOfFirst { cluster ->
-            cluster.any { it.name == primary.name }
-        }
-        val secondary = clusterReps
-            .filterIndexed { idx, _ -> idx != primaryClusterIdx }
-            .sortedWith(
-                compareByDescending<MatureTopic> { it.maturityLevel.ordinal }
-                    .thenByDescending { it.score }
+        val clusters =
+            NeuroClusters.buildClusters(
+                topicScores = matureTopics.associate { it.name to it.score },
+                affinities = brain.topicAffinities,
+                channelTopicProfiles = brain.channelTopicProfiles,
+                categories = topicCategories,
+                normalizeLemma = tokenizer::normalizeLemma,
             )
-            .take(4)
+        if (clusters.isEmpty()) return emptySelection()
+
+        val scheduled = NeuroClusters.schedule(clusters, brain.clusterRotation, now)
+
+        // Resolve each scheduled cluster back to its strongest MatureTopic.
+        val byBase = HashMap<String, MatureTopic>()
+        matureTopics.forEach { topic ->
+            byBase.putIfAbsent(NeuroScoring.stripDomainTag(topic.name), topic)
+        }
+        val reps =
+            scheduled.mapNotNull { cluster ->
+                cluster.topics
+                    .firstNotNullOfOrNull { byBase[it] }
+                    ?.copy(clusterKey = cluster.representative)
+            }
+        if (reps.isEmpty()) return emptySelection()
+
+        val primary = reps.firstOrNull { it.maturityLevel >= TopicMaturity.DEVELOPING } ?: reps.first()
+        val secondary = reps.filter { it.name != primary.name }.take(4)
 
         val representedNames = (listOf(primary) + secondary).map { it.name }.toSet()
-        val emerging = clusterReps
-            .filter {
-                it.maturityLevel == TopicMaturity.DEVELOPING &&
-                    it.name !in representedNames
-            }
-            .take(2)
+        val emerging =
+            reps
+                .filter { it.name !in representedNames }
+                .take(2)
 
-        val representedCategories = (listOf(primary) + secondary + emerging)
-            .mapNotNull { topic ->
-                topicCategories.find { cat ->
-                    cat.topics.any {
-                        tokenizer.normalizeLemma(it) == topic.name
-                    }
-                }?.name
-            }.toSet()
-
-        val crossCategory = matureTopics
-            .filter { topic ->
-                topic.name !in representedNames &&
-                    topic.maturityLevel >= TopicMaturity.DEVELOPING &&
-                    topicCategories.find { cat ->
-                        cat.topics.any {
-                            tokenizer.normalizeLemma(it) == topic.name
-                        }
-                    }?.let { it.name !in representedCategories } == true
-            }
-            .take(2)
+        val representedCategories =
+            (listOf(primary) + secondary + emerging)
+                .mapNotNull { categoryNameOf(it.name) }
+                .toSet()
+        val crossCategory =
+            reps
+                .filter { topic ->
+                    topic.name !in representedNames &&
+                        categoryNameOf(topic.name)?.let { it !in representedCategories } == true
+                }.take(2)
 
         return TopicSelection(
             primary = listOf(primary),
             secondary = secondary,
             emerging = emerging,
-            crossCategory = crossCategory
+            crossCategory = crossCategory,
         )
+    }
+
+    private fun categoryNameOf(topicName: String): String? {
+        val base = NeuroScoring.stripDomainTag(topicName)
+        return topicCategories
+            .find { cat ->
+                cat.topics.any { tokenizer.normalizeLemma(it) == base }
+            }?.name
     }
 
     private fun isDiscoveryEligible(
         topic: MatureTopic,
-        isMatureBrain: Boolean = false
+        isMatureBrain: Boolean = false,
     ): Boolean {
         if (topic.hasDiscoveryEvidence) return true
         if (topic.maturityLevel >= TopicMaturity.DEVELOPING) return true
@@ -241,20 +199,28 @@ internal class NeuroDiscovery(
         return false
     }
 
-    private fun hasDiscoveryEvidence(topic: String, brain: UserBrain): Boolean {
+    private fun hasDiscoveryEvidence(
+        topic: String,
+        brain: UserBrain,
+    ): Boolean {
         val base = NeuroScoring.stripDomainTag(topic)
-        val preferred = brain.preferredTopics.any {
-            tokenizer.normalizeLemma(it).equals(base, ignoreCase = true)
-        }
+        val preferred =
+            brain.preferredTopics.any {
+                tokenizer.normalizeLemma(it).equals(base, ignoreCase = true)
+            }
         if (preferred) return true
 
-        val evidence = brain.topicEvidence[base] ?: brain.topicEvidence[topic]
-            ?: return false
+        val evidence =
+            brain.topicEvidence[base] ?: brain.topicEvidence[topic]
+                ?: return false
 
         return evidence.explicitSignals > 0 ||
             evidence.watchSignals >= 2 ||
             evidence.videoIds.size >= 2 ||
-            evidence.positiveScore >= 1.2
+            evidence.positiveScore >= 1.2 ||
+            // Modest but repeated engagement: enough to earn scheduled rotation
+            // slots for weak-tail interests (probation still damps their scores).
+            (evidence.positiveSignals >= 2 && evidence.positiveScore >= 0.5)
     }
 
     // ═══════════════════════════════════════════════
@@ -263,35 +229,90 @@ internal class NeuroDiscovery(
     // Used sparingly, only when a clear preference exists.
     // ═══════════════════════════════════════════════
 
-    private val FRESHNESS_WORDS = listOf("2025", "2026", "new", "latest")
+    private val freshnessWords = listOf("2025", "2026", "new", "latest")
 
-    private val LONG_FORM_WORDS = listOf(
-        "documentary", "deep dive", "essay", "full", "breakdown"
-    )
+    private val longFormWords =
+        listOf(
+            "documentary",
+            "deep dive",
+            "essay",
+            "full",
+            "breakdown",
+        )
 
-    private val SHORT_FORM_WORDS = listOf(
-        "highlights", "best moments", "compilation"
-    )
+    private val shortFormWords =
+        listOf(
+            "highlights",
+            "best moments",
+            "compilation",
+        )
 
     // ═══════════════════════════════════════════════
     // QUERY ENRICHMENT FOR AMBIGUOUS TOPICS
     // ═══════════════════════════════════════════════
 
-    private val AMBIGUOUS_QUERY_WORDS = hashSetOf(
-        "code", "design", "build", "run", "play", "model", "train",
-        "stream", "fire", "rock", "metal", "spring", "cell", "plant",
-        "pitch", "jam", "bar", "wave", "track", "scale", "craft",
-        "mine", "host", "board", "drop", "lead", "light", "block",
-        "bass", "clip", "fan", "gear", "kit", "log", "net", "pad",
-        "port", "rig", "set", "tap", "tip", "web", "flow",
-        "mix", "beat", "sound", "work", "world", "life", "point",
-        "style", "power", "space", "match"
-    )
+    private val ambiguousQueryWords =
+        hashSetOf(
+            "code",
+            "design",
+            "build",
+            "run",
+            "play",
+            "model",
+            "train",
+            "stream",
+            "fire",
+            "rock",
+            "metal",
+            "spring",
+            "cell",
+            "plant",
+            "pitch",
+            "jam",
+            "bar",
+            "wave",
+            "track",
+            "scale",
+            "craft",
+            "mine",
+            "host",
+            "board",
+            "drop",
+            "lead",
+            "light",
+            "block",
+            "bass",
+            "clip",
+            "fan",
+            "gear",
+            "kit",
+            "log",
+            "net",
+            "pad",
+            "port",
+            "rig",
+            "set",
+            "tap",
+            "tip",
+            "web",
+            "flow",
+            "mix",
+            "beat",
+            "sound",
+            "work",
+            "world",
+            "life",
+            "point",
+            "style",
+            "power",
+            "space",
+            "match",
+        )
 
     private fun needsQueryEnrichment(topic: String): Boolean {
         val base = NeuroScoring.stripDomainTag(topic)
         return base.length < 6 ||
-            base in AMBIGUOUS_QUERY_WORDS ||
+            base in ambiguousQueryWords ||
             base in tokenizer.POLYSEMOUS_WORDS
     }
 
@@ -307,7 +328,7 @@ internal class NeuroDiscovery(
      */
     private fun buildNaturalQuery(
         topic: String,
-        brain: UserBrain
+        brain: UserBrain,
     ): String {
         val base = NeuroScoring.stripDomainTag(topic)
 
@@ -316,7 +337,7 @@ internal class NeuroDiscovery(
         // 1. Domain-tagged: the tag IS the context
         if (topic.contains(":")) {
             val domain = topic.substringAfter(":")
-            val qualifier = DOMAIN_TO_QUERY_WORD[domain] ?: domain
+            val qualifier = domainToQueryWord[domain] ?: domain
             return "$base $qualifier"
         }
 
@@ -327,9 +348,9 @@ internal class NeuroDiscovery(
                 parts.size == 2 &&
                     (parts[0] == base || parts[1] == base) &&
                     value > 0.10
-            }
-            .sortedByDescending { it.value }
-            .firstOrNull()?.let { (key, _) ->
+            }.sortedByDescending { it.value }
+            .firstOrNull()
+            ?.let { (key, _) ->
                 val parts = key.split("|")
                 val partner = if (parts[0] == base) parts[1] else parts[0]
                 if (isSubstantialTopic(partner)) return "$base $partner"
@@ -340,57 +361,60 @@ internal class NeuroDiscovery(
             .filter { (k, v) ->
                 val kBase = NeuroScoring.stripDomainTag(k)
                 kBase != base && v > 0.05 && isSubstantialTopic(kBase)
-            }
-            .sortedByDescending { it.value }
-            .firstOrNull()?.let { (k, _) ->
+            }.sortedByDescending { it.value }
+            .firstOrNull()
+            ?.let { (k, _) ->
                 val kBase = NeuroScoring.stripDomainTag(k)
                 return "$base $kBase"
             }
 
         // 4. Category keyword
-        topicCategories.find { cat ->
-            cat.topics.any { tokenizer.normalizeLemma(it) == base }
-        }?.let { cat ->
-            val catWord = cat.topics
-                .firstOrNull { tokenizer.normalizeLemma(it) != base && it.length > 3 }
-            if (catWord != null) return "$base $catWord"
-        }
+        topicCategories
+            .find { cat ->
+                cat.topics.any { tokenizer.normalizeLemma(it) == base }
+            }?.let { cat ->
+                val catWord =
+                    cat.topics
+                        .firstOrNull { tokenizer.normalizeLemma(it) != base && it.length > 3 }
+                if (catWord != null) return "$base $catWord"
+            }
 
         return base
     }
 
-    private val DOMAIN_TO_QUERY_WORD = mapOf(
-        "programming" to "programming",
-        "music" to "music",
-        "gaming" to "gaming",
-        "tech" to "technology",
-        "sport" to "sports",
-        "fitness" to "fitness",
-        "science" to "science",
-        "nature" to "nature",
-        "fishing" to "fishing",
-        "climbing" to "climbing",
-        "live" to "livestream",
-        "ai" to "artificial intelligence",
-        "fashion" to "fashion",
-        "hobby" to "hobby",
-        "season" to "season",
-        "biology" to "biology",
-        "energy" to "energy",
-        "botany" to "plants",
-        "industrial" to "industrial",
-        "business" to "business",
-        "pc" to "pc build",
-        "construction" to "construction",
-        "car" to "car build",
-        "graphic" to "graphic design",
-        "interior" to "interior design",
-        "game" to "game design",
-        "diy" to "diy crafts",
-        "promo" to "deals",
-        "entertainment" to "movie",
-        "hair" to "hairstyle"
-    )
+    private val domainToQueryWord =
+        mapOf(
+            "programming" to "programming",
+            "music" to "music",
+            "gaming" to "gaming",
+            "tech" to "technology",
+            "sport" to "sports",
+            "fitness" to "fitness",
+            "science" to "science",
+            "nature" to "nature",
+            "fishing" to "fishing",
+            "climbing" to "climbing",
+            "live" to "livestream",
+            "ai" to "artificial intelligence",
+            "fashion" to "fashion",
+            "hobby" to "hobby",
+            "season" to "season",
+            "biology" to "biology",
+            "energy" to "energy",
+            "botany" to "plants",
+            "industrial" to "industrial",
+            "business" to "business",
+            "pc" to "pc build",
+            "construction" to "construction",
+            "car" to "car build",
+            "graphic" to "graphic design",
+            "interior" to "interior design",
+            "game" to "game design",
+            "diy" to "diy crafts",
+            "promo" to "deals",
+            "entertainment" to "movie",
+            "hair" to "hairstyle",
+        )
 
     // ═══════════════════════════════════════════════
     // MAIN QUERY GENERATION
@@ -398,7 +422,8 @@ internal class NeuroDiscovery(
 
     fun generateQueries(
         brain: UserBrain,
-        personaProvider: (UserBrain) -> FlowPersona
+        now: Long = System.currentTimeMillis(),
+        personaProvider: (UserBrain) -> FlowPersona,
     ): List<DiscoveryQuery> {
         val persona = personaProvider(brain)
         val blocked = brain.blockedTopics
@@ -408,17 +433,18 @@ internal class NeuroDiscovery(
         // Step 1: Analyze topic maturity
         val bucket = TimeBucket.current()
         val timeVector = brain.timeVectors[bucket] ?: ContentVector()
-        val timeTopicSet = timeVector.topics.entries
-            .sortedByDescending { it.value }
-            .take(5)
-            .map { it.key }
-            .filter { isSubstantialTopic(it) }
-            .toSet()
+        val timeTopicSet =
+            timeVector.topics.entries
+                .sortedByDescending { it.value }
+                .take(5)
+                .map { it.key }
+                .filter { isSubstantialTopic(it) }
+                .toSet()
 
         val matureTopics = analyzeMatureTopics(brain, timeTopicSet)
 
-        // Step 2: Select diverse topics
-        val selection = selectDiverseTopics(matureTopics, brain)
+        // Step 2: Select diverse topics (cluster rotation)
+        val selection = selectDiverseTopics(matureTopics, brain, now)
 
         // Step 3: Generate queries — every strategy is interest-rooted
         val queries = mutableListOf<DiscoveryQuery>()
@@ -434,13 +460,13 @@ internal class NeuroDiscovery(
         if (isMatureBrain) addPreferredTopicAnchors(queries, brain)
 
         // Step 4: Filter, sanitize, balance
-        val filtered = queries
-            .filter { q ->
-                !blocked.any { b -> q.query.lowercase().contains(b) }
-            }
-            .mapNotNull { q ->
-                sanitizeQuery(q.query)?.let { q.copy(query = it) }
-            }
+        val filtered =
+            queries
+                .filter { q ->
+                    !blocked.any { b -> q.query.lowercase().contains(b) }
+                }.mapNotNull { q ->
+                    sanitizeQuery(q.query)?.let { q.copy(query = it) }
+                }
 
         return balanceQueryStrategies(filtered, selection.uniqueTopicCount())
     }
@@ -456,7 +482,7 @@ internal class NeuroDiscovery(
         selection: TopicSelection,
         persona: FlowPersona,
         brain: UserBrain,
-        isMatureBrain: Boolean
+        isMatureBrain: Boolean,
     ) {
         // Primary interest — always included
         selection.primary.filter { isDiscoveryEligible(it, isMatureBrain) }.forEach { topic ->
@@ -465,18 +491,20 @@ internal class NeuroDiscovery(
                     buildNaturalQuery(topic.name, brain),
                     QueryStrategy.DEEP_DIVE,
                     calculateConfidence(topic),
-                    "Core interest: ${topic.name}"
-                )
+                    "Core interest: ${topic.name}",
+                    clusterKey = topic.clusterKey,
+                ),
             )
         }
 
         // Secondary interests — count varies by persona
-        val secondaryCount = when (persona) {
-            FlowPersona.SPECIALIST -> 1
-            FlowPersona.EXPLORER -> 4
-            FlowPersona.SKIMMER -> 3
-            else -> 2
-        }
+        val secondaryCount =
+            when (persona) {
+                FlowPersona.SPECIALIST -> 1
+                FlowPersona.EXPLORER -> 4
+                FlowPersona.SKIMMER -> 3
+                else -> 2
+            }
 
         selection.secondary
             .filter { isDiscoveryEligible(it, isMatureBrain) }
@@ -487,8 +515,9 @@ internal class NeuroDiscovery(
                         buildNaturalQuery(topic.name, brain),
                         QueryStrategy.DEEP_DIVE,
                         calculateConfidence(topic) - 0.05,
-                        "Secondary interest: ${topic.name}"
-                    )
+                        "Secondary interest: ${topic.name}",
+                        clusterKey = topic.clusterKey,
+                    ),
                 )
             }
 
@@ -505,7 +534,7 @@ internal class NeuroDiscovery(
     private fun addCombinationQueries(
         queries: MutableList<DiscoveryQuery>,
         selection: TopicSelection,
-        isMatureBrain: Boolean
+        isMatureBrain: Boolean,
     ) {
         val primary = selection.primary.firstOrNull { isDiscoveryEligible(it, isMatureBrain) } ?: return
         val secondary = selection.secondary.filter { isDiscoveryEligible(it, isMatureBrain) }
@@ -522,8 +551,9 @@ internal class NeuroDiscovery(
                     "$primaryName $secName",
                     QueryStrategy.CROSS_TOPIC,
                     0.60,
-                    "Combination: ${primary.name} + ${sec.name}"
-                )
+                    "Combination: ${primary.name} + ${sec.name}",
+                    clusterKey = sec.clusterKey,
+                ),
             )
         }
 
@@ -534,8 +564,9 @@ internal class NeuroDiscovery(
                     "${NeuroScoring.stripDomainTag(secondary[0].name)} ${NeuroScoring.stripDomainTag(secondary[1].name)}",
                     QueryStrategy.CROSS_TOPIC,
                     0.50,
-                    "Secondary pair: ${secondary[0].name} + ${secondary[1].name}"
-                )
+                    "Secondary pair: ${secondary[0].name} + ${secondary[1].name}",
+                    clusterKey = secondary[0].clusterKey,
+                ),
             )
         }
 
@@ -546,8 +577,9 @@ internal class NeuroDiscovery(
                     "$primaryName ${NeuroScoring.stripDomainTag(cross.name)}",
                     QueryStrategy.CROSS_TOPIC,
                     0.45,
-                    "Cross-category: ${primary.name} + ${cross.name}"
-                )
+                    "Cross-category: ${primary.name} + ${cross.name}",
+                    clusterKey = cross.clusterKey,
+                ),
             )
         }
     }
@@ -560,7 +592,7 @@ internal class NeuroDiscovery(
 
     private fun addAffinityQueries(
         queries: MutableList<DiscoveryQuery>,
-        brain: UserBrain
+        brain: UserBrain,
     ) {
         brain.topicAffinities.entries
             .filter { it.value > 0.15 }
@@ -572,15 +604,17 @@ internal class NeuroDiscovery(
                 val (t1, t2) = parts
                 if (!isSubstantialTopic(t1) ||
                     !isSubstantialTopic(t2)
-                ) return@forEach
+                ) {
+                    return@forEach
+                }
 
                 queries.add(
                     DiscoveryQuery(
                         "$t1 $t2",
                         QueryStrategy.CROSS_TOPIC,
                         0.55 + (score * 0.25),
-                        "Co-watched (${"%.2f".format(score)}): $t1 + $t2"
-                    )
+                        "Co-watched (${"%.2f".format(score)}): $t1 + $t2",
+                    ),
                 )
             }
     }
@@ -602,26 +636,28 @@ internal class NeuroDiscovery(
         queries: MutableList<DiscoveryQuery>,
         brain: UserBrain,
         bucket: TimeBucket,
-        selection: TopicSelection
+        selection: TopicSelection,
     ) {
         val timeVector = brain.timeVectors[bucket] ?: return
         if (timeVector.topics.isEmpty()) return
 
-        val timeTopics = timeVector.topics.entries
-            .sortedByDescending { it.value }
-            .take(5)
-            .filter { isSubstantialTopic(it.key) }
-            .map { it.key }
+        val timeTopics =
+            timeVector.topics.entries
+                .sortedByDescending { it.value }
+                .take(5)
+                .filter { isSubstantialTopic(it.key) }
+                .map { it.key }
 
         if (timeTopics.isEmpty()) return
 
         // Only use time topics confirmed by global interest vector
         // This prevents spurious one-time watches from generating queries
         val globalTopics = brain.globalVector.topics
-        val confirmed = timeTopics.filter { topic ->
-            val globalScore = globalTopics[topic] ?: 0.0
-            globalScore > 0.10 && hasDiscoveryEvidence(topic, brain)
-        }
+        val confirmed =
+            timeTopics.filter { topic ->
+                val globalScore = globalTopics[topic] ?: 0.0
+                globalScore > 0.10 && hasDiscoveryEvidence(topic, brain)
+            }
 
         val usableTopics = confirmed
         if (usableTopics.isEmpty()) return
@@ -636,8 +672,8 @@ internal class NeuroDiscovery(
                         timeTop,
                         QueryStrategy.CONTEXTUAL,
                         0.60,
-                        "Your ${formatBucketName(bucket)} interest: $timeTop"
-                    )
+                        "Your ${formatBucketName(bucket)} interest: $timeTop",
+                    ),
                 )
             }
         }
@@ -651,25 +687,30 @@ internal class NeuroDiscovery(
                     "${usableTopics[0]} ${usableTopics[1]}",
                     QueryStrategy.CONTEXTUAL,
                     0.50,
-                    "Time combination: ${usableTopics[0]} + ${usableTopics[1]}"
-                )
+                    "Time combination: ${usableTopics[0]} + ${usableTopics[1]}",
+                ),
             )
         }
     }
 
-    private fun formatBucketName(bucket: TimeBucket): String = when (bucket) {
-        TimeBucket.WEEKDAY_MORNING,
-        TimeBucket.WEEKEND_MORNING -> "morning"
+    private fun formatBucketName(bucket: TimeBucket): String =
+        when (bucket) {
+            TimeBucket.WEEKDAY_MORNING,
+            TimeBucket.WEEKEND_MORNING,
+            -> "morning"
 
-        TimeBucket.WEEKDAY_AFTERNOON,
-        TimeBucket.WEEKEND_AFTERNOON -> "afternoon"
+            TimeBucket.WEEKDAY_AFTERNOON,
+            TimeBucket.WEEKEND_AFTERNOON,
+            -> "afternoon"
 
-        TimeBucket.WEEKDAY_EVENING,
-        TimeBucket.WEEKEND_EVENING -> "evening"
+            TimeBucket.WEEKDAY_EVENING,
+            TimeBucket.WEEKEND_EVENING,
+            -> "evening"
 
-        TimeBucket.WEEKDAY_NIGHT,
-        TimeBucket.WEEKEND_NIGHT -> "night"
-    }
+            TimeBucket.WEEKDAY_NIGHT,
+            TimeBucket.WEEKEND_NIGHT,
+            -> "night"
+        }
 
     // ═══════════════════════════════════════════════
     // STRATEGY 5: CHANNEL TOPIC SIGNATURES
@@ -679,23 +720,26 @@ internal class NeuroDiscovery(
 
     private fun addChannelQueries(
         queries: MutableList<DiscoveryQuery>,
-        brain: UserBrain
+        brain: UserBrain,
     ) {
-        val topChannels = brain.channelScores.entries
-            .filter { it.value > 0.5 }
-            .sortedByDescending { it.value }
-            .take(3)
+        val topChannels =
+            brain.channelScores.entries
+                .filter { it.value > 0.5 }
+                .sortedByDescending { it.value }
+                .take(3)
 
         topChannels.forEach { (channelId, score) ->
-            val profile = brain.channelTopicProfiles[channelId]
-                ?: return@forEach
+            val profile =
+                brain.channelTopicProfiles[channelId]
+                    ?: return@forEach
             if (profile.size < 2) return@forEach
 
-            val topTopics = profile.entries
-                .sortedByDescending { it.value }
-                .take(2)
-                .map { it.key }
-                .filter { isSubstantialTopic(it) && hasDiscoveryEvidence(it, brain) }
+            val topTopics =
+                profile.entries
+                    .sortedByDescending { it.value }
+                    .take(2)
+                    .map { it.key }
+                    .filter { isSubstantialTopic(it) && hasDiscoveryEvidence(it, brain) }
 
             if (topTopics.size >= 2) {
                 queries.add(
@@ -703,19 +747,20 @@ internal class NeuroDiscovery(
                         "${topTopics[0]} ${topTopics[1]}",
                         QueryStrategy.CHANNEL_DISCOVERY,
                         0.50 + (score * 0.15),
-                        "Channel signature: $channelId"
-                    )
+                        "Channel signature: $channelId",
+                    ),
                 )
             }
         }
 
         // Top niche across all channels
-        val topNiche = brain.channelTopicProfiles.values
-            .flatMap { it.entries }
-            .groupBy { it.key }
-            .mapValues { (_, entries) -> entries.sumOf { it.value } }
-            .filter { isSubstantialTopic(it.key) && hasDiscoveryEvidence(it.key, brain) }
-            .maxByOrNull { it.value }
+        val topNiche =
+            brain.channelTopicProfiles.values
+                .flatMap { it.entries }
+                .groupBy { it.key }
+                .mapValues { (_, entries) -> entries.sumOf { it.value } }
+                .filter { isSubstantialTopic(it.key) && hasDiscoveryEvidence(it.key, brain) }
+                .maxByOrNull { it.value }
 
         if (topNiche != null) {
             queries.add(
@@ -723,8 +768,8 @@ internal class NeuroDiscovery(
                     topNiche.key,
                     QueryStrategy.CHANNEL_DISCOVERY,
                     0.50,
-                    "Top channel niche: ${topNiche.key}"
-                )
+                    "Top channel niche: ${topNiche.key}",
+                ),
             )
         }
     }
@@ -740,27 +785,31 @@ internal class NeuroDiscovery(
         selection: TopicSelection,
         currentYear: Int,
         brain: UserBrain,
-        isMatureBrain: Boolean
+        isMatureBrain: Boolean,
     ) {
-        val established = selection.allTopics()
-            .filter { it.maturityLevel >= TopicMaturity.ESTABLISHED && isDiscoveryEligible(it, isMatureBrain) }
-            .take(2)
+        val established =
+            selection
+                .allTopics()
+                .filter { it.maturityLevel >= TopicMaturity.ESTABLISHED && isDiscoveryEligible(it, isMatureBrain) }
+                .take(2)
 
         established.forEachIndexed { index, topic ->
             val baseName = buildNaturalQuery(topic.name, brain)
-            val qualifier = if (index == 0) {
-                currentYear.toString()
-            } else {
-                FRESHNESS_WORDS.random()
-            }
+            val qualifier =
+                if (index == 0) {
+                    currentYear.toString()
+                } else {
+                    freshnessWords.random()
+                }
 
             queries.add(
                 DiscoveryQuery(
                     "$baseName $qualifier",
                     QueryStrategy.TRENDING,
                     calculateConfidence(topic) - 0.05,
-                    "Fresh: ${topic.name} $qualifier"
-                )
+                    "Fresh: ${topic.name} $qualifier",
+                    clusterKey = topic.clusterKey,
+                ),
             )
         }
     }
@@ -778,72 +827,114 @@ internal class NeuroDiscovery(
         selection: TopicSelection,
         brain: UserBrain,
         persona: FlowPersona,
-        isMatureBrain: Boolean
+        isMatureBrain: Boolean,
     ) {
         val primary = selection.primary.firstOrNull { isDiscoveryEligible(it, isMatureBrain) } ?: return
         val v = brain.globalVector
 
-        val formatWord = when {
-            v.duration > 0.75 ||
-                persona == FlowPersona.DEEP_DIVER ||
-                persona == FlowPersona.SCHOLAR ->
-                LONG_FORM_WORDS.random()
+        val formatWord =
+            when {
+                v.duration > 0.75 ||
+                    persona == FlowPersona.DEEP_DIVER ||
+                    persona == FlowPersona.SCHOLAR -> {
+                    longFormWords.random()
+                }
 
-            v.duration < 0.30 ||
-                persona == FlowPersona.SKIMMER ->
-                SHORT_FORM_WORDS.random()
+                v.duration < 0.30 ||
+                    persona == FlowPersona.SKIMMER -> {
+                    shortFormWords.random()
+                }
 
-            else -> return // No clear preference — skip format queries
-        }
+                else -> {
+                    return
+                } // No clear preference — skip format queries
+            }
 
         queries.add(
             DiscoveryQuery(
                 "${primary.name} $formatWord",
                 QueryStrategy.FORMAT_DRIVEN,
                 0.55,
-                "Format: ${primary.name} $formatWord"
-            )
+                "Format: ${primary.name} $formatWord",
+                clusterKey = primary.clusterKey,
+            ),
         )
     }
 
     // ═══════════════════════════════════════════════
-    // STRATEGY 8: EXPLORATION
-    // Low-scored categories for broadening horizons.
-    // Uses actual category topics, not invented queries.
+    // STRATEGY 8: ADJACENT EXPLORATION
+    // Strictly user-grounded: candidates are topics the user's OWN graph
+    // points at but the vector barely knows — affinity partners of real
+    // interests, and topics taught by channels the user rates well.
+    // No catalog topics are ever injected.
     // ═══════════════════════════════════════════════
 
     private fun addExplorationQueries(
         queries: MutableList<DiscoveryQuery>,
-        brain: UserBrain
+        brain: UserBrain,
     ) {
         // Always reserve at least one exploration slot — no decay-to-zero bubble.
         val explorationBudget = if (brain.totalInteractions > 80) 1 else 2
-
         val blocked = brain.blockedTopics
 
-        val underexplored = topicCategories
-            .flatMap { cat -> cat.topics.take(3) }
-            .distinct()
-            .filter { topic ->
-                val normalized = topic.lowercase()
-                val lemma = tokenizer.normalizeLemma(normalized)
-                val score = brain.globalVector.topics[lemma] ?: 0.0
-                score < NeuroScoring.EXPLORATION_SCORE_THRESHOLD &&
-                    !blocked.any { b ->
-                        normalized.contains(b) || lemma.contains(b)
-                    }
-            }
-            .shuffled()
-            .take(explorationBudget)
+        fun globalScore(base: String): Double {
+            brain.globalVector.topics[base]?.let { return it }
+            return brain.globalVector.topics.entries
+                .firstOrNull { NeuroScoring.stripDomainTag(it.key) == base }
+                ?.value ?: 0.0
+        }
 
-        underexplored.forEach { topic ->
+        val adjacentWeights = mutableMapOf<String, Double>()
+
+        // (a) Affinity partners of established interests that the vector barely knows:
+        // the user has already watched these topics TOGETHER with a real interest.
+        brain.topicAffinities.forEach { (key, affinity) ->
+            val parts = key.split("|")
+            if (parts.size != 2) return@forEach
+            for ((anchor, partner) in listOf(parts[0] to parts[1], parts[1] to parts[0])) {
+                if (!isSubstantialTopic(partner)) continue
+                if (globalScore(anchor) >= 0.15 &&
+                    globalScore(partner) < NeuroScoring.EXPLORATION_SCORE_THRESHOLD
+                ) {
+                    adjacentWeights.merge(partner, affinity * globalScore(anchor), Double::plus)
+                }
+            }
+        }
+
+        // (b) Topics that well-rated channels teach but the user hasn't explored.
+        brain.channelTopicProfiles.forEach { (channelId, profile) ->
+            val channelQuality = brain.channelScores[channelId] ?: return@forEach
+            if (channelQuality < 0.55) return@forEach
+            profile.entries
+                .sortedByDescending { it.value }
+                .take(4)
+                .forEach { (topic, weight) ->
+                    val base = NeuroScoring.stripDomainTag(topic)
+                    if (isSubstantialTopic(base) &&
+                        globalScore(base) < NeuroScoring.EXPLORATION_SCORE_THRESHOLD
+                    ) {
+                        adjacentWeights.merge(base, weight * channelQuality, Double::plus)
+                    }
+                }
+        }
+
+        val picks =
+            adjacentWeights.entries
+                .filter { (topic, _) ->
+                    !blocked.any { b -> topic.contains(b) || tokenizer.normalizeLemma(topic).contains(b) }
+                }.sortedByDescending { it.value }
+                .take(6)
+                .shuffled()
+                .take(explorationBudget)
+
+        picks.forEach { (topic, _) ->
             queries.add(
                 DiscoveryQuery(
-                    topic,
+                    buildNaturalQuery(topic, brain),
                     QueryStrategy.ADJACENT_EXPLORATION,
                     0.35,
-                    "Exploration: $topic"
-                )
+                    "Adjacent: $topic",
+                ),
             )
         }
     }
@@ -854,28 +945,31 @@ internal class NeuroDiscovery(
 
     private fun addPreferredTopicAnchors(
         queries: MutableList<DiscoveryQuery>,
-        brain: UserBrain
+        brain: UserBrain,
     ) {
         if (brain.preferredTopics.isEmpty()) return
 
-        val existingTokens = queries.flatMap { q ->
-            q.query.lowercase()
-                .split(NeuroTokenizer.WHITESPACE_REGEX)
-                .filter { it.length > 2 }
-                .map { tokenizer.normalizeLemma(it) }
-        }.toSet()
+        val existingTokens =
+            queries
+                .flatMap { q ->
+                    q.query
+                        .lowercase()
+                        .split(NeuroTokenizer.WHITESPACE_REGEX)
+                        .filter { it.length > 2 }
+                        .map { tokenizer.normalizeLemma(it) }
+                }.toSet()
 
         val blocked = brain.blockedTopics
-        val missing = brain.preferredTopics
-            .map { it.trim() }
-            .filter { pref ->
-                val lemma = tokenizer.normalizeLemma(pref)
-                lemma.length >= 3 &&
-                    lemma !in existingTokens &&
-                    !blocked.any { b -> lemma.contains(b) }
-            }
-            .shuffled()
-            .take(3)
+        val missing =
+            brain.preferredTopics
+                .map { it.trim() }
+                .filter { pref ->
+                    val lemma = tokenizer.normalizeLemma(pref)
+                    lemma.length >= 3 &&
+                        lemma !in existingTokens &&
+                        !blocked.any { b -> lemma.contains(b) }
+                }.shuffled()
+                .take(3)
 
         missing.forEach { topic ->
             queries.add(
@@ -883,8 +977,8 @@ internal class NeuroDiscovery(
                     topic,
                     QueryStrategy.DEEP_DIVE,
                     0.45,
-                    "Preferred anchor: $topic"
-                )
+                    "Preferred anchor: $topic",
+                ),
             )
         }
     }
@@ -894,15 +988,17 @@ internal class NeuroDiscovery(
     // ═══════════════════════════════════════════════
 
     private fun calculateConfidence(topic: MatureTopic): Double {
-        val maturityBase = when (topic.maturityLevel) {
-            TopicMaturity.CORE -> 0.90
-            TopicMaturity.ESTABLISHED -> 0.75
-            TopicMaturity.DEVELOPING -> 0.55
-            TopicMaturity.EMERGING -> 0.35
-        }
+        val maturityBase =
+            when (topic.maturityLevel) {
+                TopicMaturity.CORE -> 0.90
+                TopicMaturity.ESTABLISHED -> 0.75
+                TopicMaturity.DEVELOPING -> 0.55
+                TopicMaturity.EMERGING -> 0.35
+            }
 
-        val supportBonus = (topic.categorySupport * 0.03)
-            .coerceAtMost(0.10)
+        val supportBonus =
+            (topic.categorySupport * 0.03)
+                .coerceAtMost(0.10)
         val timeBonus = if (topic.hasTimeContext) 0.05 else 0.0
 
         return (maturityBase + supportBonus + timeBonus)
@@ -913,40 +1009,66 @@ internal class NeuroDiscovery(
     // QUERY QUALITY FILTERS
     // ═══════════════════════════════════════════════
 
-    private val YEAR_REGEX = Regex("^20[2-9]\\d$")
+    private val yearRegex = Regex("^20[2-9]\\d$")
 
-    private val QUERY_NOISE_WORDS = hashSetOf(
-        "prompt", "prompts", "prompting",
-        "use", "used", "using",
-        "guide", "tutorial", "tips", "tricks",
-        "thing", "things", "stuff", "way", "ways",
-        "type", "types", "kind", "level",
-        "sensei", "guru", "master", "pro", "official",
-        "studio", "studios", "media", "network"
-    )
+    private val queryNoiseWords =
+        hashSetOf(
+            "prompt",
+            "prompts",
+            "prompting",
+            "use",
+            "used",
+            "using",
+            "guide",
+            "tutorial",
+            "tips",
+            "tricks",
+            "thing",
+            "things",
+            "stuff",
+            "way",
+            "ways",
+            "type",
+            "types",
+            "kind",
+            "level",
+            "sensei",
+            "guru",
+            "master",
+            "pro",
+            "official",
+            "studio",
+            "studios",
+            "media",
+            "network",
+        )
 
     private fun sanitizeQuery(raw: String): String? {
         val words = raw.trim().split(NeuroTokenizer.WHITESPACE_REGEX)
         val deduped = LinkedHashSet(words)
-        val cleaned = deduped.filter { word ->
-            val lower = word.lowercase()
-            lower.isNotEmpty() &&
-                lower !in QUERY_NOISE_WORDS &&
-                !YEAR_REGEX.matches(lower)
-        }
+        val cleaned =
+            deduped.filter { word ->
+                val lower = word.lowercase()
+                lower.isNotEmpty() &&
+                    lower !in queryNoiseWords &&
+                    !yearRegex.matches(lower)
+            }
         // Allow single-word queries (direct topic searches are natural)
         if (cleaned.isEmpty()) return null
         val result = cleaned.joinToString(" ")
-        if (result.length > 60) return result.take(60)
-            .substringBeforeLast(" ")
+        if (result.length > 60) {
+            return result
+                .take(60)
+                .substringBeforeLast(" ")
+        }
         return result
     }
 
     private fun isSubstantialTopic(topic: String): Boolean {
         if (topic.length < 3) return false
         val lower = topic.lowercase()
-        if (lower in QUERY_NOISE_WORDS) return false
-        if (YEAR_REGEX.matches(lower)) return false
+        if (lower in queryNoiseWords) return false
+        if (yearRegex.matches(lower)) return false
         if (lower.all { it.isDigit() }) return false
         // Strip domain tags for checking: "metal:music" → "metal"
         val base = if (lower.contains(":")) lower.substringBefore(":") else lower
@@ -958,21 +1080,44 @@ internal class NeuroDiscovery(
     // BALANCING & DEDUPLICATION
     // ═══════════════════════════════════════════════
 
-    private val FILLER_WORDS = hashSetOf(
-        "best", "new", "top", "how", "what", "why",
-        "complete", "full", "advanced", "beginner",
-        "learn", "understand", "understanding",
-        "explained", "explains", "explanation",
-        "morning", "evening", "night", "afternoon",
-        "late", "early", "chill", "relaxing",
-        "quick", "fast", "slow",
-        "must", "watch", "see",
-        "latest"
-    )
+    private val fillerWords =
+        hashSetOf(
+            "best",
+            "new",
+            "top",
+            "how",
+            "what",
+            "why",
+            "complete",
+            "full",
+            "advanced",
+            "beginner",
+            "learn",
+            "understand",
+            "understanding",
+            "explained",
+            "explains",
+            "explanation",
+            "morning",
+            "evening",
+            "night",
+            "afternoon",
+            "late",
+            "early",
+            "chill",
+            "relaxing",
+            "quick",
+            "fast",
+            "slow",
+            "must",
+            "watch",
+            "see",
+            "latest",
+        )
 
     private fun balanceQueryStrategies(
         queries: List<DiscoveryQuery>,
-        availableTopicCount: Int
+        availableTopicCount: Int,
     ): List<DiscoveryQuery> {
         // ── Semantic deduplication ──
         val deduped = mutableListOf<DiscoveryQuery>()
@@ -981,18 +1126,21 @@ internal class NeuroDiscovery(
         val sorted = queries.sortedByDescending { it.confidence }
 
         for (query in sorted) {
-            val tokens = query.query.lowercase()
-                .split(NeuroTokenizer.WHITESPACE_REGEX)
-                .filter { it.length > 2 }
-                .map { tokenizer.normalizeLemma(it) }
-                .toSet()
+            val tokens =
+                query.query
+                    .lowercase()
+                    .split(NeuroTokenizer.WHITESPACE_REGEX)
+                    .filter { it.length > 2 }
+                    .map { tokenizer.normalizeLemma(it) }
+                    .toSet()
 
-            val isDuplicate = seenTokenSets.any { existing ->
-                if (existing.isEmpty() || tokens.isEmpty()) return@any false
-                val intersection = tokens.intersect(existing).size
-                val union = tokens.union(existing).size
-                (intersection.toDouble() / union) > 0.3
-            }
+            val isDuplicate =
+                seenTokenSets.any { existing ->
+                    if (existing.isEmpty() || tokens.isEmpty()) return@any false
+                    val intersection = tokens.intersect(existing).size
+                    val union = tokens.union(existing).size
+                    (intersection.toDouble() / union) > 0.3
+                }
 
             if (!isDuplicate) {
                 deduped.add(query)
@@ -1001,26 +1149,28 @@ internal class NeuroDiscovery(
         }
 
         // ── Diversity budget ──
-        val minDistinctTopics = when {
-            availableTopicCount >= 6 -> 4
-            availableTopicCount >= 3 -> 3
-            else -> availableTopicCount.coerceAtLeast(1)
-        }
+        val minDistinctTopics =
+            when {
+                availableTopicCount >= 6 -> 4
+                availableTopicCount >= 3 -> 3
+                else -> availableTopicCount.coerceAtLeast(1)
+            }
 
         val maxQueries = 12
         val balanced = mutableListOf<DiscoveryQuery>()
         val topicsCovered = mutableSetOf<String>()
 
         // Phase 1: Ensure strategy diversity (1 per strategy)
-        val strategyPriority = listOf(
-            QueryStrategy.DEEP_DIVE,
-            QueryStrategy.CROSS_TOPIC,
-            QueryStrategy.TRENDING,
-            QueryStrategy.CONTEXTUAL,
-            QueryStrategy.CHANNEL_DISCOVERY,
-            QueryStrategy.ADJACENT_EXPLORATION,
-            QueryStrategy.FORMAT_DRIVEN
-        )
+        val strategyPriority =
+            listOf(
+                QueryStrategy.DEEP_DIVE,
+                QueryStrategy.CROSS_TOPIC,
+                QueryStrategy.TRENDING,
+                QueryStrategy.CONTEXTUAL,
+                QueryStrategy.CHANNEL_DISCOVERY,
+                QueryStrategy.ADJACENT_EXPLORATION,
+                QueryStrategy.FORMAT_DRIVEN,
+            )
 
         val byStrategy = deduped.groupBy { it.strategy }
         strategyPriority.forEach { strategy ->
@@ -1055,22 +1205,27 @@ internal class NeuroDiscovery(
         }
 
         val used = balanced.toSet()
-        val rest = deduped
-            .filter { it !in used }
-            .sortedByDescending { it.confidence }
+        val rest =
+            deduped
+                .filter { it !in used }
+                .sortedByDescending { it.confidence }
 
         for (query in rest) {
             if (balanced.size >= maxQueries) break
 
             val topicRoot = extractTopicRoot(query.query)
-            val topicCount = if (topicRoot != null) {
-                topicCountInOutput[topicRoot] ?: 0
-            } else 0
+            val topicCount =
+                if (topicRoot != null) {
+                    topicCountInOutput[topicRoot] ?: 0
+                } else {
+                    0
+                }
 
             if (topicCount >= 2) continue
 
-            val strategyCount = balanced
-                .count { it.strategy == query.strategy }
+            val strategyCount =
+                balanced
+                    .count { it.strategy == query.strategy }
             if (strategyCount >= 3) continue
 
             balanced.add(query)
@@ -1081,62 +1236,32 @@ internal class NeuroDiscovery(
         }
 
         // Phase 4: Shuffle within confidence tiers for variety
-        val highConf = balanced
-            .filter { it.confidence >= 0.7 }.shuffled()
-        val medConf = balanced
-            .filter { it.confidence in 0.4..0.69 }.shuffled()
-        val lowConf = balanced
-            .filter { it.confidence < 0.4 }.shuffled()
+        val highConf =
+            balanced
+                .filter { it.confidence >= 0.7 }
+                .shuffled()
+        val medConf =
+            balanced
+                .filter { it.confidence in 0.4..0.69 }
+                .shuffled()
+        val lowConf =
+            balanced
+                .filter { it.confidence < 0.4 }
+                .shuffled()
 
         return highConf + medConf + lowConf
     }
 
     private fun extractTopicRoot(query: String): String? {
-        val words = query.lowercase()
-            .split(NeuroTokenizer.WHITESPACE_REGEX)
-            .filter { it.length > 2 }
-            .map { tokenizer.normalizeLemma(it) }
-            .filter { it !in FILLER_WORDS }
+        val words =
+            query
+                .lowercase()
+                .split(NeuroTokenizer.WHITESPACE_REGEX)
+                .filter { it.length > 2 }
+                .map { tokenizer.normalizeLemma(it) }
+                .filter { it !in fillerWords }
 
         if (words.isEmpty()) return null
         return words.sorted().joinToString("|")
-    }
-
-    // ═══════════════════════════════════════════════
-    // LEGACY API — kept for backward compatibility
-    // ═══════════════════════════════════════════════
-
-    fun getExplorationQueries(brain: UserBrain): List<String> {
-        val blocked = brain.blockedTopics
-
-        val macroCategoryCleanRegex = Regex("[^a-zA-Z ]")
-        val macroCategories = topicCategories.flatMap { category ->
-            listOf(
-                category.name
-                    .replace(macroCategoryCleanRegex, "")
-                    .trim()
-            ) + category.topics.take(3)
-        }.distinct()
-
-        return macroCategories
-            .filter { category ->
-                val normalized = category.lowercase()
-                val lemma = tokenizer.normalizeLemma(normalized)
-                !blocked.any { blockedTerm ->
-                    normalized.contains(blockedTerm) ||
-                        lemma.contains(blockedTerm)
-                }
-            }
-            .map { category ->
-                val score = brain.globalVector
-                    .topics[tokenizer.normalizeLemma(category)] ?: 0.0
-                category to score
-            }
-            .filter {
-                it.second < NeuroScoring.EXPLORATION_SCORE_THRESHOLD
-            }
-            .sortedBy { it.second }
-            .take(2)
-            .map { it.first }
     }
 }

--- a/app/src/main/java/io/github/aedev/flow/data/recommendation/NeuroDiscovery.kt
+++ b/app/src/main/java/io/github/aedev/flow/data/recommendation/NeuroDiscovery.kt
@@ -135,6 +135,7 @@ internal class NeuroDiscovery(
                 channelTopicProfiles = brain.channelTopicProfiles,
                 categories = topicCategories,
                 normalizeLemma = tokenizer::normalizeLemma,
+                tagAffinities = brain.tagAffinities,
             )
         if (clusters.isEmpty()) return emptySelection()
 

--- a/app/src/main/java/io/github/aedev/flow/data/recommendation/NeuroDiscovery.kt
+++ b/app/src/main/java/io/github/aedev/flow/data/recommendation/NeuroDiscovery.kt
@@ -108,23 +108,37 @@ internal class NeuroDiscovery(
     // the feed across sessions instead of the top topics monopolizing.
     // ═══════════════════════════════════════════════
 
+    /**
+     * One served cluster's contribution to this feed. At depth 0 the query is the
+     * cluster's anchor; at depth d > 0 it becomes "anchor member_d" — walking the
+     * cluster's members like a tree so each load-more digs a branch deeper.
+     */
+    private data class ClusterChoice(
+        val topic: MatureTopic,
+        val comboWith: String?,
+    )
+
     private data class TopicSelection(
-        val primary: List<MatureTopic>,
-        val secondary: List<MatureTopic>,
+        val choices: List<ClusterChoice>,
         val emerging: List<MatureTopic>,
         val crossCategory: List<MatureTopic>,
     ) {
-        fun allTopics(): List<MatureTopic> = (primary + secondary + emerging + crossCategory).distinctBy { it.name }
+        val primary: List<MatureTopic> get() = choices.take(1).map { it.topic }
+        val secondary: List<MatureTopic> get() = choices.drop(1).map { it.topic }
+
+        fun allTopics(): List<MatureTopic> = (choices.map { it.topic } + emerging + crossCategory).distinctBy { it.name }
 
         fun uniqueTopicCount(): Int = allTopics().map { it.name }.distinct().size
     }
 
-    private fun emptySelection() = TopicSelection(emptyList(), emptyList(), emptyList(), emptyList())
+    private fun emptySelection() = TopicSelection(emptyList(), emptyList(), emptyList())
 
     private fun selectDiverseTopics(
         matureTopics: List<MatureTopic>,
         brain: UserBrain,
         now: Long,
+        depth: Int,
+        maxClusters: Int,
     ): TopicSelection {
         if (matureTopics.isEmpty()) return emptySelection()
 
@@ -141,42 +155,67 @@ internal class NeuroDiscovery(
 
         val scheduled = NeuroClusters.schedule(clusters, brain.clusterRotation, now)
 
-        // Resolve each scheduled cluster back to its strongest MatureTopic.
         val byBase = HashMap<String, MatureTopic>()
         matureTopics.forEach { topic ->
             byBase.putIfAbsent(NeuroScoring.stripDomainTag(topic.name), topic)
         }
-        val reps =
-            scheduled.mapNotNull { cluster ->
-                cluster.topics
-                    .firstNotNullOfOrNull { byBase[it] }
-                    ?.copy(clusterKey = cluster.representative)
+
+        // The user's MAJOR interests (top clusters by mass) are in EVERY feed —
+        // never rotated away by staleness. Rotation governs only the tail slots,
+        // cycling micro-interests and fresh seeds through the remaining budget.
+        val budget = maxClusters.coerceAtLeast(1)
+        val majorKeys =
+            clusters
+                .sortedByDescending { it.mass }
+                .take(NeuroScoring.MAJOR_CLUSTER_SLOTS.coerceAtMost(budget))
+                .filter { it.mass > 0.0 }
+                .map { it.representative }
+                .toSet()
+        val served =
+            (
+                scheduled.filter { it.representative in majorKeys } +
+                    scheduled.filter { it.representative !in majorKeys && it.mass > 0.0 }
+            ).take(budget)
+        val choices =
+            served.mapNotNull { cluster ->
+                val members = cluster.topics.mapNotNull { byBase[it] }
+                if (members.isEmpty()) return@mapNotNull null
+                val anchor = members.first().copy(clusterKey = cluster.representative)
+                val comboWith =
+                    if (depth > 0 && members.size > 1) {
+                        val branch = members[1 + ((depth - 1) % (members.size - 1))]
+                        NeuroScoring.stripDomainTag(branch.name).takeIf { it != NeuroScoring.stripDomainTag(anchor.name) }
+                    } else {
+                        null
+                    }
+                ClusterChoice(anchor, comboWith)
             }
-        if (reps.isEmpty()) return emptySelection()
+        if (choices.isEmpty()) return emptySelection()
 
-        val primary = reps.firstOrNull { it.maturityLevel >= TopicMaturity.DEVELOPING } ?: reps.first()
-        val secondary = reps.filter { it.name != primary.name }.take(4)
+        val representedNames = choices.map { it.topic.name }.toSet()
+        val leftoverReps =
+            scheduled
+                .drop(served.size)
+                .mapNotNull { cluster ->
+                    cluster.topics
+                        .firstNotNullOfOrNull { byBase[it] }
+                        ?.copy(clusterKey = cluster.representative)
+                }.filter { it.name !in representedNames }
 
-        val representedNames = (listOf(primary) + secondary).map { it.name }.toSet()
-        val emerging =
-            reps
-                .filter { it.name !in representedNames }
-                .take(2)
-
+        val emerging = leftoverReps.take(2)
         val representedCategories =
-            (listOf(primary) + secondary + emerging)
+            (choices.map { it.topic } + emerging)
                 .mapNotNull { categoryNameOf(it.name) }
                 .toSet()
         val crossCategory =
-            reps
+            leftoverReps
                 .filter { topic ->
-                    topic.name !in representedNames &&
+                    topic !in emerging &&
                         categoryNameOf(topic.name)?.let { it !in representedCategories } == true
                 }.take(2)
 
         return TopicSelection(
-            primary = listOf(primary),
-            secondary = secondary,
+            choices = choices,
             emerging = emerging,
             crossCategory = crossCategory,
         )
@@ -312,9 +351,9 @@ internal class NeuroDiscovery(
 
     private fun needsQueryEnrichment(topic: String): Boolean {
         val base = NeuroScoring.stripDomainTag(topic)
-        return base.length < 6 ||
-            base in ambiguousQueryWords ||
-            base in tokenizer.polysemousWords
+        // Only genuinely AMBIGUOUS words need a qualifier. The old length<6 rule
+        // polluted short-but-specific anchors: "mma" became "mma android".
+        return base in ambiguousQueryWords || base in tokenizer.polysemousWords
     }
 
     /**
@@ -424,6 +463,7 @@ internal class NeuroDiscovery(
     fun generateQueries(
         brain: UserBrain,
         now: Long = System.currentTimeMillis(),
+        depth: Int = 0,
         personaProvider: (UserBrain) -> FlowPersona,
     ): List<DiscoveryQuery> {
         val persona = personaProvider(brain)
@@ -444,13 +484,19 @@ internal class NeuroDiscovery(
 
         val matureTopics = analyzeMatureTopics(brain, timeTopicSet)
 
-        // Step 2: Select diverse topics (cluster rotation)
-        val selection = selectDiverseTopics(matureTopics, brain, now)
+        // Step 2: Select topics — EVERY served cluster contributes to EVERY feed,
+        // and depth walks each cluster's members like a tree on load-more.
+        val maxClusters =
+            when (persona) {
+                FlowPersona.SPECIALIST -> 3
+                else -> NeuroScoring.MAX_CLUSTERS_PER_REFRESH
+            }
+        val selection = selectDiverseTopics(matureTopics, brain, now, depth, maxClusters)
 
         // Step 3: Generate queries — every strategy is interest-rooted
         val queries = mutableListOf<DiscoveryQuery>()
 
-        addDirectQueries(queries, selection, persona, brain, isMatureBrain)
+        addDirectQueries(queries, selection, brain, isMatureBrain, depth)
         addCombinationQueries(queries, selection, isMatureBrain)
         addAffinityQueries(queries, brain)
         addTimeContextQueries(queries, brain, bucket, selection)
@@ -481,49 +527,36 @@ internal class NeuroDiscovery(
     private fun addDirectQueries(
         queries: MutableList<DiscoveryQuery>,
         selection: TopicSelection,
-        persona: FlowPersona,
         brain: UserBrain,
         isMatureBrain: Boolean,
+        depth: Int,
     ) {
-        // Primary interest — always included
-        selection.primary.filter { isDiscoveryEligible(it, isMatureBrain) }.forEach { topic ->
+        // EVERY served cluster contributes one direct query per feed — that is the
+        // whole point of a multi-interest feed. Depth > 0 digs the cluster's branch
+        // ("android" → "android machine learning") instead of repeating the anchor.
+        selection.choices.forEachIndexed { index, choice ->
+            val topic = choice.topic
+            if (!isDiscoveryEligible(topic, isMatureBrain)) return@forEachIndexed
+
+            val anchorBase = NeuroScoring.stripDomainTag(topic.name)
+            val query =
+                if (choice.comboWith != null) {
+                    "$anchorBase ${choice.comboWith}"
+                } else {
+                    buildNaturalQuery(topic.name, brain)
+                }
+            val label = if (index == 0) "Core interest" else "Cluster interest"
+            val branch = choice.comboWith?.let { " → $it" } ?: ""
             queries.add(
                 DiscoveryQuery(
-                    buildNaturalQuery(topic.name, brain),
+                    query,
                     QueryStrategy.DEEP_DIVE,
-                    calculateConfidence(topic),
-                    "Core interest: ${topic.name}",
+                    calculateConfidence(topic) - (if (index == 0) 0.0 else 0.05) - depth * 0.02,
+                    "$label: ${topic.name}$branch",
                     clusterKey = topic.clusterKey,
                 ),
             )
         }
-
-        // Secondary interests — count varies by persona
-        val secondaryCount =
-            when (persona) {
-                FlowPersona.SPECIALIST -> 1
-                FlowPersona.EXPLORER -> 4
-                FlowPersona.SKIMMER -> 3
-                else -> 2
-            }
-
-        selection.secondary
-            .filter { isDiscoveryEligible(it, isMatureBrain) }
-            .take(secondaryCount)
-            .forEach { topic ->
-                queries.add(
-                    DiscoveryQuery(
-                        buildNaturalQuery(topic.name, brain),
-                        QueryStrategy.DEEP_DIVE,
-                        calculateConfidence(topic) - 0.05,
-                        "Secondary interest: ${topic.name}",
-                        clusterKey = topic.clusterKey,
-                    ),
-                )
-            }
-
-        // Emerging interests — requires DEVELOPING threshold before generating queries
-        // (removed: premature EMERGING queries flood feed on first interaction)
     }
 
     // ═══════════════════════════════════════════════
@@ -1124,7 +1157,14 @@ internal class NeuroDiscovery(
         val deduped = mutableListOf<DiscoveryQuery>()
         val seenTokenSets = mutableListOf<Set<String>>()
 
-        val sorted = queries.sortedByDescending { it.confidence }
+        // Cluster ANCHORS (direct deep-dives) enter dedup first: they are each
+        // community's flag query. Otherwise a cross-combo like "android mma" can
+        // out-confidence a developing cluster's own "mma" and absorb its tokens.
+        val sorted =
+            queries.sortedWith(
+                compareByDescending<DiscoveryQuery> { it.strategy == QueryStrategy.DEEP_DIVE && it.clusterKey != null }
+                    .thenByDescending { it.confidence },
+            )
 
         for (query in sorted) {
             val tokens =
@@ -1143,7 +1183,14 @@ internal class NeuroDiscovery(
                     (intersection.toDouble() / union) > 0.3
                 }
 
-            if (!isDuplicate) {
+            // A cluster's sole representative always survives dedup — token overlap
+            // with another cluster's query must not erase a community from the feed.
+            val keepForClusterCoverage =
+                isDuplicate &&
+                    query.clusterKey != null &&
+                    deduped.none { it.clusterKey == query.clusterKey }
+
+            if (!isDuplicate || keepForClusterCoverage) {
                 deduped.add(query)
                 seenTokenSets.add(tokens)
             }
@@ -1161,6 +1208,20 @@ internal class NeuroDiscovery(
         val balanced = mutableListOf<DiscoveryQuery>()
         val topicsCovered = mutableSetOf<String>()
 
+        // Phase 0: cluster coverage is the FIRST guarantee — every served cluster's
+        // best query makes the cut before any strategy or confidence balancing.
+        // This is what puts mma + android + anime in the SAME feed.
+        deduped
+            .filter { it.clusterKey != null }
+            .groupBy { it.clusterKey }
+            .forEach { (_, clusterQueries) ->
+                val best = clusterQueries.maxByOrNull { it.confidence } ?: return@forEach
+                if (best !in balanced) {
+                    balanced.add(best)
+                    extractTopicRoot(best.query)?.let { topicsCovered.add(it) }
+                }
+            }
+
         // Phase 1: Ensure strategy diversity (1 per strategy)
         val strategyPriority =
             listOf(
@@ -1175,10 +1236,12 @@ internal class NeuroDiscovery(
 
         val byStrategy = deduped.groupBy { it.strategy }
         strategyPriority.forEach { strategy ->
-            byStrategy[strategy]?.firstOrNull()?.let { best ->
-                balanced.add(best)
-                extractTopicRoot(best.query)?.let {
-                    topicsCovered.add(it)
+            byStrategy[strategy]?.firstOrNull { it !in balanced }?.let { best ->
+                if (balanced.none { it.strategy == strategy }) {
+                    balanced.add(best)
+                    extractTopicRoot(best.query)?.let {
+                        topicsCovered.add(it)
+                    }
                 }
             }
         }

--- a/app/src/main/java/io/github/aedev/flow/data/recommendation/NeuroDiscovery.kt
+++ b/app/src/main/java/io/github/aedev/flow/data/recommendation/NeuroDiscovery.kt
@@ -314,7 +314,7 @@ internal class NeuroDiscovery(
         val base = NeuroScoring.stripDomainTag(topic)
         return base.length < 6 ||
             base in ambiguousQueryWords ||
-            base in tokenizer.POLYSEMOUS_WORDS
+            base in tokenizer.polysemousWords
     }
 
     /**

--- a/app/src/main/java/io/github/aedev/flow/data/recommendation/NeuroMaintenance.kt
+++ b/app/src/main/java/io/github/aedev/flow/data/recommendation/NeuroMaintenance.kt
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 2025-2026 Flow | A-EDev
+ *
+ * This file is part of Flow (https://github.com/A-EDev/Flow).
+ *
+ * This recommendation algorithm (FlowNeuroEngine) is the intellectual property
+ * of the Flow project. Any use of this code in other projects must
+ * explicitly credit "Flow Android Client" and link back to the original repository.
+ */
+
+package io.github.aedev.flow.data.recommendation
+
+/**
+ * One-time brain maintenance migrations. Pure — no Context, no state — so the
+ * engine, offline diagnostics, and tests all run the identical code.
+ *
+ * V15 repairs two long-standing learning defects: the affinity instant-prune
+ * bug deleted every organic co-watch edge, and the acquisition wall kept new
+ * topics out of mature vectors — leaving the vector a decayed copy of the
+ * onboarding seeds while channelTopicProfiles (which learn undamped) kept the
+ * user's REAL interests. This scrubs junk and rehydrates the vector and
+ * affinity edges from those profiles, once.
+ */
+internal object NeuroMaintenance {
+    const val TARGET_SCHEMA_VERSION = 15
+
+    private const val REHYDRATE_MAX_TOPICS = 40
+    private const val REHYDRATE_MAX_WEIGHT = 0.30
+    private const val REHYDRATE_MIN_WEIGHT = 0.06
+    private const val REHYDRATE_AFFINITY_SEED = 0.15
+    private const val REHYDRATE_MIN_CHANNEL_QUALITY = 0.4
+
+    fun runV15IfNeeded(
+        brain: UserBrain,
+        tokenizer: NeuroTokenizer,
+    ): UserBrain {
+        if (brain.schemaVersion >= TARGET_SCHEMA_VERSION) return brain
+
+        val cleanedTopics =
+            brain.globalVector.topics.filter { (topic, score) ->
+                score >= NeuroVectorMath.TOPIC_PRUNE_THRESHOLD && !tokenizer.isNoiseTopic(topic)
+            }
+        var updated =
+            brain.copy(globalVector = brain.globalVector.copy(topics = cleanedTopics))
+
+        updated = rehydrateFromChannelProfiles(updated, tokenizer)
+
+        return updated.copy(schemaVersion = TARGET_SCHEMA_VERSION)
+    }
+
+    private fun rehydrateFromChannelProfiles(
+        brain: UserBrain,
+        tokenizer: NeuroTokenizer,
+    ): UserBrain {
+        if (brain.channelTopicProfiles.isEmpty()) return brain
+
+        val aggregated = HashMap<String, Double>()
+        brain.channelTopicProfiles.forEach { (channelId, profile) ->
+            val quality = brain.channelScores[channelId] ?: 0.5
+            if (quality < REHYDRATE_MIN_CHANNEL_QUALITY) return@forEach
+            profile.forEach { (topic, weight) ->
+                if (!tokenizer.isNoiseTopic(topic)) {
+                    aggregated.merge(topic, weight * quality, Double::plus)
+                }
+            }
+        }
+        if (aggregated.isEmpty()) return brain
+        val maxAggregate = aggregated.values.max()
+        if (maxAggregate <= 0.0) return brain
+
+        // Max-merge topic seeds: never lowers an existing score, tops out below
+        // established interests so rehydrated topics still need reinforcement.
+        val topics = brain.globalVector.topics.toMutableMap()
+        aggregated.entries
+            .sortedByDescending { it.value }
+            .take(REHYDRATE_MAX_TOPICS)
+            .forEach { (topic, aggregate) ->
+                val seeded =
+                    (aggregate / maxAggregate * REHYDRATE_MAX_WEIGHT)
+                        .coerceAtLeast(REHYDRATE_MIN_WEIGHT)
+                topics[topic] = maxOf(topics[topic] ?: 0.0, seeded)
+            }
+
+        // Seed affinity edges from co-taught topics per channel so clustering
+        // has real structure immediately (organic edges were all lost to the
+        // instant-prune bug).
+        val affinities = brain.topicAffinities.toMutableMap()
+        brain.channelTopicProfiles.forEach { (channelId, profile) ->
+            val quality = brain.channelScores[channelId] ?: 0.5
+            if (quality < REHYDRATE_MIN_CHANNEL_QUALITY) return@forEach
+            val top =
+                profile.entries
+                    .filter { !tokenizer.isNoiseTopic(it.key) }
+                    .sortedByDescending { it.value }
+                    .take(3)
+                    .map { NeuroScoring.stripDomainTag(it.key) }
+                    .distinct()
+            for (i in top.indices) {
+                for (j in i + 1 until top.size) {
+                    val key = NeuroScoring.makeAffinityKey(top[i], top[j])
+                    affinities[key] = maxOf(affinities[key] ?: 0.0, REHYDRATE_AFFINITY_SEED)
+                }
+            }
+        }
+
+        return brain.copy(
+            globalVector = brain.globalVector.copy(topics = topics),
+            topicAffinities = affinities,
+        )
+    }
+}

--- a/app/src/main/java/io/github/aedev/flow/data/recommendation/NeuroModels.kt
+++ b/app/src/main/java/io/github/aedev/flow/data/recommendation/NeuroModels.kt
@@ -116,6 +116,8 @@ data class UserBrain(
     val recentRelatedSeeds: Map<String, Long> = emptyMap(),
     /** Discovery queries whose RESULTS were mostly already-shown (staleKey → markedAt). */
     val staleQueries: Map<String, Long> = emptyMap(),
+    /** Interest-cluster rotation state (cluster representative → lastServedAt). */
+    val clusterRotation: Map<String, Long> = emptyMap(),
     val schemaVersion: Int = 14,
 )
 
@@ -166,6 +168,8 @@ data class DiscoveryQuery(
     val strategy: QueryStrategy,
     val confidence: Double,
     val reasoning: String,
+    /** Interest-cluster representative this query serves, for rotation tracking. */
+    val clusterKey: String? = null,
 )
 
 enum class QueryStrategy {

--- a/app/src/main/java/io/github/aedev/flow/data/recommendation/NeuroModels.kt
+++ b/app/src/main/java/io/github/aedev/flow/data/recommendation/NeuroModels.kt
@@ -243,6 +243,9 @@ enum class GraphSeedSource {
     WATCH_HISTORY,
     LIKED,
     PLAYLIST,
+
+    /** A video currently in the feed — used to keep load-more digging related lanes. */
+    FEED,
 }
 
 /** A candidate seed for related-graph retrieval, with enough context for one shared selector. */

--- a/app/src/main/java/io/github/aedev/flow/data/recommendation/NeuroModels.kt
+++ b/app/src/main/java/io/github/aedev/flow/data/recommendation/NeuroModels.kt
@@ -118,6 +118,8 @@ data class UserBrain(
     val staleQueries: Map<String, Long> = emptyMap(),
     /** Interest-cluster rotation state (cluster representative → lastServedAt). */
     val clusterRotation: Map<String, Long> = emptyMap(),
+    /** Tag co-occurrence edges from opened videos ("a|b" → weight), for clustering. */
+    val tagAffinities: Map<String, Double> = emptyMap(),
     val schemaVersion: Int = 14,
 )
 

--- a/app/src/main/java/io/github/aedev/flow/data/recommendation/NeuroModels.kt
+++ b/app/src/main/java/io/github/aedev/flow/data/recommendation/NeuroModels.kt
@@ -120,7 +120,7 @@ data class UserBrain(
     val clusterRotation: Map<String, Long> = emptyMap(),
     /** Tag co-occurrence edges from opened videos ("a|b" → weight), for clustering. */
     val tagAffinities: Map<String, Double> = emptyMap(),
-    val schemaVersion: Int = 14,
+    val schemaVersion: Int = 15,
 )
 
 // ── Interaction Types ──

--- a/app/src/main/java/io/github/aedev/flow/data/recommendation/NeuroModels.kt
+++ b/app/src/main/java/io/github/aedev/flow/data/recommendation/NeuroModels.kt
@@ -112,7 +112,11 @@ data class UserBrain(
     val feedHistory: Map<String, FeedEntry> = emptyMap(),
     val recentQueryTokens: List<Set<String>> = emptyList(),
     val topicEvidence: Map<String, TopicEvidence> = emptyMap(),
-    val schemaVersion: Int = 13,
+    /** Related-graph seeds used recently (seedVideoId → lastUsedAt), for rotation. */
+    val recentRelatedSeeds: Map<String, Long> = emptyMap(),
+    /** Discovery queries whose RESULTS were mostly already-shown (staleKey → markedAt). */
+    val staleQueries: Map<String, Long> = emptyMap(),
+    val schemaVersion: Int = 14,
 )
 
 // ── Interaction Types ──

--- a/app/src/main/java/io/github/aedev/flow/data/recommendation/NeuroModels.kt
+++ b/app/src/main/java/io/github/aedev/flow/data/recommendation/NeuroModels.kt
@@ -18,7 +18,7 @@ import androidx.annotation.StringRes
 import io.github.aedev.flow.R
 import java.util.Calendar
 
-/**
+/*
  * Pure data definitions. No logic, no dependencies.
  * Every other file imports from here.
  */
@@ -30,7 +30,7 @@ data class ContentVector(
     val duration: Double = 0.5,
     val pacing: Double = 0.5,
     val complexity: Double = 0.5,
-    val isLive: Double = 0.0
+    val isLive: Double = 0.0,
 )
 
 // ── Time Buckets ──
@@ -43,15 +43,17 @@ enum class TimeBucket {
     WEEKEND_MORNING,
     WEEKEND_AFTERNOON,
     WEEKEND_EVENING,
-    WEEKEND_NIGHT;
+    WEEKEND_NIGHT,
+    ;
 
     companion object {
         fun current(): TimeBucket {
             val cal = Calendar.getInstance()
             val hour = cal.get(Calendar.HOUR_OF_DAY)
             val dayOfWeek = cal.get(Calendar.DAY_OF_WEEK)
-            val isWeekend = dayOfWeek == Calendar.SATURDAY ||
-                dayOfWeek == Calendar.SUNDAY
+            val isWeekend =
+                dayOfWeek == Calendar.SATURDAY ||
+                    dayOfWeek == Calendar.SUNDAY
 
             return when {
                 isWeekend && hour in 6..11 -> WEEKEND_MORNING
@@ -70,8 +72,9 @@ enum class TimeBucket {
 // ── User Brain ──
 
 data class UserBrain(
-    val timeVectors: Map<TimeBucket, ContentVector> = TimeBucket.entries
-        .associateWith { ContentVector() },
+    val timeVectors: Map<TimeBucket, ContentVector> =
+        TimeBucket.entries
+            .associateWith { ContentVector() },
     val globalVector: ContentVector = ContentVector(),
     val channelScores: Map<String, Double> = emptyMap(),
     val topicAffinities: Map<String, Double> = emptyMap(),
@@ -100,29 +103,29 @@ data class UserBrain(
      * Maps channelId → timestamp. Escalates to blockedChannels on second signal.
      */
     val suppressedChannels: Map<String, Long> = emptyMap(),
-
     /**
      * Rejection pattern memory. Tracks topic patterns the user
      * repeatedly rejects via "not interested".
      */
     val rejectionPatterns: Map<String, RejectionSignal> = emptyMap(),
-
     // ── Feed repetition prevention ──
-
     val feedHistory: Map<String, FeedEntry> = emptyMap(),
-
     val recentQueryTokens: List<Set<String>> = emptyList(),
-
-
     val topicEvidence: Map<String, TopicEvidence> = emptyMap(),
-
-    val schemaVersion: Int = 13
+    val schemaVersion: Int = 13,
 )
 
 // ── Interaction Types ──
 
 enum class InteractionType {
-    CLICK, LIKED, WATCHED, SKIPPED, DISLIKED
+    CLICK,
+    LIKED,
+    WATCHED,
+    SKIPPED,
+    DISLIKED,
+
+    /** High-intent save: download, Watch Later, playlist add. Positive but weaker than LIKED. */
+    SAVED,
 }
 
 // ── Persona ──
@@ -130,7 +133,7 @@ enum class InteractionType {
 enum class FlowPersona(
     @StringRes val titleRes: Int,
     @StringRes val descriptionRes: Int,
-    val icon: String
+    val icon: String,
 ) {
     INITIATE(R.string.persona_initiate_title, R.string.persona_initiate_description, "🌱"),
     AUDIOPHILE(R.string.persona_audiophile_title, R.string.persona_audiophile_description, "🎧"),
@@ -141,7 +144,7 @@ enum class FlowPersona(
     DEEP_DIVER(R.string.persona_deep_diver_title, R.string.persona_deep_diver_description, "🤿"),
     SKIMMER(R.string.persona_skimmer_title, R.string.persona_skimmer_description, "⚡"),
     SPECIALIST(R.string.persona_specialist_title, R.string.persona_specialist_description, "🎯"),
-    EXPLORER(R.string.persona_explorer_title, R.string.persona_explorer_description, "🧭")
+    EXPLORER(R.string.persona_explorer_title, R.string.persona_explorer_description, "🧭"),
 }
 
 // ── Topic Category (Onboarding) ──
@@ -149,7 +152,7 @@ enum class FlowPersona(
 data class TopicCategory(
     val name: String,
     val icon: String,
-    val topics: List<String>
+    val topics: List<String>,
 )
 
 // ── Discovery Query ──
@@ -158,7 +161,7 @@ data class DiscoveryQuery(
     val query: String,
     val strategy: QueryStrategy,
     val confidence: Double,
-    val reasoning: String
+    val reasoning: String,
 )
 
 enum class QueryStrategy {
@@ -168,7 +171,7 @@ enum class QueryStrategy {
     ADJACENT_EXPLORATION,
     CHANNEL_DISCOVERY,
     CONTEXTUAL,
-    FORMAT_DRIVEN
+    FORMAT_DRIVEN,
 }
 
 // ── Internal Tracking Structures ──
@@ -176,12 +179,12 @@ enum class QueryStrategy {
 internal data class ScoredVideo(
     val video: io.github.aedev.flow.data.model.Video,
     var score: Double,
-    val vector: ContentVector
+    val vector: ContentVector,
 )
 
 data class RejectionSignal(
     val count: Int,
-    val lastRejectedAt: Long
+    val lastRejectedAt: Long,
 )
 
 data class TopicEvidence(
@@ -193,23 +196,32 @@ data class TopicEvidence(
     val videoIds: Set<String> = emptySet(),
     val channelIds: Set<String> = emptySet(),
     val firstSeenAt: Long = 0L,
-    val lastSeenAt: Long = 0L
+    val lastSeenAt: Long = 0L,
 )
 
-internal data class ImpressionEntry(var count: Int, var lastSeen: Long)
+internal data class ImpressionEntry(
+    var count: Int,
+    var lastSeen: Long,
+)
 
-internal data class WatchEntry(val percentWatched: Float, val timestamp: Long)
+internal data class WatchEntry(
+    val percentWatched: Float,
+    val timestamp: Long,
+)
 
-internal data class MomentumEntry(val topic: String, val positive: Boolean)
+internal data class MomentumEntry(
+    val topic: String,
+    val positive: Boolean,
+)
 
 data class FeedEntry(
     val lastShown: Long,
-    val showCount: Int
+    val showCount: Int,
 )
 
 internal data class IdfSnapshot(
     val wordFrequency: Map<String, Int>,
-    val totalDocs: Int
+    val totalDocs: Int,
 )
 
 /**
@@ -220,7 +232,7 @@ internal data class IdfSnapshot(
 enum class GraphSeedSource {
     WATCH_HISTORY,
     LIKED,
-    PLAYLIST
+    PLAYLIST,
 }
 
 /** A candidate seed for related-graph retrieval, with enough context for one shared selector. */
@@ -233,14 +245,14 @@ data class GraphSeedInput(
     val timestamp: Long,
     val durationSec: Int,
     val percentWatched: Double,
-    val isShort: Boolean = false
+    val isShort: Boolean = false,
 )
 
 /** A seed annotated with its interest cluster, for diversified selection. */
 internal data class SeedRank(
     val id: String,
     val clusterKey: String,
-    val weight: Double
+    val weight: Double,
 )
 
 internal data class ScoringParams(
@@ -261,5 +273,5 @@ internal data class ScoringParams(
     val recentInteractions: List<MomentumEntry>,
     val candidatePoolSize: Int,
     val now: Long,
-    val exploreWeight: Double = 0.0
+    val exploreWeight: Double = 0.0,
 )

--- a/app/src/main/java/io/github/aedev/flow/data/recommendation/NeuroScoring.kt
+++ b/app/src/main/java/io/github/aedev/flow/data/recommendation/NeuroScoring.kt
@@ -26,6 +26,9 @@ internal object NeuroScoring {
     // ── Scoring Weight Constants ──
     const val SUBSCRIPTION_BOOST = 0.15
     const val SUBSCRIPTION_BOOST_MAX = 0.30
+
+    /** Channel-boredom multiplier at the 0.5 starting EMA — the neutral point. */
+    const val CHANNEL_SIGNAL_NEUTRAL = 0.7801
     const val SERENDIPITY_BONUS = 0.10
     const val CURIOSITY_GAP_BONUS = 0.10
     const val NOT_INTERESTED_CHANNEL_FLOOR = 0.20
@@ -51,8 +54,10 @@ internal object NeuroScoring {
     const val COLD_START_ENGAGEMENT_FLOOR_MIN_VIEWS = 10_000L
     const val BINGE_THRESHOLD = 20
     const val BINGE_NOVELTY_FACTOR = 0.15
-    const val JITTER_COLD_START = 0.20
-    const val JITTER_NORMAL = 0.02
+
+    // Jitter is a FRACTION of the median candidate score (see rank()), not absolute.
+    const val JITTER_COLD_START = 0.40
+    const val JITTER_NORMAL = 0.05
     const val TITLE_SIMILARITY_STRICT = 0.55
     const val TITLE_SIMILARITY_RELAXED = 0.60
     const val CLASSIC_VIEW_THRESHOLD = 5_000_000L
@@ -328,14 +333,15 @@ internal object NeuroScoring {
             signal += (subBoost * freshnessMultiplier).coerceAtMost(SUBSCRIPTION_BOOST_MAX)
         }
 
-        // V9.3 Fix 4: Sigmoid channel boredom
+        // V9.3 Fix 4 + V11 recenter: sigmoid channel boredom, neutral at the EMA
+        // start (0.5). The old form subtracted 1.0, which handed EVERY known
+        // channel an additive penalty (-0.22 at the 0.5 starting EMA) and made
+        // familiar channels rank below never-seen ones for ~20 interactions.
         if (brain.channelScores.containsKey(video.channelId)) {
             val channelClickRate = brain.channelScores[video.channelId] ?: 0.5
-            // Sigmoid: 0.01→0.10x, 0.20→0.25x, 0.35→0.52x, 0.50→0.77x, 0.70→0.93x
             val channelQuality = 1.0 / (1.0 + exp(-8.0 * (channelClickRate - 0.35)))
             val channelMultiplier = 0.05 + 0.95 * channelQuality
-            // Encode as additive penalty/bonus relative to 1.0
-            signal += (channelMultiplier - 1.0)
+            signal += (channelMultiplier - CHANNEL_SIGNAL_NEUTRAL)
         }
 
         return signal
@@ -632,6 +638,69 @@ internal object NeuroScoring {
         return basePenalty + (1.0 - basePenalty) * (1.0 - scarcityRelaxation)
     }
 
+    // ── Precision topic blocking ──
+
+    data class BlockedMatchers(
+        val phrases: Set<String>,
+        val tokens: Set<String>,
+    ) {
+        fun isEmpty(): Boolean = phrases.isEmpty() && tokens.isEmpty()
+    }
+
+    /**
+     * A block is precise: the term and its lemma, token-matched. Expanding to a
+     * whole catalog category happens ONLY when the user blocked the category
+     * NAME itself — blocking "Fortnite" must not silently erase all of Gaming.
+     */
+    fun buildBlockedMatchers(
+        blockedTopics: Set<String>,
+        categories: List<TopicCategory>,
+        normalizeLemma: (String) -> String,
+    ): BlockedMatchers {
+        val phrases = mutableSetOf<String>()
+        val tokens = mutableSetOf<String>()
+
+        fun addTerm(term: String) {
+            val lower = term.lowercase().trim()
+            if (lower.isEmpty()) return
+            if (lower.contains(' ')) {
+                phrases += lower
+            } else {
+                tokens += lower
+                tokens += normalizeLemma(lower)
+            }
+        }
+
+        blockedTopics.forEach { blocked ->
+            val blockedLower = blocked.lowercase()
+            categories
+                .find { it.name.lowercase() == blockedLower }
+                ?.topics
+                ?.forEach(::addTerm)
+            addTerm(blockedLower)
+        }
+        return BlockedMatchers(phrases, tokens)
+    }
+
+    /** Token-boundary matching: blocking "art" hides "art", never "startup". */
+    fun isBlockedByText(
+        title: String,
+        channelName: String,
+        matchers: BlockedMatchers,
+        normalizeLemma: (String) -> String,
+    ): Boolean {
+        if (matchers.isEmpty()) return false
+        val titleLower = title.lowercase()
+        val channelLower = channelName.lowercase()
+        if (matchers.phrases.any { titleLower.contains(it) || channelLower.contains(it) }) return true
+        if (matchers.tokens.isEmpty()) return false
+        return sequenceOf(titleLower, channelLower)
+            .flatMap { it.splitToSequence(' ', '-', '_', '|', ',', '.', ':', '(', ')', '[', ']', '#') }
+            .map { it.trim { c -> !c.isLetterOrDigit() } }
+            .filter { it.length > 1 }
+            .any { token -> token in matchers.tokens || normalizeLemma(token) in matchers.tokens }
+    }
+
     /**
      * Hard seen-gate: industry practice (Twitter home-mixer's "previously seen
      * removal") treats recent repeats as a FILTER, not a score penalty — a
@@ -698,10 +767,11 @@ internal object NeuroScoring {
     }
 
     /**
-     * Calculates adaptive jitter based on feed staleness.
-     * When most candidates were recently shown, increases randomization
-     * to break deterministic ordering. When fresh candidates arrive,
-     * drops back to minimal jitter to let quality ranking dominate.
+     * Adaptive jitter based on feed staleness, expressed as a FRACTION of the
+     * median candidate score (the caller multiplies). When most candidates were
+     * recently shown, randomization rises to break deterministic ordering; with
+     * fresh candidates it drops so quality ranking dominates. Relative scaling
+     * keeps noise proportional — it can no longer drown the signal outright.
      */
     fun calculateAdaptiveJitter(
         totalInteractions: Int,
@@ -713,11 +783,11 @@ internal object NeuroScoring {
             }
 
             feedOverlapRatio > 0.5 -> {
-                0.12
+                0.25
             }
 
             feedOverlapRatio > 0.2 -> {
-                0.06
+                0.12
             }
 
             else -> {

--- a/app/src/main/java/io/github/aedev/flow/data/recommendation/NeuroScoring.kt
+++ b/app/src/main/java/io/github/aedev/flow/data/recommendation/NeuroScoring.kt
@@ -123,6 +123,24 @@ internal object NeuroScoring {
     const val FEED_HISTORY_MAX = 3000
     const val FEED_HISTORY_EXPIRY_DAYS = 14L
 
+    // ── Hard seen-gate (repetition filter, not penalty) ──
+    const val SEEN_GATE_SHOW_COUNT = 2
+    const val SEEN_GATE_WINDOW_HOURS = 60.0
+
+    /** Even a single viewport impression hides an item for this short window. */
+    const val SEEN_GATE_SINGLE_SHOW_WINDOW_HOURS = 6.0
+    const val SEEN_GATE_MIN_POOL = 25
+    const val SEEN_GATE_MIN_RESULTS = 10
+
+    // ── Related-seed rotation ──
+    const val RELATED_SEED_COOLDOWN_HOURS = 6L
+    const val RECENT_RELATED_SEEDS_MAX = 60
+
+    // ── Stale-query memory (result novelty, not query wording) ──
+    const val STALE_QUERY_NOVELTY_THRESHOLD = 0.4
+    const val STALE_QUERY_EXPIRY_HOURS = 24L
+    const val STALE_QUERY_MAX = 40
+
     // ── Implicit Disinterest Constants ──
     const val IMPLICIT_DISINTEREST_WINDOW_HOURS = 48.0
     const val IMPLICIT_DISINTEREST_THRESHOLD_HEAVY = 5
@@ -603,6 +621,35 @@ internal object NeuroScoring {
 
         // Blend toward 1.0 when pool is scarce
         return basePenalty + (1.0 - basePenalty) * (1.0 - scarcityRelaxation)
+    }
+
+    /**
+     * Hard seen-gate: industry practice (Twitter home-mixer's "previously seen
+     * removal") treats recent repeats as a FILTER, not a score penalty — a
+     * penalty lets high-scoring items punch back into the feed. Items shown
+     * [SEEN_GATE_SHOW_COUNT]+ times within [SEEN_GATE_WINDOW_HOURS] are dropped
+     * entirely, with two scarcity guards: small pools skip the gate, and if the
+     * gate would leave fewer than [SEEN_GATE_MIN_RESULTS] items it backs off.
+     */
+    fun <T> applySeenGate(
+        items: List<T>,
+        feedHistory: Map<String, FeedEntry>,
+        now: Long,
+        idOf: (T) -> String,
+    ): List<T> {
+        if (items.size < SEEN_GATE_MIN_POOL || feedHistory.isEmpty()) return items
+        val kept =
+            items.filter { item ->
+                val entry = feedHistory[idOf(item)] ?: return@filter true
+                val hoursSince = (now - entry.lastShown) / 3_600_000.0
+                // A single impression hides the item briefly (kills the classic
+                // "same video on every refresh"); repeats hide it for days.
+                if (hoursSince < SEEN_GATE_SINGLE_SHOW_WINDOW_HOURS) return@filter false
+                if (entry.showCount < SEEN_GATE_SHOW_COUNT) return@filter true
+                hoursSince >= SEEN_GATE_WINDOW_HOURS
+            }
+        if (kept.size == items.size) return items
+        return if (kept.size >= SEEN_GATE_MIN_RESULTS) kept else items
     }
 
     /**

--- a/app/src/main/java/io/github/aedev/flow/data/recommendation/NeuroScoring.kt
+++ b/app/src/main/java/io/github/aedev/flow/data/recommendation/NeuroScoring.kt
@@ -144,6 +144,12 @@ internal object NeuroScoring {
     // ── Interest-cluster rotation state cap ──
     const val CLUSTER_ROTATION_MAX = 40
 
+    // ── Tag co-occurrence edges (from opened videos' real tags) ──
+    const val TAG_AFFINITY_TOKENS = 6
+    const val TAG_AFFINITY_INCREMENT = 0.05
+    const val TAG_AFFINITY_MAX_ENTRIES = 400
+    const val TAG_AFFINITY_KEEP_TOP = 300
+
     // ── Implicit Disinterest Constants ──
     const val IMPLICIT_DISINTEREST_WINDOW_HOURS = 48.0
     const val IMPLICIT_DISINTEREST_THRESHOLD_HEAVY = 5

--- a/app/src/main/java/io/github/aedev/flow/data/recommendation/NeuroScoring.kt
+++ b/app/src/main/java/io/github/aedev/flow/data/recommendation/NeuroScoring.kt
@@ -957,24 +957,30 @@ internal object NeuroScoring {
     }
 
     /**
-     * Greedy cluster-diversified seed pick: highest weight first, at most
-     * maxPerCluster per cluster, capped at maxSeeds — prevents seed monoculture.
+     * Cluster-diversified seed pick with PROGRESSIVE fill: pass 1 takes at most
+     * one seed per cluster (spread-first, so with community-mapped keys each
+     * major interest gets a related seed before any interest gets two); later
+     * passes relax up to maxPerCluster only when slots remain.
      */
     fun pickDiverseSeeds(
         seeds: List<SeedRank>,
         maxSeeds: Int,
         maxPerCluster: Int,
     ): List<String> {
-        val out = mutableListOf<String>()
+        val sortedSeeds = seeds.sortedByDescending { it.weight }
+        val out = LinkedHashSet<String>()
         val perCluster = HashMap<String, Int>()
-        for (s in seeds.sortedByDescending { it.weight }) {
-            if (out.size >= maxSeeds) break
-            val count = perCluster[s.clusterKey] ?: 0
-            if (count >= maxPerCluster) continue
-            out.add(s.id)
-            perCluster[s.clusterKey] = count + 1
+        for (allowed in 1..maxPerCluster.coerceAtLeast(1)) {
+            for (s in sortedSeeds) {
+                if (out.size >= maxSeeds) return out.toList()
+                if (s.id in out) continue
+                val count = perCluster[s.clusterKey] ?: 0
+                if (count >= allowed) continue
+                out.add(s.id)
+                perCluster[s.clusterKey] = count + 1
+            }
         }
-        return out
+        return out.toList()
     }
 
     // ── Topic probation (damp brand-new, unconfirmed topics on mature brains) ──

--- a/app/src/main/java/io/github/aedev/flow/data/recommendation/NeuroScoring.kt
+++ b/app/src/main/java/io/github/aedev/flow/data/recommendation/NeuroScoring.kt
@@ -86,9 +86,12 @@ internal object NeuroScoring {
     const val SEEN_SHORTS_MAX = 3000
     const val SEEN_SHORT_PENALTY = 0.05
     const val SEEN_SHORT_EXPIRY_DAYS = 7
-    const val AFFINITY_INCREMENT = 0.01
+
+    // 0.03/co-watch: one shared session creates a cluster edge (min 0.02), five
+    // reach the affinity-query threshold (0.15). The old 0.01 could never outlive
+    // the per-update prune that used to sit at 0.05.
+    const val AFFINITY_INCREMENT = 0.03
     const val AFFINITY_MAX = 1.0
-    const val AFFINITY_PRUNE_THRESHOLD = 0.05
     const val AFFINITY_MAX_ENTRIES = 500
     const val AFFINITY_KEEP_TOP = 300
     const val AFFINITY_MAX_BOOST_PER_VIDEO = 0.15
@@ -148,6 +151,16 @@ internal object NeuroScoring {
 
     // ── Interest-cluster rotation state cap ──
     const val CLUSTER_ROTATION_MAX = 40
+
+    /** Clusters contributing to EVERY feed; staleness rotation gates only the tail beyond this. */
+    const val MAX_CLUSTERS_PER_REFRESH = 6
+
+    /** Top-mass clusters guaranteed a slot in every feed regardless of staleness. */
+    const val MAJOR_CLUSTER_SLOTS = 3
+
+    // ── Topic acquisition floor (strong signals plant new interests) ──
+    const val TOPIC_ACQUISITION_FLOOR = 0.05
+    const val TOPIC_ACQUISITION_TOP_K = 3
 
     // ── Tag co-occurrence edges (from opened videos' real tags) ──
     const val TAG_AFFINITY_TOKENS = 6

--- a/app/src/main/java/io/github/aedev/flow/data/recommendation/NeuroScoring.kt
+++ b/app/src/main/java/io/github/aedev/flow/data/recommendation/NeuroScoring.kt
@@ -141,6 +141,9 @@ internal object NeuroScoring {
     const val STALE_QUERY_EXPIRY_HOURS = 24L
     const val STALE_QUERY_MAX = 40
 
+    // ── Interest-cluster rotation state cap ──
+    const val CLUSTER_ROTATION_MAX = 40
+
     // ── Implicit Disinterest Constants ──
     const val IMPLICIT_DISINTEREST_WINDOW_HOURS = 48.0
     const val IMPLICIT_DISINTEREST_THRESHOLD_HEAVY = 5

--- a/app/src/main/java/io/github/aedev/flow/data/recommendation/NeuroStorage.kt
+++ b/app/src/main/java/io/github/aedev/flow/data/recommendation/NeuroStorage.kt
@@ -159,23 +159,8 @@ internal class NeuroStorage(
             isLive = isLive,
         )
 
-    fun SerializableVector.toContentVector() =
-        ContentVector(
-            topics = topics,
-            duration = duration,
-            pacing = pacing,
-            complexity = complexity,
-            isLive = isLive,
-        )
-
     fun FeedEntry.toSerializable() =
         SerializableFeedEntry(
-            lastShown = lastShown,
-            showCount = showCount,
-        )
-
-    fun SerializableFeedEntry.toFeedEntry() =
-        FeedEntry(
             lastShown = lastShown,
             showCount = showCount,
         )
@@ -186,26 +171,8 @@ internal class NeuroStorage(
             lastRejectedAt = lastRejectedAt,
         )
 
-    fun SerializableRejectionSignal.toRejectionSignal() =
-        RejectionSignal(
-            count = count,
-            lastRejectedAt = lastRejectedAt,
-        )
-
     fun TopicEvidence.toSerializable() =
         SerializableTopicEvidence(
-            positiveSignals = positiveSignals,
-            watchSignals = watchSignals,
-            explicitSignals = explicitSignals,
-            positiveScore = positiveScore,
-            videoIds = videoIds,
-            channelIds = channelIds,
-            firstSeenAt = firstSeenAt,
-            lastSeenAt = lastSeenAt,
-        )
-
-    fun SerializableTopicEvidence.toTopicEvidence() =
-        TopicEvidence(
             positiveSignals = positiveSignals,
             watchSignals = watchSignals,
             explicitSignals = explicitSignals,
@@ -255,47 +222,6 @@ internal class NeuroStorage(
             clusterRotation = clusterRotation,
             tagAffinities = tagAffinities,
         )
-
-    fun SerializableBrain.toUserBrain(): UserBrain {
-        val vectors =
-            TimeBucket.entries.associateWith { bucket ->
-                val serialized = timeVectors[bucket.name]
-                serialized?.toContentVector() ?: ContentVector()
-            }
-        return UserBrain(
-            timeVectors = vectors,
-            globalVector = global.toContentVector(),
-            channelScores = channelScores,
-            topicAffinities = topicAffinities,
-            totalInteractions = interactions,
-            consecutiveSkips = consecutiveSkips,
-            blockedTopics = blockedTopics,
-            blockedChannels = blockedChannels,
-            preferredTopics = preferredTopics,
-            hasCompletedOnboarding = hasCompletedOnboarding,
-            lastPersona = lastPersona,
-            personaStability = personaStability,
-            idfWordFrequency = idfWordFrequency,
-            idfTotalDocuments = idfTotalDocuments,
-            watchHistoryMap = watchHistoryMap,
-            seenShortsHistory = seenShortsHistory,
-            channelTopicProfiles = channelTopicProfiles,
-            shortsVector = shortsVector.toContentVector(),
-            suppressedVideoIds = suppressedVideoIds,
-            suppressedChannels = suppressedChannels,
-            rejectionPatterns =
-                rejectionPatterns.mapValues { (_, v) ->
-                    v.toRejectionSignal()
-                },
-            feedHistory = feedHistory.mapValues { (_, v) -> v.toFeedEntry() },
-            recentQueryTokens = recentQueryTokens.map { it.toSet() },
-            topicEvidence = topicEvidence.mapValues { (_, v) -> v.toTopicEvidence() },
-            recentRelatedSeeds = recentRelatedSeeds,
-            staleQueries = staleQueries,
-            clusterRotation = clusterRotation,
-            tagAffinities = tagAffinities,
-        )
-    }
 
     // ── Persistence operations ──
 
@@ -651,4 +577,82 @@ internal class NeuroStorage(
             isLive = jsonObj.optDouble("isLive", 0.0),
         )
     }
+}
+
+// ── Reverse conversions (pure, Context-free) ──
+// Top-level so offline diagnostics can parse an exported brain without an
+// Android Context. The forward (save) direction stays inside NeuroStorage.
+
+internal fun NeuroStorage.SerializableVector.toContentVector() =
+    ContentVector(
+        topics = topics,
+        duration = duration,
+        pacing = pacing,
+        complexity = complexity,
+        isLive = isLive,
+    )
+
+internal fun NeuroStorage.SerializableFeedEntry.toFeedEntry() =
+    FeedEntry(
+        lastShown = lastShown,
+        showCount = showCount,
+    )
+
+internal fun NeuroStorage.SerializableRejectionSignal.toRejectionSignal() =
+    RejectionSignal(
+        count = count,
+        lastRejectedAt = lastRejectedAt,
+    )
+
+internal fun NeuroStorage.SerializableTopicEvidence.toTopicEvidence() =
+    TopicEvidence(
+        positiveSignals = positiveSignals,
+        watchSignals = watchSignals,
+        explicitSignals = explicitSignals,
+        positiveScore = positiveScore,
+        videoIds = videoIds,
+        channelIds = channelIds,
+        firstSeenAt = firstSeenAt,
+        lastSeenAt = lastSeenAt,
+    )
+
+internal fun NeuroStorage.SerializableBrain.toUserBrain(): UserBrain {
+    val vectors =
+        TimeBucket.entries.associateWith { bucket ->
+            val serialized = timeVectors[bucket.name]
+            serialized?.toContentVector() ?: ContentVector()
+        }
+    return UserBrain(
+        timeVectors = vectors,
+        globalVector = global.toContentVector(),
+        channelScores = channelScores,
+        topicAffinities = topicAffinities,
+        totalInteractions = interactions,
+        consecutiveSkips = consecutiveSkips,
+        blockedTopics = blockedTopics,
+        blockedChannels = blockedChannels,
+        preferredTopics = preferredTopics,
+        hasCompletedOnboarding = hasCompletedOnboarding,
+        lastPersona = lastPersona,
+        personaStability = personaStability,
+        idfWordFrequency = idfWordFrequency,
+        idfTotalDocuments = idfTotalDocuments,
+        watchHistoryMap = watchHistoryMap,
+        seenShortsHistory = seenShortsHistory,
+        channelTopicProfiles = channelTopicProfiles,
+        shortsVector = shortsVector.toContentVector(),
+        suppressedVideoIds = suppressedVideoIds,
+        suppressedChannels = suppressedChannels,
+        rejectionPatterns =
+            rejectionPatterns.mapValues { (_, v) ->
+                v.toRejectionSignal()
+            },
+        feedHistory = feedHistory.mapValues { (_, v) -> v.toFeedEntry() },
+        recentQueryTokens = recentQueryTokens.map { it.toSet() },
+        topicEvidence = topicEvidence.mapValues { (_, v) -> v.toTopicEvidence() },
+        recentRelatedSeeds = recentRelatedSeeds,
+        staleQueries = staleQueries,
+        clusterRotation = clusterRotation,
+        tagAffinities = tagAffinities,
+    )
 }

--- a/app/src/main/java/io/github/aedev/flow/data/recommendation/NeuroStorage.kt
+++ b/app/src/main/java/io/github/aedev/flow/data/recommendation/NeuroStorage.kt
@@ -34,12 +34,13 @@ import java.io.OutputStream
  * All persistence concerns: DataStore, serialization,
  * legacy migration, export/import.
  */
-internal class NeuroStorage(private val appContext: Context) {
-
+internal class NeuroStorage(
+    private val appContext: Context,
+) {
     companion object {
         private const val TAG = "FlowNeuroEngine"
         private const val BRAIN_FILENAME = "user_neuro_brain.json"
-        private const val SCHEMA_VERSION = 13
+        private const val SCHEMA_VERSION = 14
     }
 
     // ── Serializable models ──
@@ -50,19 +51,19 @@ internal class NeuroStorage(private val appContext: Context) {
         val duration: Double = 0.5,
         val pacing: Double = 0.5,
         val complexity: Double = 0.5,
-        val isLive: Double = 0.0
+        val isLive: Double = 0.0,
     )
 
     @Serializable
     data class SerializableFeedEntry(
         val lastShown: Long = 0L,
-        val showCount: Int = 0
+        val showCount: Int = 0,
     )
 
     @Serializable
     data class SerializableRejectionSignal(
         val count: Int = 0,
-        val lastRejectedAt: Long = 0L
+        val lastRejectedAt: Long = 0L,
     )
 
     @Serializable
@@ -74,7 +75,7 @@ internal class NeuroStorage(private val appContext: Context) {
         val videoIds: Set<String> = emptySet(),
         val channelIds: Set<String> = emptySet(),
         val firstSeenAt: Long = 0L,
-        val lastSeenAt: Long = 0L
+        val lastSeenAt: Long = 0L,
     )
 
     @Serializable
@@ -103,7 +104,9 @@ internal class NeuroStorage(private val appContext: Context) {
         val rejectionPatterns: Map<String, SerializableRejectionSignal> = emptyMap(),
         val feedHistory: Map<String, SerializableFeedEntry> = emptyMap(),
         val recentQueryTokens: List<List<String>> = emptyList(),
-        val topicEvidence: Map<String, SerializableTopicEvidence> = emptyMap()
+        val topicEvidence: Map<String, SerializableTopicEvidence> = emptyMap(),
+        val recentRelatedSeeds: Map<String, Long> = emptyMap(),
+        val staleQueries: Map<String, Long> = emptyMap(),
     )
 
     // ── DataStore setup ──
@@ -111,27 +114,28 @@ internal class NeuroStorage(private val appContext: Context) {
     private object BrainSerializer : Serializer<SerializableBrain> {
         override val defaultValue: SerializableBrain = SerializableBrain()
 
-        override suspend fun readFrom(
-            input: InputStream
-        ): SerializableBrain {
-            return try {
+        override suspend fun readFrom(input: InputStream): SerializableBrain =
+            try {
                 val text = input.bufferedReader().readText()
-                if (text.isBlank()) defaultValue
-                else Json { ignoreUnknownKeys = true }
-                    .decodeFromString<SerializableBrain>(text)
+                if (text.isBlank()) {
+                    defaultValue
+                } else {
+                    Json { ignoreUnknownKeys = true }
+                        .decodeFromString<SerializableBrain>(text)
+                }
             } catch (e: Exception) {
                 Log.e(TAG, "Failed to read brain", e)
                 defaultValue
             }
-        }
 
         override suspend fun writeTo(
             t: SerializableBrain,
-            output: OutputStream
+            output: OutputStream,
         ) {
             output.write(
                 Json { encodeDefaults = true }
-                    .encodeToString(t).toByteArray()
+                    .encodeToString(t)
+                    .toByteArray(),
             )
         }
     }
@@ -139,100 +143,121 @@ internal class NeuroStorage(private val appContext: Context) {
     private val Context.brainDataStore: DataStore<SerializableBrain>
         by dataStore(
             fileName = "flow_neuro_brain_v10.json",
-            serializer = BrainSerializer
+            serializer = BrainSerializer,
         )
 
     // ── Conversion functions ──
 
-    fun ContentVector.toSerializable() = SerializableVector(
-        topics = topics, duration = duration, pacing = pacing,
-        complexity = complexity, isLive = isLive
-    )
+    fun ContentVector.toSerializable() =
+        SerializableVector(
+            topics = topics,
+            duration = duration,
+            pacing = pacing,
+            complexity = complexity,
+            isLive = isLive,
+        )
 
-    fun SerializableVector.toContentVector() = ContentVector(
-        topics = topics, duration = duration, pacing = pacing,
-        complexity = complexity, isLive = isLive
-    )
+    fun SerializableVector.toContentVector() =
+        ContentVector(
+            topics = topics,
+            duration = duration,
+            pacing = pacing,
+            complexity = complexity,
+            isLive = isLive,
+        )
 
-    fun FeedEntry.toSerializable() = SerializableFeedEntry(
-        lastShown = lastShown,
-        showCount = showCount
-    )
+    fun FeedEntry.toSerializable() =
+        SerializableFeedEntry(
+            lastShown = lastShown,
+            showCount = showCount,
+        )
 
-    fun SerializableFeedEntry.toFeedEntry() = FeedEntry(
-        lastShown = lastShown,
-        showCount = showCount
-    )
+    fun SerializableFeedEntry.toFeedEntry() =
+        FeedEntry(
+            lastShown = lastShown,
+            showCount = showCount,
+        )
 
-    fun RejectionSignal.toSerializable() = SerializableRejectionSignal(
-        count = count,
-        lastRejectedAt = lastRejectedAt
-    )
+    fun RejectionSignal.toSerializable() =
+        SerializableRejectionSignal(
+            count = count,
+            lastRejectedAt = lastRejectedAt,
+        )
 
-    fun SerializableRejectionSignal.toRejectionSignal() = RejectionSignal(
-        count = count,
-        lastRejectedAt = lastRejectedAt
-    )
+    fun SerializableRejectionSignal.toRejectionSignal() =
+        RejectionSignal(
+            count = count,
+            lastRejectedAt = lastRejectedAt,
+        )
 
-    fun TopicEvidence.toSerializable() = SerializableTopicEvidence(
-        positiveSignals = positiveSignals,
-        watchSignals = watchSignals,
-        explicitSignals = explicitSignals,
-        positiveScore = positiveScore,
-        videoIds = videoIds,
-        channelIds = channelIds,
-        firstSeenAt = firstSeenAt,
-        lastSeenAt = lastSeenAt
-    )
+    fun TopicEvidence.toSerializable() =
+        SerializableTopicEvidence(
+            positiveSignals = positiveSignals,
+            watchSignals = watchSignals,
+            explicitSignals = explicitSignals,
+            positiveScore = positiveScore,
+            videoIds = videoIds,
+            channelIds = channelIds,
+            firstSeenAt = firstSeenAt,
+            lastSeenAt = lastSeenAt,
+        )
 
-    fun SerializableTopicEvidence.toTopicEvidence() = TopicEvidence(
-        positiveSignals = positiveSignals,
-        watchSignals = watchSignals,
-        explicitSignals = explicitSignals,
-        positiveScore = positiveScore,
-        videoIds = videoIds,
-        channelIds = channelIds,
-        firstSeenAt = firstSeenAt,
-        lastSeenAt = lastSeenAt
-    )
+    fun SerializableTopicEvidence.toTopicEvidence() =
+        TopicEvidence(
+            positiveSignals = positiveSignals,
+            watchSignals = watchSignals,
+            explicitSignals = explicitSignals,
+            positiveScore = positiveScore,
+            videoIds = videoIds,
+            channelIds = channelIds,
+            firstSeenAt = firstSeenAt,
+            lastSeenAt = lastSeenAt,
+        )
 
-    fun UserBrain.toSerializable() = SerializableBrain(
-        schemaVersion = SCHEMA_VERSION,
-        timeVectors = timeVectors.map { (k, v) ->
-            k.name to v.toSerializable()
-        }.toMap(),
-        global = globalVector.toSerializable(),
-        channelScores = channelScores,
-        topicAffinities = topicAffinities,
-        interactions = totalInteractions,
-        consecutiveSkips = consecutiveSkips,
-        blockedTopics = blockedTopics,
-        blockedChannels = blockedChannels,
-        preferredTopics = preferredTopics,
-        hasCompletedOnboarding = hasCompletedOnboarding,
-        lastPersona = lastPersona,
-        personaStability = personaStability,
-        idfWordFrequency = idfWordFrequency,
-        idfTotalDocuments = idfTotalDocuments,
-        watchHistoryMap = watchHistoryMap,
-        seenShortsHistory = seenShortsHistory,
-        channelTopicProfiles = channelTopicProfiles,
-        shortsVector = shortsVector.toSerializable(),
-        suppressedVideoIds = suppressedVideoIds,
-        suppressedChannels = suppressedChannels,
-        rejectionPatterns = rejectionPatterns.mapValues { (_, v) ->
-            v.toSerializable()
-        },
-        feedHistory = feedHistory.mapValues { (_, v) -> v.toSerializable() },
-        recentQueryTokens = recentQueryTokens.map { it.toList() },
-        topicEvidence = topicEvidence.mapValues { (_, v) -> v.toSerializable() }
-    )
+    fun UserBrain.toSerializable() =
+        SerializableBrain(
+            schemaVersion = SCHEMA_VERSION,
+            timeVectors =
+                timeVectors
+                    .map { (k, v) ->
+                        k.name to v.toSerializable()
+                    }.toMap(),
+            global = globalVector.toSerializable(),
+            channelScores = channelScores,
+            topicAffinities = topicAffinities,
+            interactions = totalInteractions,
+            consecutiveSkips = consecutiveSkips,
+            blockedTopics = blockedTopics,
+            blockedChannels = blockedChannels,
+            preferredTopics = preferredTopics,
+            hasCompletedOnboarding = hasCompletedOnboarding,
+            lastPersona = lastPersona,
+            personaStability = personaStability,
+            idfWordFrequency = idfWordFrequency,
+            idfTotalDocuments = idfTotalDocuments,
+            watchHistoryMap = watchHistoryMap,
+            seenShortsHistory = seenShortsHistory,
+            channelTopicProfiles = channelTopicProfiles,
+            shortsVector = shortsVector.toSerializable(),
+            suppressedVideoIds = suppressedVideoIds,
+            suppressedChannels = suppressedChannels,
+            rejectionPatterns =
+                rejectionPatterns.mapValues { (_, v) ->
+                    v.toSerializable()
+                },
+            feedHistory = feedHistory.mapValues { (_, v) -> v.toSerializable() },
+            recentQueryTokens = recentQueryTokens.map { it.toList() },
+            topicEvidence = topicEvidence.mapValues { (_, v) -> v.toSerializable() },
+            recentRelatedSeeds = recentRelatedSeeds,
+            staleQueries = staleQueries,
+        )
 
     fun SerializableBrain.toUserBrain(): UserBrain {
-        val vectors = TimeBucket.entries.associateWith { bucket ->
-            val serialized = timeVectors[bucket.name]
-            serialized?.toContentVector() ?: ContentVector()
-        }
+        val vectors =
+            TimeBucket.entries.associateWith { bucket ->
+                val serialized = timeVectors[bucket.name]
+                serialized?.toContentVector() ?: ContentVector()
+            }
         return UserBrain(
             timeVectors = vectors,
             globalVector = global.toContentVector(),
@@ -254,12 +279,15 @@ internal class NeuroStorage(private val appContext: Context) {
             shortsVector = shortsVector.toContentVector(),
             suppressedVideoIds = suppressedVideoIds,
             suppressedChannels = suppressedChannels,
-            rejectionPatterns = rejectionPatterns.mapValues { (_, v) ->
-                v.toRejectionSignal()
-            },
+            rejectionPatterns =
+                rejectionPatterns.mapValues { (_, v) ->
+                    v.toRejectionSignal()
+                },
             feedHistory = feedHistory.mapValues { (_, v) -> v.toFeedEntry() },
             recentQueryTokens = recentQueryTokens.map { it.toSet() },
             topicEvidence = topicEvidence.mapValues { (_, v) -> v.toTopicEvidence() },
+            recentRelatedSeeds = recentRelatedSeeds,
+            staleQueries = staleQueries,
         )
     }
 
@@ -285,7 +313,7 @@ internal class NeuroStorage(private val appContext: Context) {
                     Log.i(
                         TAG,
                         "Loaded brain v${data.schemaVersion}, " +
-                            "${data.interactions} interactions"
+                            "${data.interactions} interactions",
                     )
                     return@withContext brain
                 }
@@ -321,12 +349,17 @@ internal class NeuroStorage(private val appContext: Context) {
             global.topics.isNotEmpty() ||
             timeVectors.any { (_, vector) -> vector.topics.isNotEmpty() }
 
-    suspend fun exportToStream(brain: UserBrain, output: OutputStream): Boolean =
+    suspend fun exportToStream(
+        brain: UserBrain,
+        output: OutputStream,
+    ): Boolean =
         withContext(Dispatchers.IO) {
             try {
                 val brainCopy = brain.toSerializable()
-                val jsonBytes = Json { encodeDefaults = true }
-                    .encodeToString(brainCopy).toByteArray()
+                val jsonBytes =
+                    Json { encodeDefaults = true }
+                        .encodeToString(brainCopy)
+                        .toByteArray()
                 output.write(jsonBytes)
                 output.flush()
                 Log.i(TAG, "Brain exported")
@@ -343,25 +376,28 @@ internal class NeuroStorage(private val appContext: Context) {
                 val text = input.bufferedReader().readText()
                 val jsonParser = Json { ignoreUnknownKeys = true }
 
-                val imported = jsonParser
-                    .decodeFromString<SerializableBrain>(text)
+                val imported =
+                    jsonParser
+                        .decodeFromString<SerializableBrain>(text)
 
-                val hasTimeData = imported.timeVectors.any { (_, v) ->
-                    v.topics.isNotEmpty()
-                }
+                val hasTimeData =
+                    imported.timeVectors.any { (_, v) ->
+                        v.topics.isNotEmpty()
+                    }
 
-                val finalBrain = if (hasTimeData) {
-                    imported.toUserBrain()
-                } else {
-                    migrateLegacyBackup(text, imported)
-                }
+                val finalBrain =
+                    if (hasTimeData) {
+                        imported.toUserBrain()
+                    } else {
+                        migrateLegacyBackup(text, imported)
+                    }
 
                 Log.i(
                     TAG,
                     "Brain imported (${finalBrain.totalInteractions} " +
                         "interactions, ${finalBrain.timeVectors.count {
                             it.value.topics.isNotEmpty()
-                        }} active time buckets)"
+                        }} active time buckets)",
                 )
                 finalBrain
             } catch (e: Exception) {
@@ -372,28 +408,31 @@ internal class NeuroStorage(private val appContext: Context) {
 
     // ── Migration ──
 
-    suspend fun migrateLegacy(): UserBrain? = withContext(Dispatchers.IO) {
-        val legacyFile = File(appContext.filesDir, BRAIN_FILENAME)
-        if (legacyFile.exists()) {
-            try {
-                Log.i(TAG, "Migrating legacy JSON brain...")
-                val text = legacyFile.readText()
-                val migrated = migrateLegacyBackup(
-                    text, SerializableBrain()
-                )
-                Log.i(
-                    TAG,
-                    "Legacy brain migrated " +
-                        "(${migrated.totalInteractions} interactions)"
-                )
-                return@withContext migrated
-            } catch (e: Exception) {
-                Log.e(TAG, "Legacy JSON migration failed", e)
+    suspend fun migrateLegacy(): UserBrain? =
+        withContext(Dispatchers.IO) {
+            val legacyFile = File(appContext.filesDir, BRAIN_FILENAME)
+            if (legacyFile.exists()) {
+                try {
+                    Log.i(TAG, "Migrating legacy JSON brain...")
+                    val text = legacyFile.readText()
+                    val migrated =
+                        migrateLegacyBackup(
+                            text,
+                            SerializableBrain(),
+                        )
+                    Log.i(
+                        TAG,
+                        "Legacy brain migrated " +
+                            "(${migrated.totalInteractions} interactions)",
+                    )
+                    return@withContext migrated
+                } catch (e: Exception) {
+                    Log.e(TAG, "Legacy JSON migration failed", e)
+                }
             }
-        }
 
-        tryMigrateFromPreviousDataStore()
-    }
+            tryMigrateFromPreviousDataStore()
+        }
 
     fun deleteLegacyFile() {
         val legacyFile = File(appContext.filesDir, BRAIN_FILENAME)
@@ -405,14 +444,15 @@ internal class NeuroStorage(private val appContext: Context) {
 
     fun migrateLegacyBackup(
         rawJson: String,
-        partialParse: SerializableBrain
+        partialParse: SerializableBrain,
     ): UserBrain {
         try {
             val jsonObj = JSONObject(rawJson)
 
             fun parseVector(key: String): ContentVector {
-                val obj = jsonObj.optJSONObject(key)
-                    ?: return ContentVector()
+                val obj =
+                    jsonObj.optJSONObject(key)
+                        ?: return ContentVector()
                 return legacyJsonToVector(obj)
             }
 
@@ -421,9 +461,13 @@ internal class NeuroStorage(private val appContext: Context) {
             val eveningVec = parseVector("evening")
             val nightVec = parseVector("night")
 
-            val hasLegacyData = listOf(
-                morningVec, afternoonVec, eveningVec, nightVec
-            ).any { it.topics.isNotEmpty() }
+            val hasLegacyData =
+                listOf(
+                    morningVec,
+                    afternoonVec,
+                    eveningVec,
+                    nightVec,
+                ).any { it.topics.isNotEmpty() }
 
             val timeVectors: Map<TimeBucket, ContentVector> =
                 if (hasLegacyData) {
@@ -435,29 +479,32 @@ internal class NeuroStorage(private val appContext: Context) {
                         TimeBucket.WEEKDAY_EVENING to eveningVec,
                         TimeBucket.WEEKEND_EVENING to eveningVec,
                         TimeBucket.WEEKDAY_NIGHT to nightVec,
-                        TimeBucket.WEEKEND_NIGHT to nightVec
+                        TimeBucket.WEEKEND_NIGHT to nightVec,
                     )
                 } else {
                     val tvObj = jsonObj.optJSONObject("timeVectors")
                     if (tvObj != null) {
                         TimeBucket.entries.associateWith { bucket ->
                             val bucketObj = tvObj.optJSONObject(bucket.name)
-                            if (bucketObj != null)
+                            if (bucketObj != null) {
                                 legacyJsonToVector(bucketObj)
-                            else ContentVector()
+                            } else {
+                                ContentVector()
+                            }
                         }
                     } else {
                         TimeBucket.entries.associateWith { ContentVector() }
                     }
                 }
 
-            val globalVec = if (partialParse.global.topics.isNotEmpty()) {
-                partialParse.global.toContentVector()
-            } else {
-                parseVector("global").let {
-                    if (it.topics.isEmpty()) parseVector("longTerm") else it
+            val globalVec =
+                if (partialParse.global.topics.isNotEmpty()) {
+                    partialParse.global.toContentVector()
+                } else {
+                    parseVector("global").let {
+                        if (it.topics.isEmpty()) parseVector("longTerm") else it
+                    }
                 }
-            }
 
             val channelScores = mutableMapOf<String, Double>()
             val scoresObj = jsonObj.optJSONObject("channelScores")
@@ -490,37 +537,55 @@ internal class NeuroStorage(private val appContext: Context) {
             return UserBrain(
                 timeVectors = timeVectors,
                 globalVector = globalVec,
-                channelScores = if (channelScores.isNotEmpty())
-                    channelScores
-                else partialParse.channelScores,
-                topicAffinities = if (affinities.isNotEmpty())
-                    affinities
-                else partialParse.topicAffinities,
-                totalInteractions = if (partialParse.interactions > 0)
-                    partialParse.interactions
-                else jsonObj.optInt("interactions", 0),
+                channelScores =
+                    if (channelScores.isNotEmpty()) {
+                        channelScores
+                    } else {
+                        partialParse.channelScores
+                    },
+                topicAffinities =
+                    if (affinities.isNotEmpty()) {
+                        affinities
+                    } else {
+                        partialParse.topicAffinities
+                    },
+                totalInteractions =
+                    if (partialParse.interactions > 0) {
+                        partialParse.interactions
+                    } else {
+                        jsonObj.optInt("interactions", 0)
+                    },
                 consecutiveSkips = partialParse.consecutiveSkips,
-                blockedTopics = partialParse.blockedTopics.ifEmpty {
-                    loadStringSet("blockedTopics")
-                },
-                blockedChannels = partialParse.blockedChannels.ifEmpty {
-                    loadStringSet("blockedChannels")
-                },
-                preferredTopics = partialParse.preferredTopics.ifEmpty {
-                    loadStringSet("preferredTopics")
-                },
+                blockedTopics =
+                    partialParse.blockedTopics.ifEmpty {
+                        loadStringSet("blockedTopics")
+                    },
+                blockedChannels =
+                    partialParse.blockedChannels.ifEmpty {
+                        loadStringSet("blockedChannels")
+                    },
+                preferredTopics =
+                    partialParse.preferredTopics.ifEmpty {
+                        loadStringSet("preferredTopics")
+                    },
                 hasCompletedOnboarding =
-                partialParse.hasCompletedOnboarding ||
-                    jsonObj.optBoolean("hasCompletedOnboarding", false),
+                    partialParse.hasCompletedOnboarding ||
+                        jsonObj.optBoolean("hasCompletedOnboarding", false),
                 lastPersona = partialParse.lastPersona,
                 personaStability = partialParse.personaStability,
-                idfWordFrequency = if (legacyIdfFreq.isNotEmpty())
-                    legacyIdfFreq
-                else partialParse.idfWordFrequency,
-                idfTotalDocuments = if (legacyIdfTotal > 0)
-                    legacyIdfTotal
-                else partialParse.idfTotalDocuments,
-                watchHistoryMap = partialParse.watchHistoryMap
+                idfWordFrequency =
+                    if (legacyIdfFreq.isNotEmpty()) {
+                        legacyIdfFreq
+                    } else {
+                        partialParse.idfWordFrequency
+                    },
+                idfTotalDocuments =
+                    if (legacyIdfTotal > 0) {
+                        legacyIdfTotal
+                    } else {
+                        partialParse.idfTotalDocuments
+                    },
+                watchHistoryMap = partialParse.watchHistoryMap,
             )
         } catch (e: Exception) {
             Log.e(TAG, "Legacy backup migration failed", e)
@@ -532,18 +597,20 @@ internal class NeuroStorage(private val appContext: Context) {
         val versions = listOf("v9", "v8", "v7")
         for (version in versions) {
             try {
-                val file = File(
-                    appContext.filesDir,
-                    "datastore/flow_neuro_brain_$version.json"
-                )
+                val file =
+                    File(
+                        appContext.filesDir,
+                        "datastore/flow_neuro_brain_$version.json",
+                    )
                 if (!file.exists()) continue
 
                 Log.i(TAG, "Found $version DataStore, migrating to V9...")
                 val text = file.readText()
                 if (text.isBlank()) continue
 
-                val data = Json { ignoreUnknownKeys = true }
-                    .decodeFromString<SerializableBrain>(text)
+                val data =
+                    Json { ignoreUnknownKeys = true }
+                        .decodeFromString<SerializableBrain>(text)
 
                 if (data.interactions > 0 ||
                     data.hasCompletedOnboarding ||
@@ -553,7 +620,7 @@ internal class NeuroStorage(private val appContext: Context) {
                     Log.i(
                         TAG,
                         "Migrated $version brain " +
-                            "(${data.interactions} interactions)"
+                            "(${data.interactions} interactions)",
                     )
                     return brain
                 }
@@ -575,7 +642,7 @@ internal class NeuroStorage(private val appContext: Context) {
             duration = jsonObj.optDouble("duration", 0.5),
             pacing = jsonObj.optDouble("pacing", 0.5),
             complexity = jsonObj.optDouble("complexity", 0.5),
-            isLive = jsonObj.optDouble("isLive", 0.0)
+            isLive = jsonObj.optDouble("isLive", 0.0),
         )
     }
 }

--- a/app/src/main/java/io/github/aedev/flow/data/recommendation/NeuroStorage.kt
+++ b/app/src/main/java/io/github/aedev/flow/data/recommendation/NeuroStorage.kt
@@ -108,6 +108,7 @@ internal class NeuroStorage(
         val recentRelatedSeeds: Map<String, Long> = emptyMap(),
         val staleQueries: Map<String, Long> = emptyMap(),
         val clusterRotation: Map<String, Long> = emptyMap(),
+        val tagAffinities: Map<String, Double> = emptyMap(),
     )
 
     // ── DataStore setup ──
@@ -252,6 +253,7 @@ internal class NeuroStorage(
             recentRelatedSeeds = recentRelatedSeeds,
             staleQueries = staleQueries,
             clusterRotation = clusterRotation,
+            tagAffinities = tagAffinities,
         )
 
     fun SerializableBrain.toUserBrain(): UserBrain {
@@ -291,6 +293,7 @@ internal class NeuroStorage(
             recentRelatedSeeds = recentRelatedSeeds,
             staleQueries = staleQueries,
             clusterRotation = clusterRotation,
+            tagAffinities = tagAffinities,
         )
     }
 

--- a/app/src/main/java/io/github/aedev/flow/data/recommendation/NeuroStorage.kt
+++ b/app/src/main/java/io/github/aedev/flow/data/recommendation/NeuroStorage.kt
@@ -40,7 +40,7 @@ internal class NeuroStorage(
     companion object {
         private const val TAG = "FlowNeuroEngine"
         private const val BRAIN_FILENAME = "user_neuro_brain.json"
-        private const val SCHEMA_VERSION = 14
+        private const val SCHEMA_VERSION = 15
     }
 
     // ── Serializable models ──
@@ -654,5 +654,6 @@ internal fun NeuroStorage.SerializableBrain.toUserBrain(): UserBrain {
         staleQueries = staleQueries,
         clusterRotation = clusterRotation,
         tagAffinities = tagAffinities,
+        schemaVersion = schemaVersion,
     )
 }

--- a/app/src/main/java/io/github/aedev/flow/data/recommendation/NeuroStorage.kt
+++ b/app/src/main/java/io/github/aedev/flow/data/recommendation/NeuroStorage.kt
@@ -107,6 +107,7 @@ internal class NeuroStorage(
         val topicEvidence: Map<String, SerializableTopicEvidence> = emptyMap(),
         val recentRelatedSeeds: Map<String, Long> = emptyMap(),
         val staleQueries: Map<String, Long> = emptyMap(),
+        val clusterRotation: Map<String, Long> = emptyMap(),
     )
 
     // ── DataStore setup ──
@@ -250,6 +251,7 @@ internal class NeuroStorage(
             topicEvidence = topicEvidence.mapValues { (_, v) -> v.toSerializable() },
             recentRelatedSeeds = recentRelatedSeeds,
             staleQueries = staleQueries,
+            clusterRotation = clusterRotation,
         )
 
     fun SerializableBrain.toUserBrain(): UserBrain {
@@ -288,6 +290,7 @@ internal class NeuroStorage(
             topicEvidence = topicEvidence.mapValues { (_, v) -> v.toTopicEvidence() },
             recentRelatedSeeds = recentRelatedSeeds,
             staleQueries = staleQueries,
+            clusterRotation = clusterRotation,
         )
     }
 

--- a/app/src/main/java/io/github/aedev/flow/data/recommendation/NeuroTokenizer.kt
+++ b/app/src/main/java/io/github/aedev/flow/data/recommendation/NeuroTokenizer.kt
@@ -411,6 +411,15 @@ internal class NeuroTokenizer {
             "than",
             "well",
             "even",
+            // Filler adverbs that leaked into topic vectors as junk unigrams and
+            // bigram halves ("laptops right" from "laptops right now").
+            "right",
+            "gonna",
+            "wanna",
+            "gotta",
+            "honestly",
+            "maybe",
+            "probably",
         )
 
     // ── Tag Spam Filter ──
@@ -711,6 +720,24 @@ internal class NeuroTokenizer {
             .filter { !stopWords.contains(it) && !YEAR_TAG_REGEX.matches(it) }
 
     fun tokenizeForSimilarity(text: String): Set<String> = tokenize(text).toSet()
+
+    /**
+     * True when a learned topic key is vocabulary noise rather than an interest:
+     * too short, numeric, a stop word, or a uni/bigram whose parts are stop words.
+     * Used to scrub historical junk from vectors and to gate rehydration seeds.
+     */
+    fun isNoiseTopic(topic: String): Boolean {
+        val base = topic.substringBefore(':').lowercase().trim()
+        if (base.length < 3) return true
+        if (base.all { it.isDigit() } || YEAR_TAG_REGEX.matches(base)) return true
+        val parts = base.split(' ').filter { it.isNotBlank() }
+        if (parts.isEmpty()) return true
+        // Degenerate bigrams like "code code" are tokenizer echoes, not topics.
+        if (parts.size > 1 && parts.distinct().size < parts.size) return true
+        return parts.any { part ->
+            part in stopWords || normalizeLemma(part) in stopWords || part.length < 3
+        }
+    }
 
     fun calculateIdfWeight(
         word: String,

--- a/app/src/main/java/io/github/aedev/flow/data/recommendation/NeuroTokenizer.kt
+++ b/app/src/main/java/io/github/aedev/flow/data/recommendation/NeuroTokenizer.kt
@@ -24,7 +24,6 @@ import kotlin.math.*
  * Stateless utility — can be shared across all other components.
  */
 internal class NeuroTokenizer {
-
     companion object {
         val WHITESPACE_REGEX = Regex("\\s+")
 
@@ -62,281 +61,661 @@ internal class NeuroTokenizer {
 
     // ── Lemma Map ──
 
-    private val LEMMA_MAP = mapOf(
-        // Gaming
-        "gaming" to "game", "games" to "game", "gamer" to "game",
-        "gamers" to "game", "gameplay" to "game", "gamed" to "game",
-        // Coding / Programming
-        "coding" to "code", "coder" to "code", "coders" to "code",
-        "codes" to "code", "coded" to "code",
-        "programming" to "program", "programmer" to "program",
-        "programmers" to "program", "programs" to "program",
-        "programmed" to "program",
-        // Cooking
-        "cooking" to "cook", "cooked" to "cook", "cooks" to "cook",
-        "cooker" to "cook",
-        // Music
-        "songs" to "song", "singing" to "sing", "singer" to "sing",
-        "singers" to "sing", "musics" to "music", "musical" to "music",
-        "musician" to "music", "musicians" to "music",
-        // Technology
-        "technologies" to "technology", "technological" to "technology",
-        "computers" to "computer", "computing" to "computer",
-        "computed" to "computer",
-        // Art
-        "drawing" to "draw", "drawings" to "draw", "drawn" to "draw",
-        "painting" to "paint", "paintings" to "paint",
-        "painted" to "paint", "painter" to "paint",
-        "animating" to "animation", "animated" to "animation",
-        "animations" to "animation", "animator" to "animation",
-        // Fitness
-        "workouts" to "workout", "exercising" to "exercise",
-        "exercises" to "exercise", "exercised" to "exercise",
-        "learning" to "learn", "learned" to "learn",
-        "learner" to "learn", "learners" to "learn",
-        "teaching" to "teach", "teacher" to "teach",
-        "teachers" to "teach", "taught" to "teach",
-        "studying" to "study", "studies" to "study",
-        "studied" to "study", "tutorials" to "tutorial",
-        "making" to "make", "maker" to "make", "makers" to "make",
-        "makes" to "make", "made" to "make",
-        "reviewing" to "review", "reviewed" to "review",
-        "reviews" to "review", "reviewer" to "review",
-        "testing" to "test", "tested" to "test", "tests" to "test",
-        "tester" to "test",
-        "editing" to "edit", "edited" to "edit", "edits" to "edit",
-        "editor" to "edit",
-        "traveling" to "travel", "travelled" to "travel",
-        "travels" to "travel", "traveler" to "travel",
-        "vlogging" to "vlog", "vlogs" to "vlog", "vlogger" to "vlog",
-        "vloggers" to "vlog",
-        "reactions" to "reaction",
-        "compilations" to "compilation",
-        // Science
-        "experiments" to "experiment", "experimenting" to "experiment",
-        "experimental" to "experiment",
-        "sciences" to "science", "scientific" to "science",
-        "scientist" to "science",
-        "engineering" to "engineer", "engineered" to "engineer",
-        "engineers" to "engineer",
-        "inventions" to "invention", "inventing" to "invention",
-        "invented" to "invention",
-        // Nature
-        "animals" to "animal",
-        // Lifestyle
-        "recipes" to "recipe", "baking" to "bake", "baked" to "bake",
-        "baker" to "bake",
-        "gardening" to "garden", "gardens" to "garden",
-        "photographing" to "photography",
-        "photographs" to "photography",
-        "photographer" to "photography",
-        // Common verbs
-        "explained" to "explain", "explains" to "explain",
-        "explaining" to "explain",
-        "created" to "create", "creates" to "create",
-        "creating" to "create", "creator" to "create",
-        "creators" to "create",
-        "discovered" to "discover", "discovers" to "discover",
-        "discovering" to "discover",
-        "exploring" to "explore", "explored" to "explore",
-        "explores" to "explore",
-        "comparing" to "compare", "compared" to "compare",
-        "compares" to "compare", "comparison" to "compare",
-        "comparisons" to "compare",
-        // Plurals
-        "videos" to "video", "channels" to "channel",
-        "episodes" to "episode",
-        "movies" to "movie", "documentaries" to "documentary",
-        "podcasts" to "podcast", "interviews" to "interview",
-        "challenges" to "challenge",
-        "montages" to "montage"
-    )
+    private val lemmaMap =
+        mapOf(
+            // Gaming
+            "gaming" to "game",
+            "games" to "game",
+            "gamer" to "game",
+            "gamers" to "game",
+            "gameplay" to "game",
+            "gamed" to "game",
+            // Coding / Programming
+            "coding" to "code",
+            "coder" to "code",
+            "coders" to "code",
+            "codes" to "code",
+            "coded" to "code",
+            "programming" to "program",
+            "programmer" to "program",
+            "programmers" to "program",
+            "programs" to "program",
+            "programmed" to "program",
+            // Cooking
+            "cooking" to "cook",
+            "cooked" to "cook",
+            "cooks" to "cook",
+            "cooker" to "cook",
+            // Music
+            "songs" to "song",
+            "singing" to "sing",
+            "singer" to "sing",
+            "singers" to "sing",
+            "musics" to "music",
+            "musical" to "music",
+            "musician" to "music",
+            "musicians" to "music",
+            // Technology
+            "technologies" to "technology",
+            "technological" to "technology",
+            "computers" to "computer",
+            "computing" to "computer",
+            "computed" to "computer",
+            // Art
+            "drawing" to "draw",
+            "drawings" to "draw",
+            "drawn" to "draw",
+            "painting" to "paint",
+            "paintings" to "paint",
+            "painted" to "paint",
+            "painter" to "paint",
+            "animating" to "animation",
+            "animated" to "animation",
+            "animations" to "animation",
+            "animator" to "animation",
+            // Fitness
+            "workouts" to "workout",
+            "exercising" to "exercise",
+            "exercises" to "exercise",
+            "exercised" to "exercise",
+            "learning" to "learn",
+            "learned" to "learn",
+            "learner" to "learn",
+            "learners" to "learn",
+            "teaching" to "teach",
+            "teacher" to "teach",
+            "teachers" to "teach",
+            "taught" to "teach",
+            "studying" to "study",
+            "studies" to "study",
+            "studied" to "study",
+            "tutorials" to "tutorial",
+            "making" to "make",
+            "maker" to "make",
+            "makers" to "make",
+            "makes" to "make",
+            "made" to "make",
+            "reviewing" to "review",
+            "reviewed" to "review",
+            "reviews" to "review",
+            "reviewer" to "review",
+            "testing" to "test",
+            "tested" to "test",
+            "tests" to "test",
+            "tester" to "test",
+            "editing" to "edit",
+            "edited" to "edit",
+            "edits" to "edit",
+            "editor" to "edit",
+            "traveling" to "travel",
+            "travelled" to "travel",
+            "travels" to "travel",
+            "traveler" to "travel",
+            "vlogging" to "vlog",
+            "vlogs" to "vlog",
+            "vlogger" to "vlog",
+            "vloggers" to "vlog",
+            "reactions" to "reaction",
+            "compilations" to "compilation",
+            // Science
+            "experiments" to "experiment",
+            "experimenting" to "experiment",
+            "experimental" to "experiment",
+            "sciences" to "science",
+            "scientific" to "science",
+            "scientist" to "science",
+            "engineering" to "engineer",
+            "engineered" to "engineer",
+            "engineers" to "engineer",
+            "inventions" to "invention",
+            "inventing" to "invention",
+            "invented" to "invention",
+            // Nature
+            "animals" to "animal",
+            // Lifestyle
+            "recipes" to "recipe",
+            "baking" to "bake",
+            "baked" to "bake",
+            "baker" to "bake",
+            "gardening" to "garden",
+            "gardens" to "garden",
+            "photographing" to "photography",
+            "photographs" to "photography",
+            "photographer" to "photography",
+            // Common verbs
+            "explained" to "explain",
+            "explains" to "explain",
+            "explaining" to "explain",
+            "created" to "create",
+            "creates" to "create",
+            "creating" to "create",
+            "creator" to "create",
+            "creators" to "create",
+            "discovered" to "discover",
+            "discovers" to "discover",
+            "discovering" to "discover",
+            "exploring" to "explore",
+            "explored" to "explore",
+            "explores" to "explore",
+            "comparing" to "compare",
+            "compared" to "compare",
+            "compares" to "compare",
+            "comparison" to "compare",
+            "comparisons" to "compare",
+            // Plurals
+            "videos" to "video",
+            "channels" to "channel",
+            "episodes" to "episode",
+            "movies" to "movie",
+            "documentaries" to "documentary",
+            "podcasts" to "podcast",
+            "interviews" to "interview",
+            "challenges" to "challenge",
+            "montages" to "montage",
+        )
 
     // ── Stop Words ──
 
-    private val STOP_WORDS = hashSetOf(
-        // Grammatical
-        "the", "and", "for", "that", "this", "with", "you", "how",
-        "what", "when", "mom", "types", "your", "which", "can",
-        "make", "seen", "most", "into", "best", "from", "just",
-        "about", "more", "some", "will", "one", "all", "would",
-        "there", "their", "out", "not", "but", "have", "has",
-        "been", "being", "was", "were", "are",
-        // YouTube meta
-        "video", "official", "channel", "review", "reaction",
-        "full", "episode", "part", "new", "latest", "update",
-        "hdr", "uhd", "fps", "live", "stream",
-        "watch", "subscribe", "like", "comment",
-        "share", "click", "link", "description", "below", "check",
-        "dont", "miss", "must", "now",
-        // Resolution tags
-        "1080p", "720p", "480p", "360p", "240p", "144p",
-        // Lemma-consistent
-        "compilation", "montage",
-        "reupload", "reup", "reuploaded",
-        // Format / meta descriptors
-        "guide", "tutorial", "tips", "tricks", "hack", "hacks",
-        "lesson", "course", "class", "session", "step", "steps",
-        "ways", "things", "stuff", "beginner", "beginners",
-        "advanced", "intermediate", "basic", "basics",
-        "introduction", "intro", "everything", "anything",
-        "nothing", "something", "complete", "ultimate",
-        "definitive", "easy", "simple", "hard", "difficult",
-        "free", "paid", "cheap", "expensive",
-        "first", "last", "next", "previous",
-        // AI / prompt meta-words
-        "prompt", "prompts", "prompting",
-        // YouTube engagement bait
-        "amazing", "insane", "crazy", "incredible",
-        "unbelievable", "shocking", "exposed", "revealed",
-        "secret", "secrets", "honest", "truth", "proof", "finally",
-        // High-frequency verbs with no topic meaning
-        "use", "used", "using", "need", "want", "know",
-        "help", "find", "look", "looking", "get", "got", "getting",
-        "give", "gave", "keep", "kept", "tell", "told", "say", "said",
-        "start", "stop", "try", "take", "took",
-        // Filler adverbs / discourse fillers
-        "really", "actually", "literally", "basically",
-        "ever", "never", "always", "every",
-        "still", "also", "too", "very", "only",
-        "then", "than", "well", "even"
-    )
+    private val stopWords =
+        hashSetOf(
+            // Grammatical
+            "the",
+            "and",
+            "for",
+            "that",
+            "this",
+            "with",
+            "you",
+            "how",
+            "what",
+            "when",
+            "mom",
+            "types",
+            "your",
+            "which",
+            "can",
+            "make",
+            "seen",
+            "most",
+            "into",
+            "best",
+            "from",
+            "just",
+            "about",
+            "more",
+            "some",
+            "will",
+            "one",
+            "all",
+            "would",
+            "there",
+            "their",
+            "out",
+            "not",
+            "but",
+            "have",
+            "has",
+            "been",
+            "being",
+            "was",
+            "were",
+            "are",
+            // YouTube meta
+            "video",
+            "official",
+            "channel",
+            "review",
+            "reaction",
+            "full",
+            "episode",
+            "part",
+            "new",
+            "latest",
+            "update",
+            "hdr",
+            "uhd",
+            "fps",
+            "live",
+            "stream",
+            "watch",
+            "subscribe",
+            "like",
+            "comment",
+            "share",
+            "click",
+            "link",
+            "description",
+            "below",
+            "check",
+            "dont",
+            "miss",
+            "must",
+            "now",
+            // Resolution tags
+            "1080p",
+            "720p",
+            "480p",
+            "360p",
+            "240p",
+            "144p",
+            // Lemma-consistent
+            "compilation",
+            "montage",
+            "reupload",
+            "reup",
+            "reuploaded",
+            // Format / meta descriptors
+            "guide",
+            "tutorial",
+            "tips",
+            "tricks",
+            "hack",
+            "hacks",
+            "lesson",
+            "course",
+            "class",
+            "session",
+            "step",
+            "steps",
+            "ways",
+            "things",
+            "stuff",
+            "beginner",
+            "beginners",
+            "advanced",
+            "intermediate",
+            "basic",
+            "basics",
+            "introduction",
+            "intro",
+            "everything",
+            "anything",
+            "nothing",
+            "something",
+            "complete",
+            "ultimate",
+            "definitive",
+            "easy",
+            "simple",
+            "hard",
+            "difficult",
+            "free",
+            "paid",
+            "cheap",
+            "expensive",
+            "first",
+            "last",
+            "next",
+            "previous",
+            // AI / prompt meta-words
+            "prompt",
+            "prompts",
+            "prompting",
+            // YouTube engagement bait
+            "amazing",
+            "insane",
+            "crazy",
+            "incredible",
+            "unbelievable",
+            "shocking",
+            "exposed",
+            "revealed",
+            "secret",
+            "secrets",
+            "honest",
+            "truth",
+            "proof",
+            "finally",
+            // High-frequency verbs with no topic meaning
+            "use",
+            "used",
+            "using",
+            "need",
+            "want",
+            "know",
+            "help",
+            "find",
+            "look",
+            "looking",
+            "get",
+            "got",
+            "getting",
+            "give",
+            "gave",
+            "keep",
+            "kept",
+            "tell",
+            "told",
+            "say",
+            "said",
+            "start",
+            "stop",
+            "try",
+            "take",
+            "took",
+            // Filler adverbs / discourse fillers
+            "really",
+            "actually",
+            "literally",
+            "basically",
+            "ever",
+            "never",
+            "always",
+            "every",
+            "still",
+            "also",
+            "too",
+            "very",
+            "only",
+            "then",
+            "than",
+            "well",
+            "even",
+        )
 
     // ── Tag Spam Filter ──
 
-    private val TAG_SPAM_WORDS = hashSetOf(
-        // Creator/platform names used as SEO bait
-        "mrbeast", "pewdiepie", "markiplier", "jacksepticeye",
-        "dream", "tommyinnit", "pokimane", "ninja",
-        // Broad SEO spam
-        "viral", "trending", "fyp", "foryou", "foryoupage",
-        "like", "subscribe", "comment", "share",
-        "free", "giveaway", "win",
-        // Platform names
-        "youtube", "tiktok", "instagram", "twitter", "twitch",
-        "shorts", "reels", "stories",
-        // Generic engagement bait
-        "funny", "amazing", "insane", "crazy", "incredible",
-        "satisfying", "oddly satisfying",
-        "gone wrong", "not clickbait", "must watch",
-        "you wont believe", "emotional"
-    )
+    private val tagSpamWords =
+        hashSetOf(
+            // Creator/platform names used as SEO bait
+            "mrbeast",
+            "pewdiepie",
+            "markiplier",
+            "jacksepticeye",
+            "dream",
+            "tommyinnit",
+            "pokimane",
+            "ninja",
+            // Broad SEO spam
+            "viral",
+            "trending",
+            "fyp",
+            "foryou",
+            "foryoupage",
+            "like",
+            "subscribe",
+            "comment",
+            "share",
+            "free",
+            "giveaway",
+            "win",
+            // Platform names
+            "youtube",
+            "tiktok",
+            "instagram",
+            "twitter",
+            "twitch",
+            "shorts",
+            "reels",
+            "stories",
+            // Generic engagement bait
+            "funny",
+            "amazing",
+            "insane",
+            "crazy",
+            "incredible",
+            "satisfying",
+            "oddly satisfying",
+            "gone wrong",
+            "not clickbait",
+            "must watch",
+            "you wont believe",
+            "emotional",
+        )
 
     // ── Polysemy Data ──
 
-    val POLYSEMOUS_WORDS = hashSetOf(
-        "train", "model", "build", "plant", "stream",
-        "react", "design", "film", "run", "play",
-        "cook", "fire", "spring", "match", "cell",
-        "power", "drive", "board", "frame", "scale",
-        "lead", "light", "block", "drop", "track",
-        "craft", "host", "mine", "pitch", "wave",
-        "bass", "bow", "clip", "dart", "fan",
-        "gear", "jam", "kit", "lab", "log",
-        "net", "pad", "port", "rig", "set",
-        "tap", "tip", "web",
-        // Music genres / material / nature terms with multiple meanings
-        "metal", "rock", "bar"
-    )
+    val polysemousWords =
+        hashSetOf(
+            "train",
+            "model",
+            "build",
+            "plant",
+            "stream",
+            "react",
+            "design",
+            "film",
+            "run",
+            "play",
+            "cook",
+            "fire",
+            "spring",
+            "match",
+            "cell",
+            "power",
+            "drive",
+            "board",
+            "frame",
+            "scale",
+            "lead",
+            "light",
+            "block",
+            "drop",
+            "track",
+            "craft",
+            "host",
+            "mine",
+            "pitch",
+            "wave",
+            "bass",
+            "bow",
+            "clip",
+            "dart",
+            "fan",
+            "gear",
+            "jam",
+            "kit",
+            "lab",
+            "log",
+            "net",
+            "pad",
+            "port",
+            "rig",
+            "set",
+            "tap",
+            "tip",
+            "web",
+            // Music genres / material / nature terms with multiple meanings
+            "metal",
+            "rock",
+            "bar",
+        )
 
-    val COMPOUND_TERMS = hashSetOf(
-        // AI/ML
-        "train model", "train ai", "machine learn",
-        "deep learn", "neural network", "train data",
-        "fine tune", "train network", "train system",
-        "build model", "build ai", "build network",
-        "model train", "model ai", "model build",
-        // Programming
-        "react native", "react component", "react hook",
-        "react app", "react tutorial", "react project",
-        "build system", "build tool", "build project",
-        "run test", "run code", "run server", "run script",
-        "design pattern", "design system", "web design",
-        "game design", "sound design",
-        // Specific disambiguations
-        "power plant", "plant base", "plant based",
-        "fire base", "fire wall", "fire fight",
-        "spring boot", "spring framework", "spring board",
-        "stream deck", "stream lab", "stream setup",
-        "film make", "film edit", "film score",
-        "scale model",
-        "block chain", "block list",
-        "host server", "host name",
-        "web development", "web app", "web site",
-        "net work", "net worth",
-        // Music disambiguations
-        "bass guitar", "bass boost", "bass drop",
-        "drum track", "sound track", "race track",
-        // Gaming
-        "speed run", "play through",
-        "build guide", "build order",
-        "craft recipe", "mine craft"
-    )
+    val compoundTerms =
+        hashSetOf(
+            // AI/ML
+            "train model",
+            "train ai",
+            "machine learn",
+            "deep learn",
+            "neural network",
+            "train data",
+            "fine tune",
+            "train network",
+            "train system",
+            "build model",
+            "build ai",
+            "build network",
+            "model train",
+            "model ai",
+            "model build",
+            // Programming
+            "react native",
+            "react component",
+            "react hook",
+            "react app",
+            "react tutorial",
+            "react project",
+            "build system",
+            "build tool",
+            "build project",
+            "run test",
+            "run code",
+            "run server",
+            "run script",
+            "design pattern",
+            "design system",
+            "web design",
+            "game design",
+            "sound design",
+            // Specific disambiguations
+            "power plant",
+            "plant base",
+            "plant based",
+            "fire base",
+            "fire wall",
+            "fire fight",
+            "spring boot",
+            "spring framework",
+            "spring board",
+            "stream deck",
+            "stream lab",
+            "stream setup",
+            "film make",
+            "film edit",
+            "film score",
+            "scale model",
+            "block chain",
+            "block list",
+            "host server",
+            "host name",
+            "web development",
+            "web app",
+            "web site",
+            "net work",
+            "net worth",
+            // Music disambiguations
+            "bass guitar",
+            "bass boost",
+            "bass drop",
+            "drum track",
+            "sound track",
+            "race track",
+            // Gaming
+            "speed run",
+            "play through",
+            "build guide",
+            "build order",
+            "craft recipe",
+            "mine craft",
+        )
 
-    val SPONSOR_LINE_PATTERNS = listOf(
-        "use code ", "% off", "free trial", "link in",
-        "sponsored by", "brought to you", "check out",
-        "sign up", "discount", "promo code", "coupon",
-        "affiliate", "partner", "merch", "merchandise",
-        "patreon", "ko-fi", "buymeacoffee", "buy me a coffee",
-        "subscribe", "follow me", "social media",
-        "instagram", "twitter", "tiktok", "discord",
-        "join the", "become a member", "membership",
-        "business inquiries", "business email", "contact:",
-        "►", "→", "⬇", "⇩", "👇",
-        "timestamps:", "chapters:"
-    )
+    val sponsorLinePatterns =
+        listOf(
+            "use code ",
+            "% off",
+            "free trial",
+            "link in",
+            "sponsored by",
+            "brought to you",
+            "check out",
+            "sign up",
+            "discount",
+            "promo code",
+            "coupon",
+            "affiliate",
+            "partner",
+            "merch",
+            "merchandise",
+            "patreon",
+            "ko-fi",
+            "buymeacoffee",
+            "buy me a coffee",
+            "subscribe",
+            "follow me",
+            "social media",
+            "instagram",
+            "twitter",
+            "tiktok",
+            "discord",
+            "join the",
+            "become a member",
+            "membership",
+            "business inquiries",
+            "business email",
+            "contact:",
+            "►",
+            "→",
+            "⬇",
+            "⇩",
+            "👇",
+            "timestamps:",
+            "chapters:",
+        )
 
     // ── Pacing Keywords ──
 
-    val HIGH_PACING_WORDS = setOf(
-        "compilation", "tiktok", "tiktoks", "highlights",
-        "speedrun", "trailer", "shorts", "montage", "moments",
-        "best of", "try not to", "memes", "funny", "fails",
-        "rapid", "fast", "quick", "minute", "seconds",
-        "top 10", "top 5", "ranked", "tier list", "versus"
-    )
+    val highPacingWords =
+        setOf(
+            "compilation",
+            "tiktok",
+            "tiktoks",
+            "highlights",
+            "speedrun",
+            "trailer",
+            "shorts",
+            "montage",
+            "moments",
+            "best of",
+            "try not to",
+            "memes",
+            "funny",
+            "fails",
+            "rapid",
+            "fast",
+            "quick",
+            "minute",
+            "seconds",
+            "top 10",
+            "top 5",
+            "ranked",
+            "tier list",
+            "versus",
+        )
 
-    val LOW_PACING_WORDS = setOf(
-        "podcast", "essay", "ambient", "explained", "study",
-        "meditation", "sleep", "asmr", "relaxing", "calm",
-        "deep dive", "analysis", "lecture", "course",
-        "documentary", "interview", "conversation",
-        "discussion", "breakdown", "walkthrough"
-    )
-
-    // ── Music Keywords ──
-
-    val MUSIC_KEYWORDS = setOf(
-        "music", "song", "lyrics", "remix", "lofi", "lo-fi",
-        "playlist", "official audio", "official video",
-        "music video", "feat", "ft.", "acoustic", "cover",
-        "karaoke", "instrumental", "beat", "rap", "hip hop",
-        "pop", "rock", "jazz", "classical", "edm", "mix"
-    )
+    val lowPacingWords =
+        setOf(
+            "podcast",
+            "essay",
+            "ambient",
+            "explained",
+            "study",
+            "meditation",
+            "sleep",
+            "asmr",
+            "relaxing",
+            "calm",
+            "deep dive",
+            "analysis",
+            "lecture",
+            "course",
+            "documentary",
+            "interview",
+            "conversation",
+            "discussion",
+            "breakdown",
+            "walkthrough",
+        )
 
     // ── Functions ──
 
-    fun normalizeLemma(word: String): String =
-        LEMMA_MAP[word.lowercase()] ?: word.lowercase()
+    fun normalizeLemma(word: String): String = lemmaMap[word.lowercase()] ?: word.lowercase()
 
-    fun tokenize(text: String): List<String> {
-        return text.lowercase()
+    fun tokenize(text: String): List<String> =
+        text
+            .lowercase()
             .split(WHITESPACE_REGEX)
             .map { word -> word.trim { !it.isLetterOrDigit() } }
             .filter { it.length > 2 }
             .map { normalizeLemma(it) }
-            .filter { !STOP_WORDS.contains(it) && !YEAR_TAG_REGEX.matches(it) }
-    }
+            .filter { !stopWords.contains(it) && !YEAR_TAG_REGEX.matches(it) }
 
-    fun tokenizeForSimilarity(text: String): Set<String> {
-        return tokenize(text).toSet()
-    }
+    fun tokenizeForSimilarity(text: String): Set<String> = tokenize(text).toSet()
 
     fun calculateIdfWeight(
         word: String,
         baseWeight: Double,
-        idfSnapshot: IdfSnapshot
+        idfSnapshot: IdfSnapshot,
     ): Double {
         if (idfSnapshot.totalDocs < IDF_COLD_START_DOCS) return baseWeight
 
@@ -351,7 +730,7 @@ internal class NeuroTokenizer {
     fun extractFeatures(
         video: Video,
         idfSnapshot: IdfSnapshot,
-        channelTopicProfile: Map<String, Double>? = null
+        channelTopicProfile: Map<String, Double>? = null,
     ): ContentVector {
         val topics = mutableMapOf<String, Double>()
 
@@ -375,23 +754,30 @@ internal class NeuroTokenizer {
             for (i in 0 until titleWords.size - 1) {
                 val bigram = "${titleWords[i]} ${titleWords[i + 1]}"
 
-                val isMeaningful = COMPOUND_TERMS.contains(bigram) ||
-                    POLYSEMOUS_WORDS.contains(titleWords[i]) ||
-                    POLYSEMOUS_WORDS.contains(titleWords[i + 1]) ||
-                    // Also treat domain-disambiguable words as meaningful for bigram protection
-                    titleWords[i] in DOMAIN_DISAMBIGUATION ||
-                    titleWords[i + 1] in DOMAIN_DISAMBIGUATION
+                val isMeaningful =
+                    compoundTerms.contains(bigram) ||
+                        polysemousWords.contains(titleWords[i]) ||
+                        polysemousWords.contains(titleWords[i + 1]) ||
+                        // Also treat domain-disambiguable words as meaningful for bigram protection
+                        titleWords[i] in domainDisambiguation ||
+                        titleWords[i + 1] in domainDisambiguation
 
                 if (isMeaningful) {
-                    topics[bigram] = calculateIdfWeight(
-                        bigram, BIGRAM_PRIORITY_WEIGHT, idfSnapshot
-                    )
+                    topics[bigram] =
+                        calculateIdfWeight(
+                            bigram,
+                            BIGRAM_PRIORITY_WEIGHT,
+                            idfSnapshot,
+                        )
                     claimedByBigram.add(i)
                     claimedByBigram.add(i + 1)
                 } else {
-                    topics[bigram] = calculateIdfWeight(
-                        bigram, BIGRAM_WEIGHT, idfSnapshot
-                    )
+                    topics[bigram] =
+                        calculateIdfWeight(
+                            bigram,
+                            BIGRAM_WEIGHT,
+                            idfSnapshot,
+                        )
                 }
             }
         }
@@ -400,42 +786,57 @@ internal class NeuroTokenizer {
         titleWords.forEachIndexed { index, word ->
             if (index !in claimedByBigram) {
                 // Domain-disambiguate polysemous words using full title+description context
-                val resolvedWord = if (word in DOMAIN_DISAMBIGUATION) {
-                    disambiguateWord(word, fullContext)
-                } else {
-                    word
-                }
-                topics[resolvedWord] = (topics.getOrDefault(resolvedWord, 0.0) +
-                    calculateIdfWeight(resolvedWord, TITLE_KEYWORD_WEIGHT, idfSnapshot))
+                val resolvedWord =
+                    if (word in domainDisambiguation) {
+                        disambiguateWord(word, fullContext)
+                    } else {
+                        word
+                    }
+                topics[resolvedWord] = (
+                    topics.getOrDefault(resolvedWord, 0.0) +
+                        calculateIdfWeight(resolvedWord, TITLE_KEYWORD_WEIGHT, idfSnapshot)
+                )
             }
         }
 
         // ── V9.3 Fix 5: Smart description extraction ──
-        val descriptionTopics = extractDescriptionKeywords(
-            video.description, idfSnapshot
-        )
+        val descriptionTopics =
+            extractDescriptionKeywords(
+                video.description,
+                idfSnapshot,
+            )
         descriptionTopics.forEach { (word, weight) ->
             // Also disambiguate description words using the same full context
-            val resolved = if (word in DOMAIN_DISAMBIGUATION) {
-                disambiguateWord(word, fullContext)
-            } else {
-                word
-            }
+            val resolved =
+                if (word in domainDisambiguation) {
+                    disambiguateWord(word, fullContext)
+                } else {
+                    word
+                }
             topics[resolved] = (topics.getOrDefault(resolved, 0.0) + weight)
         }
 
         // ── Tag Processing ──
         if (video.tags.isNotEmpty()) {
-            val descWords = if (!video.description.isNullOrBlank()) {
-                tokenize(
-                    video.description.lines().take(DESCRIPTION_TAKE_LINES)
-                        .joinToString(" ")
-                )
-            } else emptyList()
+            val descWords =
+                if (!video.description.isNullOrBlank()) {
+                    tokenize(
+                        video.description
+                            .lines()
+                            .take(DESCRIPTION_TAKE_LINES)
+                            .joinToString(" "),
+                    )
+                } else {
+                    emptyList()
+                }
 
-            val tagTopics = processTags(
-                video.tags, titleWords, descWords, idfSnapshot
-            )
+            val tagTopics =
+                processTags(
+                    video.tags,
+                    titleWords,
+                    descWords,
+                    idfSnapshot,
+                )
             tagTopics.forEach { (word, weight) ->
                 topics[word] = (topics[word] ?: 0.0) + weight
             }
@@ -454,99 +855,141 @@ internal class NeuroTokenizer {
         }
 
         // Normalize topic vector
-        val normalized = if (topics.isNotEmpty()) {
-            var magnitude = 0.0
-            topics.values.forEach { magnitude += it * it }
-            magnitude = sqrt(magnitude)
-            if (magnitude > 0) topics.mapValues { (_, v) -> v / magnitude }
-            else topics
-        } else topics
-
-        val durationSec = when {
-            video.duration > 0 -> video.duration
-            video.isLive -> 3600
-            else -> 300
-        }
-        val durationScore = (ln(1.0 + durationSec) /
-            ln(1.0 + 7200.0)).coerceIn(0.0, 1.0)
-
-        val pacingScore = run {
-            val titleLower = video.title.lowercase()
-
-            val highCount = HIGH_PACING_WORDS.count {
-                titleLower.contains(it)
-            }
-            val lowCount = LOW_PACING_WORDS.count {
-                titleLower.contains(it)
+        val normalized =
+            if (topics.isNotEmpty()) {
+                var magnitude = 0.0
+                topics.values.forEach { magnitude += it * it }
+                magnitude = sqrt(magnitude)
+                if (magnitude > 0) {
+                    topics.mapValues { (_, v) -> v / magnitude }
+                } else {
+                    topics
+                }
+            } else {
+                topics
             }
 
+        val durationSec =
             when {
-                highCount > lowCount -> (0.6 + highCount * 0.1)
-                    .coerceAtMost(0.95)
-                lowCount > highCount -> (0.4 - lowCount * 0.1)
-                    .coerceAtLeast(0.05)
-                video.isShort -> 0.85
-                else -> 0.5
+                video.duration > 0 -> video.duration
+                video.isLive -> 3600
+                else -> 300
             }
-        }
+        val durationScore =
+            (
+                ln(1.0 + durationSec) /
+                    ln(1.0 + 7200.0)
+            ).coerceIn(0.0, 1.0)
+
+        val pacingScore =
+            run {
+                val titleLower = video.title.lowercase()
+
+                val highCount =
+                    highPacingWords.count {
+                        titleLower.contains(it)
+                    }
+                val lowCount =
+                    lowPacingWords.count {
+                        titleLower.contains(it)
+                    }
+
+                when {
+                    highCount > lowCount -> {
+                        (0.6 + highCount * 0.1)
+                            .coerceAtMost(0.95)
+                    }
+
+                    lowCount > highCount -> {
+                        (0.4 - lowCount * 0.1)
+                            .coerceAtLeast(0.05)
+                    }
+
+                    video.isShort -> {
+                        0.85
+                    }
+
+                    else -> {
+                        0.5
+                    }
+                }
+            }
 
         val description = video.description
-        val hasChapters = if (!description.isNullOrBlank()) {
-            TIMESTAMP_PATTERN.findAll(description).count() >= CHAPTER_TIMESTAMP_MIN
-        } else false
+        val hasChapters =
+            if (!description.isNullOrBlank()) {
+                TIMESTAMP_PATTERN.findAll(description).count() >= CHAPTER_TIMESTAMP_MIN
+            } else {
+                false
+            }
 
-        val rawTitleWords = video.title.split(WHITESPACE_REGEX)
-            .filter { it.length > 1 }
+        val rawTitleWords =
+            video.title
+                .split(WHITESPACE_REGEX)
+                .filter { it.length > 1 }
 
-        val complexityScore = run {
-            val titleLenFactor = (video.title.length /
-                COMPLEXITY_TITLE_LEN_MAX).coerceIn(0.0, COMPLEXITY_TITLE_LEN_WEIGHT)
-            val avgWordLen = if (rawTitleWords.isNotEmpty()) {
-                rawTitleWords.map { it.length }.average()
-            } else 4.0
-            val wordLenFactor = (avgWordLen /
-                COMPLEXITY_WORD_LEN_DIVISOR).coerceIn(0.0, COMPLEXITY_WORD_LEN_WEIGHT)
-            val chapterBonus = if (hasChapters) COMPLEXITY_CHAPTER_BONUS else 0.0
-            (titleLenFactor + wordLenFactor + chapterBonus)
-                .coerceIn(0.0, 1.0)
-        }
+        val complexityScore =
+            run {
+                val titleLenFactor =
+                    (
+                        video.title.length /
+                            COMPLEXITY_TITLE_LEN_MAX
+                    ).coerceIn(0.0, COMPLEXITY_TITLE_LEN_WEIGHT)
+                val avgWordLen =
+                    if (rawTitleWords.isNotEmpty()) {
+                        rawTitleWords.map { it.length }.average()
+                    } else {
+                        4.0
+                    }
+                val wordLenFactor =
+                    (
+                        avgWordLen /
+                            COMPLEXITY_WORD_LEN_DIVISOR
+                    ).coerceIn(0.0, COMPLEXITY_WORD_LEN_WEIGHT)
+                val chapterBonus = if (hasChapters) COMPLEXITY_CHAPTER_BONUS else 0.0
+                (titleLenFactor + wordLenFactor + chapterBonus)
+                    .coerceIn(0.0, 1.0)
+            }
 
         return ContentVector(
             topics = normalized,
             duration = durationScore,
             pacing = pacingScore,
             complexity = complexityScore,
-            isLive = if (video.isLive) 1.0 else 0.0
+            isLive = if (video.isLive) 1.0 else 0.0,
         )
     }
 
     fun extractDescriptionKeywords(
         description: String?,
-        idfSnapshot: IdfSnapshot
+        idfSnapshot: IdfSnapshot,
     ): Map<String, Double> {
         if (description.isNullOrBlank() || description.length < DESCRIPTION_MIN_LENGTH) {
             return emptyMap()
         }
 
-        val contentLines = description.lines()
-            .filter { line ->
-                val lower = line.lowercase().trim()
-                line.trim().length > DESCRIPTION_LINE_MIN_LENGTH &&
-                !SPONSOR_LINE_PATTERNS.any { pattern -> lower.contains(pattern) } &&
-                !lower.contains("http") &&
-                !lower.trimStart().startsWith("#") &&
-                !(line.trim().length > 5 && line.trim() == line.trim().uppercase())
-            }
-            .take(DESCRIPTION_TAKE_LINES)
-            .joinToString(" ")
+        val contentLines =
+            description
+                .lines()
+                .filter { line ->
+                    val lower = line.lowercase().trim()
+                    line.trim().length > DESCRIPTION_LINE_MIN_LENGTH &&
+                        !sponsorLinePatterns.any { pattern -> lower.contains(pattern) } &&
+                        !lower.contains("http") &&
+                        !lower.trimStart().startsWith("#") &&
+                        !(line.trim().length > 5 && line.trim() == line.trim().uppercase())
+                }.take(DESCRIPTION_TAKE_LINES)
+                .joinToString(" ")
 
         if (contentLines.isBlank()) return emptyMap()
 
         val words = tokenize(contentLines).take(DESCRIPTION_TAKE_WORDS)
         val result = mutableMapOf<String, Double>()
         words.forEach { word ->
-            result[word] = (result.getOrDefault(word, 0.0) +
-                calculateIdfWeight(word, DESCRIPTION_WORD_WEIGHT, idfSnapshot))
+            result[word] = (
+                result.getOrDefault(word, 0.0) +
+                    calculateIdfWeight(word, DESCRIPTION_WORD_WEIGHT, idfSnapshot)
+            )
         }
         return result
     }
@@ -563,7 +1006,7 @@ internal class NeuroTokenizer {
         tags: List<String>,
         titleWords: List<String>,
         descriptionWords: List<String>,
-        idfSnapshot: IdfSnapshot
+        idfSnapshot: IdfSnapshot,
     ): Map<String, Double> {
         if (tags.isEmpty()) return emptyMap()
 
@@ -571,12 +1014,14 @@ internal class NeuroTokenizer {
 
         val verificationSet = (titleWords + descriptionWords).toHashSet()
 
-        val tagContextWords = tags.take(TAG_MAX_INGEST).flatMap { t ->
-            t.lowercase()
-                .split(WHITESPACE_REGEX)
-                .map { it.trim { c -> !c.isLetterOrDigit() } }
-                .filter { it.length > 1 }
-        }
+        val tagContextWords =
+            tags.take(TAG_MAX_INGEST).flatMap { t ->
+                t
+                    .lowercase()
+                    .split(WHITESPACE_REGEX)
+                    .map { it.trim { c -> !c.isLetterOrDigit() } }
+                    .filter { it.length > 1 }
+            }
         val fullDisambiguationContext = tagContextWords + titleWords + descriptionWords
 
         tags.take(TAG_MAX_INGEST).forEach { rawTag ->
@@ -584,10 +1029,12 @@ internal class NeuroTokenizer {
 
             if (cleaned.length < TAG_MIN_LENGTH ||
                 cleaned.length > TAG_MAX_LENGTH
-            ) return@forEach
+            ) {
+                return@forEach
+            }
 
-            if (cleaned in TAG_SPAM_WORDS) return@forEach
-            if (cleaned in STOP_WORDS) return@forEach
+            if (cleaned in tagSpamWords) return@forEach
+            if (cleaned in stopWords) return@forEach
             if (YEAR_TAG_REGEX.matches(cleaned)) return@forEach
 
             val tagTokens = tokenize(cleaned)
@@ -595,13 +1042,20 @@ internal class NeuroTokenizer {
 
             val isVerified = tagTokens.any { token -> token in verificationSet }
 
-            val baseWeight = if (isVerified) TAG_VERIFIED_WEIGHT
-            else TAG_UNVERIFIED_WEIGHT
+            val baseWeight =
+                if (isVerified) {
+                    TAG_VERIFIED_WEIGHT
+                } else {
+                    TAG_UNVERIFIED_WEIGHT
+                }
 
             tagTokens.forEach { token ->
-                val resolved = if (token in DOMAIN_DISAMBIGUATION) {
-                    disambiguateWord(token, fullDisambiguationContext)
-                } else token
+                val resolved =
+                    if (token in domainDisambiguation) {
+                        disambiguateWord(token, fullDisambiguationContext)
+                    } else {
+                        token
+                    }
 
                 val idfWeighted = calculateIdfWeight(resolved, baseWeight, idfSnapshot)
 
@@ -626,485 +1080,1182 @@ internal class NeuroTokenizer {
 
     private data class DomainContext(
         val domain: String,
-        val contextWords: Set<String>
+        val contextWords: Set<String>,
     )
 
-    private val DOMAIN_DISAMBIGUATION: Map<String, List<DomainContext>> = mapOf(
-        "metal" to listOf(
-            DomainContext(
-                domain = "music",
-                contextWords = setOf(
-                    "song", "band", "album", "music", "concert", "guitar",
-                    "drum", "vocal", "sing", "lyric", "playlist", "tour",
-                    "riff", "solo", "anthem", "heavy", "death", "black",
-                    "thrash", "power", "symphonic", "progressive", "doom",
-                    "genre", "metalcore", "deathcore", "djent", "cover",
-                    "react", "reaction", "review", "rank", "tier"
-                )
-            ),
-            DomainContext(
-                domain = "craft",
-                contextWords = setOf(
-                    "weld", "forge", "fabricat", "sheet", "steel", "iron",
-                    "aluminum", "copper", "brass", "tin", "alloy",
-                    "workshop", "tool", "cut", "bend", "grind", "polish",
-                    "cast", "mold", "anvil", "hammer", "lathe", "cnc",
-                    "machin", "work", "shop", "build", "construct"
-                )
-            )
-        ),
-        "rock" to listOf(
-            DomainContext(
-                domain = "music",
-                contextWords = setOf(
-                    "song", "band", "album", "music", "concert", "guitar",
-                    "drum", "vocal", "sing", "lyric", "playlist", "tour",
-                    "classic", "punk", "indie", "alternative", "grunge",
-                    "blues", "roll", "genre", "cover", "anthem",
-                    "react", "reaction", "review", "rank", "tier"
-                )
-            ),
-            DomainContext(
-                domain = "nature",
-                contextWords = setOf(
-                    "geology", "mineral", "stone", "fossil", "gem",
-                    "crystal", "boulder", "cliff", "mountain", "cave",
-                    "collect", "specimen", "earth", "volcanic", "sediment",
-                    "igneous", "metamorphic", "quarry", "dig", "formation"
-                )
-            ),
-            DomainContext(
-                domain = "climbing",
-                contextWords = setOf(
-                    "climb", "boulder", "wall", "route", "belay",
-                    "rope", "harness", "crag", "send", "flash",
-                    "dyno", "crimp", "sloper"
-                )
-            )
-        ),
-        "bass" to listOf(
-            DomainContext(
-                domain = "music",
-                contextWords = setOf(
-                    "guitar", "song", "music", "band", "play", "riff",
-                    "slap", "fretless", "amp", "pedal", "tone",
-                    "groove", "funk", "jazz", "solo", "lesson",
-                    "boost", "drop", "sub", "speaker", "audio",
-                    "headphone", "equalizer", "frequency", "woofer"
-                )
-            ),
-            DomainContext(
-                domain = "fishing",
-                contextWords = setOf(
-                    "fish", "fishing", "lure", "bait", "catch",
-                    "lake", "river", "pond", "boat", "rod",
-                    "reel", "tackle", "tournament", "largemouth",
-                    "smallmouth", "striped"
-                )
-            )
-        ),
-        "spring" to listOf(
-            DomainContext(
-                domain = "tech",
-                contextWords = setOf(
-                    "boot", "java", "framework", "api", "microservice",
-                    "backend", "server", "code", "program", "develop",
-                    "application", "deploy", "config", "bean", "inject"
-                )
-            ),
-            DomainContext(
-                domain = "season",
-                contextWords = setOf(
-                    "summer", "winter", "fall", "autumn", "season",
-                    "flower", "garden", "bloom", "clean", "outfit",
-                    "fashion", "weather", "april", "march", "may"
-                )
-            )
-        ),
-        "cell" to listOf(
-            DomainContext(
-                domain = "biology",
-                contextWords = setOf(
-                    "biology", "science", "membrane", "nucleus",
-                    "mitosis", "dna", "rna", "protein", "organism",
-                    "tissue", "bacteria", "virus", "microscope"
-                )
-            ),
-            DomainContext(
-                domain = "tech",
-                contextWords = setOf(
-                    "phone", "mobile", "battery", "charge", "signal",
-                    "carrier", "data", "plan", "network", "sim"
-                )
-            ),
-            DomainContext(
-                domain = "energy",
-                contextWords = setOf(
-                    "solar", "fuel", "battery", "power", "energy",
-                    "electric", "hydrogen", "lithium", "volt"
-                )
-            )
-        ),
-        "plant" to listOf(
-            DomainContext(
-                domain = "botany",
-                contextWords = setOf(
-                    "grow", "garden", "flower", "seed", "soil",
-                    "water", "pot", "leaf", "root", "tree",
-                    "herb", "indoor", "outdoor", "succulent", "cactus",
-                    "propagat", "prune", "fertiliz", "bloom"
-                )
-            ),
-            DomainContext(
-                domain = "industrial",
-                contextWords = setOf(
-                    "power", "factory", "nuclear", "chemical",
-                    "manufacturing", "industrial", "facility",
-                    "process", "production", "refinery"
-                )
-            )
-        ),
-        "pitch" to listOf(
-            DomainContext(
-                domain = "music",
-                contextWords = setOf(
-                    "sing", "vocal", "note", "tune", "perfect",
-                    "music", "tone", "frequency", "ear", "train"
-                )
-            ),
-            DomainContext(
-                domain = "business",
-                contextWords = setOf(
-                    "startup", "investor", "shark", "tank", "business",
-                    "company", "funding", "venture", "present",
-                    "elevator", "idea", "million"
-                )
-            ),
-            DomainContext(
-                domain = "sport",
-                contextWords = setOf(
-                    "baseball", "cricket", "throw", "ball", "strike",
-                    "mound", "pitcher", "fastball", "curve", "slider"
-                )
-            )
-        ),
-        "jam" to listOf(
-            DomainContext(
-                domain = "music",
-                contextWords = setOf(
-                    "guitar", "band", "music", "session", "play",
-                    "improvise", "solo", "groove", "funk", "blues",
-                    "live", "concert"
-                )
-            ),
-            DomainContext(
-                domain = "food",
-                contextWords = setOf(
-                    "recipe", "fruit", "strawberry", "preserve",
-                    "spread", "toast", "jar", "cook", "homemade",
-                    "sugar", "berry", "grape"
-                )
-            )
-        ),
-        "bar" to listOf(
-            DomainContext(
-                domain = "music",
-                contextWords = setOf(
-                    "beat", "measure", "rhythm", "rap", "flow",
-                    "lyric", "verse", "hook", "produce", "music"
-                )
-            ),
-            DomainContext(
-                domain = "fitness",
-                contextWords = setOf(
-                    "pull", "deadlift", "squat", "bench", "weight",
-                    "gym", "workout", "exercise", "lift", "olympic"
-                )
-            )
-        ),
-        "wave" to listOf(
-            DomainContext(
-                domain = "music",
-                contextWords = setOf(
-                    "synth", "new", "retro", "synthwave", "vaporwave",
-                    "music", "genre", "aesthetic", "80s", "electronic"
-                )
-            ),
-            DomainContext(
-                domain = "science",
-                contextWords = setOf(
-                    "ocean", "sound", "light", "electromagnetic",
-                    "frequency", "physics", "energy", "radio",
-                    "seismic", "tsunami", "surf"
-                )
-            ),
-            DomainContext(
-                domain = "hair",
-                contextWords = setOf(
-                    "hair", "style", "curl", "360", "brush",
-                    "barber", "durag", "pattern", "pomade"
-                )
-            )
-        ),
-        "track" to listOf(
-            DomainContext(
-                domain = "music",
-                contextWords = setOf(
-                    "song", "album", "music", "beat", "produce",
-                    "mix", "master", "record", "artist", "release",
-                    "single", "feature", "lyric", "audio"
-                )
-            ),
-            DomainContext(
-                domain = "sport",
-                contextWords = setOf(
-                    "race", "run", "lap", "sprint", "field",
-                    "athlete", "relay", "hurdle", "meter", "olympic",
-                    "nascar", "formula", "circuit", "drift"
-                )
-            )
-        ),
-        "model" to listOf(
-            DomainContext(
-                domain = "ai",
-                contextWords = setOf(
-                    "train", "machine", "learn", "neural", "network",
-                    "data", "predict", "gpt", "llm", "parameter",
-                    "fine", "tune", "inference", "deploy", "weight"
-                )
-            ),
-            DomainContext(
-                domain = "fashion",
-                contextWords = setOf(
-                    "fashion", "runway", "pose", "photo", "shoot",
-                    "agency", "walk", "beauty", "vogue", "style"
-                )
-            ),
-            DomainContext(
-                domain = "hobby",
-                contextWords = setOf(
-                    "scale", "kit", "miniature", "paint", "hobby",
-                    "plastic", "glue", "detail", "build", "aircraft",
-                    "tank", "ship", "car", "diorama", "warhammer"
-                )
-            )
-        ),
-        "stream" to listOf(
-            DomainContext(
-                domain = "live",
-                contextWords = setOf(
-                    "live", "twitch", "chat", "viewer", "sub",
-                    "donation", "game", "play", "broadcast", "obs",
-                    "overlay", "alert", "raid", "clip"
-                )
-            ),
-            DomainContext(
-                domain = "nature",
-                contextWords = setOf(
-                    "river", "water", "creek", "brook", "fish",
-                    "nature", "mountain", "hike", "forest", "flow",
-                    "waterfall", "trout"
-                )
-            ),
-            DomainContext(
-                domain = "tech",
-                contextWords = setOf(
-                    "data", "kafka", "process", "real-time", "event",
-                    "pipeline", "api", "java", "reactive", "buffer"
-                )
-            )
-        ),
-        "build" to listOf(
-            DomainContext(
-                domain = "gaming",
-                contextWords = setOf(
-                    "game", "character", "class", "loadout", "weapon",
-                    "armor", "skill", "spec", "talent", "meta",
-                    "tier", "rank", "guide", "fortnite", "minecraft"
-                )
-            ),
-            DomainContext(
-                domain = "pc",
-                contextWords = setOf(
-                    "pc", "computer", "gpu", "cpu", "ram", "ssd",
-                    "motherboard", "case", "cooling", "rgb", "setup",
-                    "benchmark", "gaming", "workstation", "budget"
-                )
-            ),
-            DomainContext(
-                domain = "construction",
-                contextWords = setOf(
-                    "house", "cabin", "shed", "deck", "fence",
-                    "wood", "concrete", "brick", "foundation",
-                    "roof", "wall", "frame", "diy", "workshop"
-                )
-            ),
-            DomainContext(
-                domain = "car",
-                contextWords = setOf(
-                    "car", "truck", "engine", "swap", "turbo",
-                    "exhaust", "suspension", "wheel", "tire",
-                    "drift", "race", "jdm", "sema", "custom",
-                    "restore", "project", "garage", "wrench"
-                )
-            )
-        ),
-        "scale" to listOf(
-            DomainContext(
-                domain = "music",
-                contextWords = setOf(
-                    "major", "minor", "note", "practice", "piano",
-                    "guitar", "music", "theory", "mode", "pentatonic",
-                    "chord", "interval", "key"
-                )
-            ),
-            DomainContext(
-                domain = "hobby",
-                contextWords = setOf(
-                    "model", "miniature", "kit", "rc", "diorama",
-                    "detail", "paint", "replica"
-                )
-            ),
-            DomainContext(
-                domain = "business",
-                contextWords = setOf(
-                    "startup", "growth", "business", "company",
-                    "revenue", "customer", "market", "enterprise"
-                )
-            )
-        ),
-        "code" to listOf(
-            DomainContext(
-                domain = "programming",
-                contextWords = setOf(
-                    "python", "javascript", "java", "program", "debug","react", "angular", "vue", "node", "django",
-                    "software", "develop", "engineer", "function", "variable", "kotlin", "swift", "c++", "ruby", "php",
-                    "arduino", "raspberry", "linux", "terminal", "command", "line", "script", "compile", "execute",
-                    "algorithm", "data structure", "oop", "functional", "programming", "coding",
-                    "flutter", "dart", "spring", "boot", "microservice", "api", "rest", "graphql",
-                    "machine learning", "artificial intelligence", "deep learning", "neural network",
-                    "tutorial", "learn", "beginner", "project", "build"
-                )
-            ),
-            DomainContext(
-                domain = "promo",
-                contextWords = setOf(
-                    "promo", "discount", "coupon", "sale", "deal",
-                    "off", "percent", "shop", "store", "buy",
-                    "free", "trial", "subscription", "membership"
-                )
-            ),
-            DomainContext(
-                domain = "entertainment",
-                contextWords = setOf(
-                    "movie", "film", "series", "show", "thriller",
-                    "stream", "watch", "netflix", "amazon",
-                    "episode", "season", "cast", "actor", "scene"
-                )
-            )
-        ),
-        "design" to listOf(
-            DomainContext(
-                domain = "graphic",
-                contextWords = setOf(
-                    "graphic", "logo", "brand", "illustrator", "photoshop",
-                    "vector", "font", "typography", "poster", "ui",
-                    "creative", "adobe", "canva", "layout", "mockup"
-                )
-            ),
-            DomainContext(
-                domain = "interior",
-                contextWords = setOf(
-                    "interior", "room", "home", "house", "furniture",
-                    "decor", "living", "bedroom", "kitchen", "space",
-                    "minimalist", "cozy", "tour", "makeover"
-                )
-            ),
-            DomainContext(
-                domain = "fashion",
-                contextWords = setOf(
-                    "fashion", "clothing", "dress", "outfit", "style",
-                    "runway", "model", "brand", "collection",
-                    "wear", "accessory", "trend", "couture"
-                )
-            ),
-            DomainContext(
-                domain = "game",
-                contextWords = setOf(
-                    "game", "level", "character", "map", "world",
-                    "ux", "ui", "indie", "unity", "unreal",
-                    "minecraft", "city", "park", "architect"
-                )
-            )
-        ),
-        "craft" to listOf(
-            DomainContext(
-                domain = "gaming",
-                contextWords = setOf(
-                    "minecraft", "game", "recipe", "enchant", "potion",
-                    "sword", "armor", "tool", "block",
-                    "inventory", "stack", "mod", "server"
-                )
-            ),
-            DomainContext(
-                domain = "diy",
-                contextWords = setOf(
-                    "diy", "handmade", "homemade", "glue", "scissors",
-                    "fabric", "needle", "tutorial", "project",
-                    "paint", "resin", "clay", "gift", "decor"
-                )
-            )
-        ),
-        "run" to listOf(
-            DomainContext(
-                domain = "fitness",
-                contextWords = setOf(
-                    "mile", "marathon", "jog", "sprint", "pace",
-                    "5k", "10k", "shoe", "outdoor", "trail",
-                    "training", "heart", "rate", "endurance"
-                )
-            ),
-            DomainContext(
-                domain = "gaming",
-                contextWords = setOf(
-                    "speedrun", "speed", "any", "glitch", "record",
-                    "category", "wr", "attempt", "split", "timer", "pb"
-                )
-            ),
-            DomainContext(
-                domain = "tech",
-                contextWords = setOf(
-                    "command", "script", "execute", "terminal", "process",
-                    "npm", "yarn", "pipeline", "ci", "test", "local"
-                )
-            )
-        ),
-        "play" to listOf(
-            DomainContext(
-                domain = "gaming",
-                contextWords = setOf(
-                    "game", "controller", "console", "multiplayer",
-                    "online", "steam", "xbox", "playstation",
-                    "pvp", "ranked", "match"
-                )
-            ),
-            DomainContext(
-                domain = "music",
-                contextWords = setOf(
-                    "instrument", "guitar", "piano", "drum", "violin",
-                    "chord", "note", "lesson", "song", "music",
-                    "cover", "acoustic", "solo"
-                )
-            ),
-            DomainContext(
-                domain = "sport",
-                contextWords = setOf(
-                    "football", "basketball", "soccer", "baseball",
-                    "cricket", "field", "team", "sport", "athlete"
-                )
-            )
+    private val domainDisambiguation: Map<String, List<DomainContext>> =
+        mapOf(
+            "metal" to
+                listOf(
+                    DomainContext(
+                        domain = "music",
+                        contextWords =
+                            setOf(
+                                "song",
+                                "band",
+                                "album",
+                                "music",
+                                "concert",
+                                "guitar",
+                                "drum",
+                                "vocal",
+                                "sing",
+                                "lyric",
+                                "playlist",
+                                "tour",
+                                "riff",
+                                "solo",
+                                "anthem",
+                                "heavy",
+                                "death",
+                                "black",
+                                "thrash",
+                                "power",
+                                "symphonic",
+                                "progressive",
+                                "doom",
+                                "genre",
+                                "metalcore",
+                                "deathcore",
+                                "djent",
+                                "cover",
+                                "react",
+                                "reaction",
+                                "review",
+                                "rank",
+                                "tier",
+                            ),
+                    ),
+                    DomainContext(
+                        domain = "craft",
+                        contextWords =
+                            setOf(
+                                "weld",
+                                "forge",
+                                "fabricat",
+                                "sheet",
+                                "steel",
+                                "iron",
+                                "aluminum",
+                                "copper",
+                                "brass",
+                                "tin",
+                                "alloy",
+                                "workshop",
+                                "tool",
+                                "cut",
+                                "bend",
+                                "grind",
+                                "polish",
+                                "cast",
+                                "mold",
+                                "anvil",
+                                "hammer",
+                                "lathe",
+                                "cnc",
+                                "machin",
+                                "work",
+                                "shop",
+                                "build",
+                                "construct",
+                            ),
+                    ),
+                ),
+            "rock" to
+                listOf(
+                    DomainContext(
+                        domain = "music",
+                        contextWords =
+                            setOf(
+                                "song",
+                                "band",
+                                "album",
+                                "music",
+                                "concert",
+                                "guitar",
+                                "drum",
+                                "vocal",
+                                "sing",
+                                "lyric",
+                                "playlist",
+                                "tour",
+                                "classic",
+                                "punk",
+                                "indie",
+                                "alternative",
+                                "grunge",
+                                "blues",
+                                "roll",
+                                "genre",
+                                "cover",
+                                "anthem",
+                                "react",
+                                "reaction",
+                                "review",
+                                "rank",
+                                "tier",
+                            ),
+                    ),
+                    DomainContext(
+                        domain = "nature",
+                        contextWords =
+                            setOf(
+                                "geology",
+                                "mineral",
+                                "stone",
+                                "fossil",
+                                "gem",
+                                "crystal",
+                                "boulder",
+                                "cliff",
+                                "mountain",
+                                "cave",
+                                "collect",
+                                "specimen",
+                                "earth",
+                                "volcanic",
+                                "sediment",
+                                "igneous",
+                                "metamorphic",
+                                "quarry",
+                                "dig",
+                                "formation",
+                            ),
+                    ),
+                    DomainContext(
+                        domain = "climbing",
+                        contextWords =
+                            setOf(
+                                "climb",
+                                "boulder",
+                                "wall",
+                                "route",
+                                "belay",
+                                "rope",
+                                "harness",
+                                "crag",
+                                "send",
+                                "flash",
+                                "dyno",
+                                "crimp",
+                                "sloper",
+                            ),
+                    ),
+                ),
+            "bass" to
+                listOf(
+                    DomainContext(
+                        domain = "music",
+                        contextWords =
+                            setOf(
+                                "guitar",
+                                "song",
+                                "music",
+                                "band",
+                                "play",
+                                "riff",
+                                "slap",
+                                "fretless",
+                                "amp",
+                                "pedal",
+                                "tone",
+                                "groove",
+                                "funk",
+                                "jazz",
+                                "solo",
+                                "lesson",
+                                "boost",
+                                "drop",
+                                "sub",
+                                "speaker",
+                                "audio",
+                                "headphone",
+                                "equalizer",
+                                "frequency",
+                                "woofer",
+                            ),
+                    ),
+                    DomainContext(
+                        domain = "fishing",
+                        contextWords =
+                            setOf(
+                                "fish",
+                                "fishing",
+                                "lure",
+                                "bait",
+                                "catch",
+                                "lake",
+                                "river",
+                                "pond",
+                                "boat",
+                                "rod",
+                                "reel",
+                                "tackle",
+                                "tournament",
+                                "largemouth",
+                                "smallmouth",
+                                "striped",
+                            ),
+                    ),
+                ),
+            "spring" to
+                listOf(
+                    DomainContext(
+                        domain = "tech",
+                        contextWords =
+                            setOf(
+                                "boot",
+                                "java",
+                                "framework",
+                                "api",
+                                "microservice",
+                                "backend",
+                                "server",
+                                "code",
+                                "program",
+                                "develop",
+                                "application",
+                                "deploy",
+                                "config",
+                                "bean",
+                                "inject",
+                            ),
+                    ),
+                    DomainContext(
+                        domain = "season",
+                        contextWords =
+                            setOf(
+                                "summer",
+                                "winter",
+                                "fall",
+                                "autumn",
+                                "season",
+                                "flower",
+                                "garden",
+                                "bloom",
+                                "clean",
+                                "outfit",
+                                "fashion",
+                                "weather",
+                                "april",
+                                "march",
+                                "may",
+                            ),
+                    ),
+                ),
+            "cell" to
+                listOf(
+                    DomainContext(
+                        domain = "biology",
+                        contextWords =
+                            setOf(
+                                "biology",
+                                "science",
+                                "membrane",
+                                "nucleus",
+                                "mitosis",
+                                "dna",
+                                "rna",
+                                "protein",
+                                "organism",
+                                "tissue",
+                                "bacteria",
+                                "virus",
+                                "microscope",
+                            ),
+                    ),
+                    DomainContext(
+                        domain = "tech",
+                        contextWords =
+                            setOf(
+                                "phone",
+                                "mobile",
+                                "battery",
+                                "charge",
+                                "signal",
+                                "carrier",
+                                "data",
+                                "plan",
+                                "network",
+                                "sim",
+                            ),
+                    ),
+                    DomainContext(
+                        domain = "energy",
+                        contextWords =
+                            setOf(
+                                "solar",
+                                "fuel",
+                                "battery",
+                                "power",
+                                "energy",
+                                "electric",
+                                "hydrogen",
+                                "lithium",
+                                "volt",
+                            ),
+                    ),
+                ),
+            "plant" to
+                listOf(
+                    DomainContext(
+                        domain = "botany",
+                        contextWords =
+                            setOf(
+                                "grow",
+                                "garden",
+                                "flower",
+                                "seed",
+                                "soil",
+                                "water",
+                                "pot",
+                                "leaf",
+                                "root",
+                                "tree",
+                                "herb",
+                                "indoor",
+                                "outdoor",
+                                "succulent",
+                                "cactus",
+                                "propagat",
+                                "prune",
+                                "fertiliz",
+                                "bloom",
+                            ),
+                    ),
+                    DomainContext(
+                        domain = "industrial",
+                        contextWords =
+                            setOf(
+                                "power",
+                                "factory",
+                                "nuclear",
+                                "chemical",
+                                "manufacturing",
+                                "industrial",
+                                "facility",
+                                "process",
+                                "production",
+                                "refinery",
+                            ),
+                    ),
+                ),
+            "pitch" to
+                listOf(
+                    DomainContext(
+                        domain = "music",
+                        contextWords =
+                            setOf(
+                                "sing",
+                                "vocal",
+                                "note",
+                                "tune",
+                                "perfect",
+                                "music",
+                                "tone",
+                                "frequency",
+                                "ear",
+                                "train",
+                            ),
+                    ),
+                    DomainContext(
+                        domain = "business",
+                        contextWords =
+                            setOf(
+                                "startup",
+                                "investor",
+                                "shark",
+                                "tank",
+                                "business",
+                                "company",
+                                "funding",
+                                "venture",
+                                "present",
+                                "elevator",
+                                "idea",
+                                "million",
+                            ),
+                    ),
+                    DomainContext(
+                        domain = "sport",
+                        contextWords =
+                            setOf(
+                                "baseball",
+                                "cricket",
+                                "throw",
+                                "ball",
+                                "strike",
+                                "mound",
+                                "pitcher",
+                                "fastball",
+                                "curve",
+                                "slider",
+                            ),
+                    ),
+                ),
+            "jam" to
+                listOf(
+                    DomainContext(
+                        domain = "music",
+                        contextWords =
+                            setOf(
+                                "guitar",
+                                "band",
+                                "music",
+                                "session",
+                                "play",
+                                "improvise",
+                                "solo",
+                                "groove",
+                                "funk",
+                                "blues",
+                                "live",
+                                "concert",
+                            ),
+                    ),
+                    DomainContext(
+                        domain = "food",
+                        contextWords =
+                            setOf(
+                                "recipe",
+                                "fruit",
+                                "strawberry",
+                                "preserve",
+                                "spread",
+                                "toast",
+                                "jar",
+                                "cook",
+                                "homemade",
+                                "sugar",
+                                "berry",
+                                "grape",
+                            ),
+                    ),
+                ),
+            "bar" to
+                listOf(
+                    DomainContext(
+                        domain = "music",
+                        contextWords =
+                            setOf(
+                                "beat",
+                                "measure",
+                                "rhythm",
+                                "rap",
+                                "flow",
+                                "lyric",
+                                "verse",
+                                "hook",
+                                "produce",
+                                "music",
+                            ),
+                    ),
+                    DomainContext(
+                        domain = "fitness",
+                        contextWords =
+                            setOf(
+                                "pull",
+                                "deadlift",
+                                "squat",
+                                "bench",
+                                "weight",
+                                "gym",
+                                "workout",
+                                "exercise",
+                                "lift",
+                                "olympic",
+                            ),
+                    ),
+                ),
+            "wave" to
+                listOf(
+                    DomainContext(
+                        domain = "music",
+                        contextWords =
+                            setOf(
+                                "synth",
+                                "new",
+                                "retro",
+                                "synthwave",
+                                "vaporwave",
+                                "music",
+                                "genre",
+                                "aesthetic",
+                                "80s",
+                                "electronic",
+                            ),
+                    ),
+                    DomainContext(
+                        domain = "science",
+                        contextWords =
+                            setOf(
+                                "ocean",
+                                "sound",
+                                "light",
+                                "electromagnetic",
+                                "frequency",
+                                "physics",
+                                "energy",
+                                "radio",
+                                "seismic",
+                                "tsunami",
+                                "surf",
+                            ),
+                    ),
+                    DomainContext(
+                        domain = "hair",
+                        contextWords =
+                            setOf(
+                                "hair",
+                                "style",
+                                "curl",
+                                "360",
+                                "brush",
+                                "barber",
+                                "durag",
+                                "pattern",
+                                "pomade",
+                            ),
+                    ),
+                ),
+            "track" to
+                listOf(
+                    DomainContext(
+                        domain = "music",
+                        contextWords =
+                            setOf(
+                                "song",
+                                "album",
+                                "music",
+                                "beat",
+                                "produce",
+                                "mix",
+                                "master",
+                                "record",
+                                "artist",
+                                "release",
+                                "single",
+                                "feature",
+                                "lyric",
+                                "audio",
+                            ),
+                    ),
+                    DomainContext(
+                        domain = "sport",
+                        contextWords =
+                            setOf(
+                                "race",
+                                "run",
+                                "lap",
+                                "sprint",
+                                "field",
+                                "athlete",
+                                "relay",
+                                "hurdle",
+                                "meter",
+                                "olympic",
+                                "nascar",
+                                "formula",
+                                "circuit",
+                                "drift",
+                            ),
+                    ),
+                ),
+            "model" to
+                listOf(
+                    DomainContext(
+                        domain = "ai",
+                        contextWords =
+                            setOf(
+                                "train",
+                                "machine",
+                                "learn",
+                                "neural",
+                                "network",
+                                "data",
+                                "predict",
+                                "gpt",
+                                "llm",
+                                "parameter",
+                                "fine",
+                                "tune",
+                                "inference",
+                                "deploy",
+                                "weight",
+                            ),
+                    ),
+                    DomainContext(
+                        domain = "fashion",
+                        contextWords =
+                            setOf(
+                                "fashion",
+                                "runway",
+                                "pose",
+                                "photo",
+                                "shoot",
+                                "agency",
+                                "walk",
+                                "beauty",
+                                "vogue",
+                                "style",
+                            ),
+                    ),
+                    DomainContext(
+                        domain = "hobby",
+                        contextWords =
+                            setOf(
+                                "scale",
+                                "kit",
+                                "miniature",
+                                "paint",
+                                "hobby",
+                                "plastic",
+                                "glue",
+                                "detail",
+                                "build",
+                                "aircraft",
+                                "tank",
+                                "ship",
+                                "car",
+                                "diorama",
+                                "warhammer",
+                            ),
+                    ),
+                ),
+            "stream" to
+                listOf(
+                    DomainContext(
+                        domain = "live",
+                        contextWords =
+                            setOf(
+                                "live",
+                                "twitch",
+                                "chat",
+                                "viewer",
+                                "sub",
+                                "donation",
+                                "game",
+                                "play",
+                                "broadcast",
+                                "obs",
+                                "overlay",
+                                "alert",
+                                "raid",
+                                "clip",
+                            ),
+                    ),
+                    DomainContext(
+                        domain = "nature",
+                        contextWords =
+                            setOf(
+                                "river",
+                                "water",
+                                "creek",
+                                "brook",
+                                "fish",
+                                "nature",
+                                "mountain",
+                                "hike",
+                                "forest",
+                                "flow",
+                                "waterfall",
+                                "trout",
+                            ),
+                    ),
+                    DomainContext(
+                        domain = "tech",
+                        contextWords =
+                            setOf(
+                                "data",
+                                "kafka",
+                                "process",
+                                "real-time",
+                                "event",
+                                "pipeline",
+                                "api",
+                                "java",
+                                "reactive",
+                                "buffer",
+                            ),
+                    ),
+                ),
+            "build" to
+                listOf(
+                    DomainContext(
+                        domain = "gaming",
+                        contextWords =
+                            setOf(
+                                "game",
+                                "character",
+                                "class",
+                                "loadout",
+                                "weapon",
+                                "armor",
+                                "skill",
+                                "spec",
+                                "talent",
+                                "meta",
+                                "tier",
+                                "rank",
+                                "guide",
+                                "fortnite",
+                                "minecraft",
+                            ),
+                    ),
+                    DomainContext(
+                        domain = "pc",
+                        contextWords =
+                            setOf(
+                                "pc",
+                                "computer",
+                                "gpu",
+                                "cpu",
+                                "ram",
+                                "ssd",
+                                "motherboard",
+                                "case",
+                                "cooling",
+                                "rgb",
+                                "setup",
+                                "benchmark",
+                                "gaming",
+                                "workstation",
+                                "budget",
+                            ),
+                    ),
+                    DomainContext(
+                        domain = "construction",
+                        contextWords =
+                            setOf(
+                                "house",
+                                "cabin",
+                                "shed",
+                                "deck",
+                                "fence",
+                                "wood",
+                                "concrete",
+                                "brick",
+                                "foundation",
+                                "roof",
+                                "wall",
+                                "frame",
+                                "diy",
+                                "workshop",
+                            ),
+                    ),
+                    DomainContext(
+                        domain = "car",
+                        contextWords =
+                            setOf(
+                                "car",
+                                "truck",
+                                "engine",
+                                "swap",
+                                "turbo",
+                                "exhaust",
+                                "suspension",
+                                "wheel",
+                                "tire",
+                                "drift",
+                                "race",
+                                "jdm",
+                                "sema",
+                                "custom",
+                                "restore",
+                                "project",
+                                "garage",
+                                "wrench",
+                            ),
+                    ),
+                ),
+            "scale" to
+                listOf(
+                    DomainContext(
+                        domain = "music",
+                        contextWords =
+                            setOf(
+                                "major",
+                                "minor",
+                                "note",
+                                "practice",
+                                "piano",
+                                "guitar",
+                                "music",
+                                "theory",
+                                "mode",
+                                "pentatonic",
+                                "chord",
+                                "interval",
+                                "key",
+                            ),
+                    ),
+                    DomainContext(
+                        domain = "hobby",
+                        contextWords =
+                            setOf(
+                                "model",
+                                "miniature",
+                                "kit",
+                                "rc",
+                                "diorama",
+                                "detail",
+                                "paint",
+                                "replica",
+                            ),
+                    ),
+                    DomainContext(
+                        domain = "business",
+                        contextWords =
+                            setOf(
+                                "startup",
+                                "growth",
+                                "business",
+                                "company",
+                                "revenue",
+                                "customer",
+                                "market",
+                                "enterprise",
+                            ),
+                    ),
+                ),
+            "code" to
+                listOf(
+                    DomainContext(
+                        domain = "programming",
+                        contextWords =
+                            setOf(
+                                "python",
+                                "javascript",
+                                "java",
+                                "program",
+                                "debug",
+                                "react",
+                                "angular",
+                                "vue",
+                                "node",
+                                "django",
+                                "software",
+                                "develop",
+                                "engineer",
+                                "function",
+                                "variable",
+                                "kotlin",
+                                "swift",
+                                "c++",
+                                "ruby",
+                                "php",
+                                "arduino",
+                                "raspberry",
+                                "linux",
+                                "terminal",
+                                "command",
+                                "line",
+                                "script",
+                                "compile",
+                                "execute",
+                                "algorithm",
+                                "data structure",
+                                "oop",
+                                "functional",
+                                "programming",
+                                "coding",
+                                "flutter",
+                                "dart",
+                                "spring",
+                                "boot",
+                                "microservice",
+                                "api",
+                                "rest",
+                                "graphql",
+                                "machine learning",
+                                "artificial intelligence",
+                                "deep learning",
+                                "neural network",
+                                "tutorial",
+                                "learn",
+                                "beginner",
+                                "project",
+                                "build",
+                            ),
+                    ),
+                    DomainContext(
+                        domain = "promo",
+                        contextWords =
+                            setOf(
+                                "promo",
+                                "discount",
+                                "coupon",
+                                "sale",
+                                "deal",
+                                "off",
+                                "percent",
+                                "shop",
+                                "store",
+                                "buy",
+                                "free",
+                                "trial",
+                                "subscription",
+                                "membership",
+                            ),
+                    ),
+                    DomainContext(
+                        domain = "entertainment",
+                        contextWords =
+                            setOf(
+                                "movie",
+                                "film",
+                                "series",
+                                "show",
+                                "thriller",
+                                "stream",
+                                "watch",
+                                "netflix",
+                                "amazon",
+                                "episode",
+                                "season",
+                                "cast",
+                                "actor",
+                                "scene",
+                            ),
+                    ),
+                ),
+            "design" to
+                listOf(
+                    DomainContext(
+                        domain = "graphic",
+                        contextWords =
+                            setOf(
+                                "graphic",
+                                "logo",
+                                "brand",
+                                "illustrator",
+                                "photoshop",
+                                "vector",
+                                "font",
+                                "typography",
+                                "poster",
+                                "ui",
+                                "creative",
+                                "adobe",
+                                "canva",
+                                "layout",
+                                "mockup",
+                            ),
+                    ),
+                    DomainContext(
+                        domain = "interior",
+                        contextWords =
+                            setOf(
+                                "interior",
+                                "room",
+                                "home",
+                                "house",
+                                "furniture",
+                                "decor",
+                                "living",
+                                "bedroom",
+                                "kitchen",
+                                "space",
+                                "minimalist",
+                                "cozy",
+                                "tour",
+                                "makeover",
+                            ),
+                    ),
+                    DomainContext(
+                        domain = "fashion",
+                        contextWords =
+                            setOf(
+                                "fashion",
+                                "clothing",
+                                "dress",
+                                "outfit",
+                                "style",
+                                "runway",
+                                "model",
+                                "brand",
+                                "collection",
+                                "wear",
+                                "accessory",
+                                "trend",
+                                "couture",
+                            ),
+                    ),
+                    DomainContext(
+                        domain = "game",
+                        contextWords =
+                            setOf(
+                                "game",
+                                "level",
+                                "character",
+                                "map",
+                                "world",
+                                "ux",
+                                "ui",
+                                "indie",
+                                "unity",
+                                "unreal",
+                                "minecraft",
+                                "city",
+                                "park",
+                                "architect",
+                            ),
+                    ),
+                ),
+            "craft" to
+                listOf(
+                    DomainContext(
+                        domain = "gaming",
+                        contextWords =
+                            setOf(
+                                "minecraft",
+                                "game",
+                                "recipe",
+                                "enchant",
+                                "potion",
+                                "sword",
+                                "armor",
+                                "tool",
+                                "block",
+                                "inventory",
+                                "stack",
+                                "mod",
+                                "server",
+                            ),
+                    ),
+                    DomainContext(
+                        domain = "diy",
+                        contextWords =
+                            setOf(
+                                "diy",
+                                "handmade",
+                                "homemade",
+                                "glue",
+                                "scissors",
+                                "fabric",
+                                "needle",
+                                "tutorial",
+                                "project",
+                                "paint",
+                                "resin",
+                                "clay",
+                                "gift",
+                                "decor",
+                            ),
+                    ),
+                ),
+            "run" to
+                listOf(
+                    DomainContext(
+                        domain = "fitness",
+                        contextWords =
+                            setOf(
+                                "mile",
+                                "marathon",
+                                "jog",
+                                "sprint",
+                                "pace",
+                                "5k",
+                                "10k",
+                                "shoe",
+                                "outdoor",
+                                "trail",
+                                "training",
+                                "heart",
+                                "rate",
+                                "endurance",
+                            ),
+                    ),
+                    DomainContext(
+                        domain = "gaming",
+                        contextWords =
+                            setOf(
+                                "speedrun",
+                                "speed",
+                                "any",
+                                "glitch",
+                                "record",
+                                "category",
+                                "wr",
+                                "attempt",
+                                "split",
+                                "timer",
+                                "pb",
+                            ),
+                    ),
+                    DomainContext(
+                        domain = "tech",
+                        contextWords =
+                            setOf(
+                                "command",
+                                "script",
+                                "execute",
+                                "terminal",
+                                "process",
+                                "npm",
+                                "yarn",
+                                "pipeline",
+                                "ci",
+                                "test",
+                                "local",
+                            ),
+                    ),
+                ),
+            "play" to
+                listOf(
+                    DomainContext(
+                        domain = "gaming",
+                        contextWords =
+                            setOf(
+                                "game",
+                                "controller",
+                                "console",
+                                "multiplayer",
+                                "online",
+                                "steam",
+                                "xbox",
+                                "playstation",
+                                "pvp",
+                                "ranked",
+                                "match",
+                            ),
+                    ),
+                    DomainContext(
+                        domain = "music",
+                        contextWords =
+                            setOf(
+                                "instrument",
+                                "guitar",
+                                "piano",
+                                "drum",
+                                "violin",
+                                "chord",
+                                "note",
+                                "lesson",
+                                "song",
+                                "music",
+                                "cover",
+                                "acoustic",
+                                "solo",
+                            ),
+                    ),
+                    DomainContext(
+                        domain = "sport",
+                        contextWords =
+                            setOf(
+                                "football",
+                                "basketball",
+                                "soccer",
+                                "baseball",
+                                "cricket",
+                                "field",
+                                "team",
+                                "sport",
+                                "athlete",
+                            ),
+                    ),
+                ),
         )
-    )
 
     /**
      * Resolves the domain of a polysemous word based on surrounding context.
@@ -1115,8 +2266,11 @@ internal class NeuroTokenizer {
      * Uses prefix matching on context words to catch morphological variants
      * (e.g. "fabricat" matches "fabrication", "fabricated", "fabricating").
      */
-    private fun disambiguateWord(word: String, allWords: List<String>): String {
-        val domains = DOMAIN_DISAMBIGUATION[word] ?: return word
+    private fun disambiguateWord(
+        word: String,
+        allWords: List<String>,
+    ): String {
+        val domains = domainDisambiguation[word] ?: return word
 
         var bestDomain: String? = null
         var bestScore = 0
@@ -1161,160 +2315,675 @@ internal class NeuroTokenizer {
     // Personal names and branding are noise.
     // ══════════════════════════════════════════════
 
-    private val COMMON_FIRST_NAMES = hashSetOf(
-        // English male
-        "adam", "alan", "alex", "alexander", "andrew", "anthony",
-        "austin", "ben", "benjamin", "brandon", "brian", "bruce",
-        "caleb", "cameron", "carl", "charles", "charlie", "chris",
-        "christian", "colin", "connor", "corey", "craig", "dan",
-        "daniel", "dave", "david", "dean", "derek", "devon",
-        "dominic", "don", "donald", "drew", "dustin", "dylan",
-        "ed", "edward", "eli", "elijah", "eric", "erik", "ethan",
-        "evan", "felix", "frank", "fred", "gary", "george",
-        "grant", "greg", "gregory", "harry", "henry", "howard",
-        "hunter", "ian", "isaac", "jack", "jackson", "jacob",
-        "jake", "james", "jamie", "jared", "jason", "jeff",
-        "jeffrey", "jeremy", "jerry", "jesse", "jim", "jimmy",
-        "joe", "joel", "john", "johnny", "jon", "jonathan",
-        "jordan", "jose", "joseph", "josh", "joshua", "juan",
-        "julian", "justin", "keith", "ken", "kevin", "kyle",
-        "lance", "larry", "leo", "liam", "logan", "louis",
-        "lucas", "luke", "marcus", "mark", "martin", "mason",
-        "matt", "matthew", "max", "michael", "mike", "miles",
-        "nathan", "nicholas", "nick", "noah", "nolan", "oliver",
-        "oscar", "owen", "patrick", "paul", "peter", "phil",
-        "philip", "preston", "quentin", "ralph", "randy", "ray",
-        "raymond", "richard", "rick", "robert", "robin", "roger",
-        "ron", "ronald", "ross", "roy", "russell", "ryan",
-        "sam", "samuel", "scott", "sean", "seth", "shane",
-        "simon", "spencer", "stephen", "steve", "steven",
-        "stuart", "ted", "terry", "thomas", "tim", "timothy",
-        "todd", "tom", "tommy", "tony", "travis", "trevor",
-        "troy", "tyler", "victor", "vincent", "wade", "walter",
-        "warren", "wayne", "will", "william", "zach", "zachary",
-        // English female
-        "alice", "amanda", "amber", "amy", "andrea", "angela",
-        "anna", "ashley", "barbara", "beth", "betty", "brenda",
-        "brittany", "carmen", "carol", "caroline", "catherine",
-        "charlotte", "chelsea", "christina", "christine", "claire",
-        "courtney", "crystal", "cynthia", "daisy", "dana", "danielle",
-        "deborah", "diana", "donna", "dorothy", "elizabeth", "ellen",
-        "emily", "emma", "erica", "eva", "faith", "fiona",
-        "florence", "grace", "hailey", "hannah", "heather", "helen",
-        "holly", "irene", "isabel", "isabella", "jackie", "jane",
-        "janet", "janice", "jasmine", "jennifer", "jenny", "jessica",
-        "joan", "joanne", "julia", "julie", "karen", "kate",
-        "katherine", "kathleen", "katie", "kayla", "kelly", "kim",
-        "kimberly", "kristen", "kristin", "laura", "lauren", "leah",
-        "lillian", "lily", "linda", "lisa", "liz", "lori",
-        "lucy", "lynn", "madeline", "madison", "maria", "marie",
-        "martha", "mary", "megan", "melissa", "michelle", "miranda",
-        "molly", "monica", "nancy", "natalie", "natasha", "nicole",
-        "olivia", "paige", "pamela", "patricia", "rachel", "rebecca",
-        "renee", "rita", "robin", "rosa", "rose", "ruth",
-        "sabrina", "samantha", "sandra", "sara", "sarah", "sharon",
-        "sophia", "stephanie", "susan", "tamara", "tanya", "tara",
-        "teresa", "tiffany", "tina", "tracy", "valerie", "vanessa",
-        "veronica", "victoria", "virginia", "wendy", "whitney"
-    )
+    private val commonFirstNames =
+        hashSetOf(
+            // English male
+            "adam",
+            "alan",
+            "alex",
+            "alexander",
+            "andrew",
+            "anthony",
+            "austin",
+            "ben",
+            "benjamin",
+            "brandon",
+            "brian",
+            "bruce",
+            "caleb",
+            "cameron",
+            "carl",
+            "charles",
+            "charlie",
+            "chris",
+            "christian",
+            "colin",
+            "connor",
+            "corey",
+            "craig",
+            "dan",
+            "daniel",
+            "dave",
+            "david",
+            "dean",
+            "derek",
+            "devon",
+            "dominic",
+            "don",
+            "donald",
+            "drew",
+            "dustin",
+            "dylan",
+            "ed",
+            "edward",
+            "eli",
+            "elijah",
+            "eric",
+            "erik",
+            "ethan",
+            "evan",
+            "felix",
+            "frank",
+            "fred",
+            "gary",
+            "george",
+            "grant",
+            "greg",
+            "gregory",
+            "harry",
+            "henry",
+            "howard",
+            "hunter",
+            "ian",
+            "isaac",
+            "jack",
+            "jackson",
+            "jacob",
+            "jake",
+            "james",
+            "jamie",
+            "jared",
+            "jason",
+            "jeff",
+            "jeffrey",
+            "jeremy",
+            "jerry",
+            "jesse",
+            "jim",
+            "jimmy",
+            "joe",
+            "joel",
+            "john",
+            "johnny",
+            "jon",
+            "jonathan",
+            "jordan",
+            "jose",
+            "joseph",
+            "josh",
+            "joshua",
+            "juan",
+            "julian",
+            "justin",
+            "keith",
+            "ken",
+            "kevin",
+            "kyle",
+            "lance",
+            "larry",
+            "leo",
+            "liam",
+            "logan",
+            "louis",
+            "lucas",
+            "luke",
+            "marcus",
+            "mark",
+            "martin",
+            "mason",
+            "matt",
+            "matthew",
+            "max",
+            "michael",
+            "mike",
+            "miles",
+            "nathan",
+            "nicholas",
+            "nick",
+            "noah",
+            "nolan",
+            "oliver",
+            "oscar",
+            "owen",
+            "patrick",
+            "paul",
+            "peter",
+            "phil",
+            "philip",
+            "preston",
+            "quentin",
+            "ralph",
+            "randy",
+            "ray",
+            "raymond",
+            "richard",
+            "rick",
+            "robert",
+            "robin",
+            "roger",
+            "ron",
+            "ronald",
+            "ross",
+            "roy",
+            "russell",
+            "ryan",
+            "sam",
+            "samuel",
+            "scott",
+            "sean",
+            "seth",
+            "shane",
+            "simon",
+            "spencer",
+            "stephen",
+            "steve",
+            "steven",
+            "stuart",
+            "ted",
+            "terry",
+            "thomas",
+            "tim",
+            "timothy",
+            "todd",
+            "tom",
+            "tommy",
+            "tony",
+            "travis",
+            "trevor",
+            "troy",
+            "tyler",
+            "victor",
+            "vincent",
+            "wade",
+            "walter",
+            "warren",
+            "wayne",
+            "will",
+            "william",
+            "zach",
+            "zachary",
+            // English female
+            "alice",
+            "amanda",
+            "amber",
+            "amy",
+            "andrea",
+            "angela",
+            "anna",
+            "ashley",
+            "barbara",
+            "beth",
+            "betty",
+            "brenda",
+            "brittany",
+            "carmen",
+            "carol",
+            "caroline",
+            "catherine",
+            "charlotte",
+            "chelsea",
+            "christina",
+            "christine",
+            "claire",
+            "courtney",
+            "crystal",
+            "cynthia",
+            "daisy",
+            "dana",
+            "danielle",
+            "deborah",
+            "diana",
+            "donna",
+            "dorothy",
+            "elizabeth",
+            "ellen",
+            "emily",
+            "emma",
+            "erica",
+            "eva",
+            "faith",
+            "fiona",
+            "florence",
+            "grace",
+            "hailey",
+            "hannah",
+            "heather",
+            "helen",
+            "holly",
+            "irene",
+            "isabel",
+            "isabella",
+            "jackie",
+            "jane",
+            "janet",
+            "janice",
+            "jasmine",
+            "jennifer",
+            "jenny",
+            "jessica",
+            "joan",
+            "joanne",
+            "julia",
+            "julie",
+            "karen",
+            "kate",
+            "katherine",
+            "kathleen",
+            "katie",
+            "kayla",
+            "kelly",
+            "kim",
+            "kimberly",
+            "kristen",
+            "kristin",
+            "laura",
+            "lauren",
+            "leah",
+            "lillian",
+            "lily",
+            "linda",
+            "lisa",
+            "liz",
+            "lori",
+            "lucy",
+            "lynn",
+            "madeline",
+            "madison",
+            "maria",
+            "marie",
+            "martha",
+            "mary",
+            "megan",
+            "melissa",
+            "michelle",
+            "miranda",
+            "molly",
+            "monica",
+            "nancy",
+            "natalie",
+            "natasha",
+            "nicole",
+            "olivia",
+            "paige",
+            "pamela",
+            "patricia",
+            "rachel",
+            "rebecca",
+            "renee",
+            "rita",
+            "robin",
+            "rosa",
+            "rose",
+            "ruth",
+            "sabrina",
+            "samantha",
+            "sandra",
+            "sara",
+            "sarah",
+            "sharon",
+            "sophia",
+            "stephanie",
+            "susan",
+            "tamara",
+            "tanya",
+            "tara",
+            "teresa",
+            "tiffany",
+            "tina",
+            "tracy",
+            "valerie",
+            "vanessa",
+            "veronica",
+            "victoria",
+            "virginia",
+            "wendy",
+            "whitney",
+        )
 
-    private val COMMON_LAST_NAMES = hashSetOf(
-        "smith", "johnson", "williams", "brown", "jones", "garcia",
-        "miller", "davis", "rodriguez", "martinez", "hernandez",
-        "lopez", "gonzalez", "wilson", "anderson", "thomas",
-        "taylor", "moore", "jackson", "martin", "lee", "perez",
-        "thompson", "white", "harris", "sanchez", "clark", "ramirez",
-        "lewis", "robinson", "walker", "young", "allen", "king",
-        "wright", "scott", "torres", "nguyen", "hill", "flores",
-        "green", "adams", "nelson", "baker", "hall", "rivera",
-        "campbell", "mitchell", "carter", "roberts", "turner",
-        "phillips", "parker", "evans", "edwards", "collins", "stewart",
-        "morris", "murphy", "cook", "rogers", "morgan", "peterson",
-        "cooper", "reed", "bailey", "bell", "gomez", "kelly",
-        "howard", "ward", "cox", "diaz", "richardson", "wood",
-        "watson", "brooks", "bennett", "gray", "james", "reyes",
-        "cruz", "hughes", "price", "myers", "long", "foster",
-        "sanders", "ross", "morales", "powell", "sullivan", "russell",
-        "ortiz", "jenkins", "gutierrez", "perry", "butler", "barnes",
-        "fisher", "henderson", "coleman", "simmons", "patterson",
-        "jordan", "reynolds", "hamilton", "graham", "kim", "gonzales"
-    )
+    private val commonLastNames =
+        hashSetOf(
+            "smith",
+            "johnson",
+            "williams",
+            "brown",
+            "jones",
+            "garcia",
+            "miller",
+            "davis",
+            "rodriguez",
+            "martinez",
+            "hernandez",
+            "lopez",
+            "gonzalez",
+            "wilson",
+            "anderson",
+            "thomas",
+            "taylor",
+            "moore",
+            "jackson",
+            "martin",
+            "lee",
+            "perez",
+            "thompson",
+            "white",
+            "harris",
+            "sanchez",
+            "clark",
+            "ramirez",
+            "lewis",
+            "robinson",
+            "walker",
+            "young",
+            "allen",
+            "king",
+            "wright",
+            "scott",
+            "torres",
+            "nguyen",
+            "hill",
+            "flores",
+            "green",
+            "adams",
+            "nelson",
+            "baker",
+            "hall",
+            "rivera",
+            "campbell",
+            "mitchell",
+            "carter",
+            "roberts",
+            "turner",
+            "phillips",
+            "parker",
+            "evans",
+            "edwards",
+            "collins",
+            "stewart",
+            "morris",
+            "murphy",
+            "cook",
+            "rogers",
+            "morgan",
+            "peterson",
+            "cooper",
+            "reed",
+            "bailey",
+            "bell",
+            "gomez",
+            "kelly",
+            "howard",
+            "ward",
+            "cox",
+            "diaz",
+            "richardson",
+            "wood",
+            "watson",
+            "brooks",
+            "bennett",
+            "gray",
+            "james",
+            "reyes",
+            "cruz",
+            "hughes",
+            "price",
+            "myers",
+            "long",
+            "foster",
+            "sanders",
+            "ross",
+            "morales",
+            "powell",
+            "sullivan",
+            "russell",
+            "ortiz",
+            "jenkins",
+            "gutierrez",
+            "perry",
+            "butler",
+            "barnes",
+            "fisher",
+            "henderson",
+            "coleman",
+            "simmons",
+            "patterson",
+            "jordan",
+            "reynolds",
+            "hamilton",
+            "graham",
+            "kim",
+            "gonzales",
+        )
 
-    private val CHANNEL_BRANDING = hashSetOf(
-        "tv", "hq", "official", "studios", "studio", "media",
-        "network", "show", "channel", "daily", "weekly",
-        "clips", "highlights", "productions", "entertainment",
-        "records", "label", "publishing", "digital", "online",
-        "plus", "extra", "prime", "live", "vlog", "vlogs",
-        "sensei", "guru", "master", "pro", "expert", "academy",
-        "zone", "hub", "spot", "world", "nation", "central",
-        "insider", "minute", "bytes", "bits"
-    )
+    private val channelBranding =
+        hashSetOf(
+            "tv",
+            "hq",
+            "official",
+            "studios",
+            "studio",
+            "media",
+            "network",
+            "show",
+            "channel",
+            "daily",
+            "weekly",
+            "clips",
+            "highlights",
+            "productions",
+            "entertainment",
+            "records",
+            "label",
+            "publishing",
+            "digital",
+            "online",
+            "plus",
+            "extra",
+            "prime",
+            "live",
+            "vlog",
+            "vlogs",
+            "sensei",
+            "guru",
+            "master",
+            "pro",
+            "expert",
+            "academy",
+            "zone",
+            "hub",
+            "spot",
+            "world",
+            "nation",
+            "central",
+            "insider",
+            "minute",
+            "bytes",
+            "bits",
+        )
 
-    private val ALWAYS_TOPICAL = hashSetOf(
-        // Technology
-        "tech", "technology", "science", "code", "coding", "program",
-        "programming", "software", "hardware", "cybersecurity", "linux",
-        "android", "python", "javascript", "rust", "java", "swift",
-        "flutter", "react", "devops", "database", "frontend", "backend",
-        "hacking", "ai",
-
-        // Gaming
-        "game", "gaming", "minecraft", "fortnite", "roblox", "valorant",
-        "pokemon", "nintendo", "playstation", "xbox", "esports", "speedrun",
-        "apex", "overwatch", "destiny", "warzone", "gta", "zelda",
-
-        // Music
-        "music", "guitar", "piano", "drum", "violin", "bass", "singing",
-        "jazz", "classical", "electronic", "edm", "hiphop", "rap",
-        "metal", "rock", "punk", "indie", "kpop", "lofi",
-
-        // Creative
-        "art", "drawing", "painting", "illustration", "sculpture",
-        "animation", "calligraphy", "design", "photo", "photography",
-        "film", "cinema", "filmmaking",
-
-        // Education & Academic
-        "education", "math", "mathematics", "physics", "chemistry",
-        "biology", "engineering", "geography", "geology", "economics",
-        "politics", "psychology", "philosophy", "history", "literature",
-        "language", "spanish", "japanese", "korean", "french", "german",
-
-        // Entertainment
-        "anime", "manga", "movie", "comedy", "horror",
-        "podcast", "documentary", "asmr", "chess",
-
-        // Sports & Fitness
-        "sports", "fitness", "workout", "gym", "yoga", "running",
-        "bodybuilding", "calisthenics", "nutrition", "meditation",
-        "football", "basketball", "soccer", "baseball", "hockey",
-        "golf", "tennis", "boxing", "mma", "wrestling",
-        "cycling", "swimming", "climbing", "martial",
-
-        // Food & Cooking
-        "food", "cook", "cooking", "recipe", "baking", "vegan",
-        "vegetarian", "barbecue", "cuisine",
-
-        // Lifestyle
-        "travel", "fashion", "beauty", "skincare", "health",
-        "diy", "craft", "garden", "gardening", "automotive",
-        "car", "motorcycle", "aviation",
-
-        // Nature & Science
-        "nature", "wildlife", "ocean", "marine", "aquarium",
-        "space", "astronomy", "robotics", "electronics",
-
-        // Pets
-        "dog", "cat", "pet",
-
-        // Craft & Making
-        "woodworking", "metalworking", "3d", "printing",
-        "sewing", "knitting", "pottery",
-
-        // Finance
-        "crypto", "finance", "investing", "business", "marketing",
-        "trading", "stocks", "entrepreneur"
-    )
+    private val alwaysTopical =
+        hashSetOf(
+            // Technology
+            "tech",
+            "technology",
+            "science",
+            "code",
+            "coding",
+            "program",
+            "programming",
+            "software",
+            "hardware",
+            "cybersecurity",
+            "linux",
+            "android",
+            "python",
+            "javascript",
+            "rust",
+            "java",
+            "swift",
+            "flutter",
+            "react",
+            "devops",
+            "database",
+            "frontend",
+            "backend",
+            "hacking",
+            "ai",
+            // Gaming
+            "game",
+            "gaming",
+            "minecraft",
+            "fortnite",
+            "roblox",
+            "valorant",
+            "pokemon",
+            "nintendo",
+            "playstation",
+            "xbox",
+            "esports",
+            "speedrun",
+            "apex",
+            "overwatch",
+            "destiny",
+            "warzone",
+            "gta",
+            "zelda",
+            // Music
+            "music",
+            "guitar",
+            "piano",
+            "drum",
+            "violin",
+            "bass",
+            "singing",
+            "jazz",
+            "classical",
+            "electronic",
+            "edm",
+            "hiphop",
+            "rap",
+            "metal",
+            "rock",
+            "punk",
+            "indie",
+            "kpop",
+            "lofi",
+            // Creative
+            "art",
+            "drawing",
+            "painting",
+            "illustration",
+            "sculpture",
+            "animation",
+            "calligraphy",
+            "design",
+            "photo",
+            "photography",
+            "film",
+            "cinema",
+            "filmmaking",
+            // Education & Academic
+            "education",
+            "math",
+            "mathematics",
+            "physics",
+            "chemistry",
+            "biology",
+            "engineering",
+            "geography",
+            "geology",
+            "economics",
+            "politics",
+            "psychology",
+            "philosophy",
+            "history",
+            "literature",
+            "language",
+            "spanish",
+            "japanese",
+            "korean",
+            "french",
+            "german",
+            // Entertainment
+            "anime",
+            "manga",
+            "movie",
+            "comedy",
+            "horror",
+            "podcast",
+            "documentary",
+            "asmr",
+            "chess",
+            // Sports & Fitness
+            "sports",
+            "fitness",
+            "workout",
+            "gym",
+            "yoga",
+            "running",
+            "bodybuilding",
+            "calisthenics",
+            "nutrition",
+            "meditation",
+            "football",
+            "basketball",
+            "soccer",
+            "baseball",
+            "hockey",
+            "golf",
+            "tennis",
+            "boxing",
+            "mma",
+            "wrestling",
+            "cycling",
+            "swimming",
+            "climbing",
+            "martial",
+            // Food & Cooking
+            "food",
+            "cook",
+            "cooking",
+            "recipe",
+            "baking",
+            "vegan",
+            "vegetarian",
+            "barbecue",
+            "cuisine",
+            // Lifestyle
+            "travel",
+            "fashion",
+            "beauty",
+            "skincare",
+            "health",
+            "diy",
+            "craft",
+            "garden",
+            "gardening",
+            "automotive",
+            "car",
+            "motorcycle",
+            "aviation",
+            // Nature & Science
+            "nature",
+            "wildlife",
+            "ocean",
+            "marine",
+            "aquarium",
+            "space",
+            "astronomy",
+            "robotics",
+            "electronics",
+            // Pets
+            "dog",
+            "cat",
+            "pet",
+            // Craft & Making
+            "woodworking",
+            "metalworking",
+            "3d",
+            "printing",
+            "sewing",
+            "knitting",
+            "pottery",
+            // Finance
+            "crypto",
+            "finance",
+            "investing",
+            "business",
+            "marketing",
+            "trading",
+            "stocks",
+            "entrepreneur",
+        )
 
     /**
      * Tokenizes a channel name, extracting ONLY confirmed topic keywords.
@@ -1337,17 +3006,18 @@ internal class NeuroTokenizer {
      * "History Matters"       → ["history"]
      */
     fun tokenizeChannelName(channelName: String): List<String> {
-        val rawOriginal = channelName
-            .split(WHITESPACE_REGEX)
-            .map { word -> word.trim { !it.isLetterOrDigit() } }
-            .filter { it.length > 1 }
+        val rawOriginal =
+            channelName
+                .split(WHITESPACE_REGEX)
+                .map { word -> word.trim { !it.isLetterOrDigit() } }
+                .filter { it.length > 1 }
 
         if (rawOriginal.isEmpty()) return emptyList()
 
         if (rawOriginal.size == 1) {
             val word = rawOriginal[0].lowercase()
             val lemma = normalizeLemma(word)
-            return if (lemma in ALWAYS_TOPICAL || word in ALWAYS_TOPICAL) {
+            return if (lemma in alwaysTopical || word in alwaysTopical) {
                 listOf(lemma)
             } else {
                 emptyList()
@@ -1360,8 +3030,8 @@ internal class NeuroTokenizer {
             val lemma = normalizeLemma(lower)
 
             when {
-                lemma in ALWAYS_TOPICAL -> topical.add(lemma)
-                lower in ALWAYS_TOPICAL -> topical.add(lower)
+                lemma in alwaysTopical -> topical.add(lemma)
+                lower in alwaysTopical -> topical.add(lower)
             }
         }
         return topical.distinct()
@@ -1377,20 +3047,23 @@ internal class NeuroTokenizer {
     private fun buildContextWordList(video: Video): List<String> {
         val words = mutableListOf<String>()
 
-        video.title.lowercase()
+        video.title
+            .lowercase()
             .split(WHITESPACE_REGEX)
             .map { it.trim { c -> !c.isLetterOrDigit() } }
             .filter { it.length > 1 }
             .forEach { words.add(it) }
 
-        video.channelName.lowercase()
+        video.channelName
+            .lowercase()
             .split(WHITESPACE_REGEX)
             .map { it.trim { c -> !c.isLetterOrDigit() } }
             .filter { it.length > 1 }
             .forEach { words.add(it) }
 
         if (!video.description.isNullOrBlank()) {
-            video.description.lines()
+            video.description
+                .lines()
                 .take(3)
                 .joinToString(" ")
                 .lowercase()
@@ -1403,7 +3076,8 @@ internal class NeuroTokenizer {
         // Tags provide critical disambiguation context
         if (video.tags.isNotEmpty()) {
             video.tags.take(TAG_MAX_INGEST).forEach { tag ->
-                tag.lowercase()
+                tag
+                    .lowercase()
                     .split(WHITESPACE_REGEX)
                     .map { it.trim { c -> !c.isLetterOrDigit() } }
                     .filter { it.length > 1 }

--- a/app/src/main/java/io/github/aedev/flow/data/recommendation/NeuroVectorMath.kt
+++ b/app/src/main/java/io/github/aedev/flow/data/recommendation/NeuroVectorMath.kt
@@ -22,7 +22,6 @@ import kotlin.math.*
  * Easy to unit test in isolation.
  */
 internal object NeuroVectorMath {
-
     // ── Weight Constants ──
     const val TOPIC_SIMILARITY_WEIGHT = 0.70
     const val DURATION_SIMILARITY_WEIGHT = 0.10
@@ -36,13 +35,16 @@ internal object NeuroVectorMath {
 
     /** Topics above this score are core interests — decay extremely slowly */
     const val ESTABLISHED_TOPIC_THRESHOLD = 0.30
+
     /** Topics above this score are developing — decay slowly */
     const val DEVELOPING_TOPIC_THRESHOLD = 0.10
 
     /** Established interests: half-life ~1400 interactions */
     const val ESTABLISHED_DECAY_RATE = 0.998
+
     /** Developing interests: half-life ~330 interactions */
     const val DEVELOPING_DECAY_RATE = 0.993
+
     /** Emerging/noisy topics: half-life ~46 interactions*/
     const val EMERGING_DECAY_RATE = 0.97
 
@@ -56,19 +58,24 @@ internal object NeuroVectorMath {
 
     fun calculateCosineSimilarity(
         user: ContentVector,
-        content: ContentVector
+        content: ContentVector,
     ): Double {
-        val (smallMap, largeMap) = if (
-            user.topics.size <= content.topics.size
-        ) user.topics to content.topics
-        else content.topics to user.topics
+        val (smallMap, largeMap) =
+            if (
+                user.topics.size <= content.topics.size
+            ) {
+                user.topics to content.topics
+            } else {
+                content.topics to user.topics
+            }
 
         val durationSim = 1.0 - abs(user.duration - content.duration)
         val pacingSim = 1.0 - abs(user.pacing - content.pacing)
         val complexitySim = 1.0 - abs(user.complexity - content.complexity)
-        val scalarScore = (durationSim * DURATION_SIMILARITY_WEIGHT) +
-            (pacingSim * PACING_SIMILARITY_WEIGHT) +
-            (complexitySim * COMPLEXITY_SIMILARITY_WEIGHT)
+        val scalarScore =
+            (durationSim * DURATION_SIMILARITY_WEIGHT) +
+                (pacingSim * PACING_SIMILARITY_WEIGHT) +
+                (complexitySim * COMPLEXITY_SIMILARITY_WEIGHT)
 
         if (smallMap.isEmpty()) return scalarScore * SCALAR_ONLY_DAMP
 
@@ -118,9 +125,12 @@ internal object NeuroVectorMath {
         user.topics.values.forEach { magnitudeA += it * it }
         content.topics.values.forEach { magnitudeB += it * it }
 
-        val topicSim = if (magnitudeA > 0 && magnitudeB > 0) {
-            dotProduct / (sqrt(magnitudeA) * sqrt(magnitudeB))
-        } else 0.0
+        val topicSim =
+            if (magnitudeA > 0 && magnitudeB > 0) {
+                dotProduct / (sqrt(magnitudeA) * sqrt(magnitudeB))
+            } else {
+                0.0
+            }
 
         return (topicSim * TOPIC_SIMILARITY_WEIGHT) + scalarScore
     }
@@ -128,7 +138,7 @@ internal object NeuroVectorMath {
     fun adjustVector(
         current: ContentVector,
         target: ContentVector,
-        baseRate: Double
+        baseRate: Double,
     ): ContentVector {
         val newTopics = current.topics.toMutableMap()
         val isNegative = baseRate < 0
@@ -136,20 +146,22 @@ internal object NeuroVectorMath {
         target.topics.forEach { (key, targetVal) ->
             val currentVal = newTopics[key] ?: 0.0
 
-            val delta = if (isNegative) {
-                val proportional = currentVal *
-                    currentVal.pow(NEGATIVE_PROPORTIONAL_EXPONENT) * baseRate
-                val absoluteFloor = baseRate * NEGATIVE_FLOOR_FACTOR
-                minOf(proportional, absoluteFloor)
-            } else {
-                val saturationPenalty = (1.0 - currentVal).pow(2)
-                // Cold-topic damping: brand-new topics (currentVal near 0) learn at reduced
-                // rate, requiring sustained engagement to build up.
-                // At 0.0: 50% of base rate. At 0.10: 75%. At 0.20+: ~100%.
-                val coldTopicDamping = (0.5 + 0.5 * (currentVal / 0.20).coerceAtMost(1.0))
-                val effectiveRate = baseRate * saturationPenalty * coldTopicDamping
-                (targetVal - currentVal) * effectiveRate
-            }
+            val delta =
+                if (isNegative) {
+                    val proportional =
+                        currentVal *
+                            currentVal.pow(NEGATIVE_PROPORTIONAL_EXPONENT) * baseRate
+                    val absoluteFloor = baseRate * NEGATIVE_FLOOR_FACTOR
+                    minOf(proportional, absoluteFloor)
+                } else {
+                    val saturationPenalty = (1.0 - currentVal).pow(2)
+                    // Cold-topic damping: brand-new topics (currentVal near 0) learn at reduced
+                    // rate, requiring sustained engagement to build up.
+                    // At 0.0: 50% of base rate. At 0.10: 75%. At 0.20+: ~100%.
+                    val coldTopicDamping = (0.5 + 0.5 * (currentVal / 0.20).coerceAtMost(1.0))
+                    val effectiveRate = baseRate * saturationPenalty * coldTopicDamping
+                    (targetVal - currentVal) * effectiveRate
+                }
 
             newTopics[key] = (currentVal + delta).coerceIn(0.0, 1.0)
         }
@@ -159,11 +171,12 @@ internal object NeuroVectorMath {
             val entry = iterator.next()
             val isCurrentTarget = target.topics.containsKey(entry.key)
             if (baseRate > 0 && !isCurrentTarget) {
-                val tieredDecay = when {
-                    entry.value >= ESTABLISHED_TOPIC_THRESHOLD -> ESTABLISHED_DECAY_RATE
-                    entry.value >= DEVELOPING_TOPIC_THRESHOLD -> DEVELOPING_DECAY_RATE
-                    else -> EMERGING_DECAY_RATE
-                }
+                val tieredDecay =
+                    when {
+                        entry.value >= ESTABLISHED_TOPIC_THRESHOLD -> ESTABLISHED_DECAY_RATE
+                        entry.value >= DEVELOPING_TOPIC_THRESHOLD -> DEVELOPING_DECAY_RATE
+                        else -> EMERGING_DECAY_RATE
+                    }
                 entry.setValue(entry.value * tieredDecay)
             }
             if (!isCurrentTarget && entry.value < TOPIC_PRUNE_THRESHOLD) {
@@ -178,12 +191,15 @@ internal object NeuroVectorMath {
             if (totalMagnitude > 0 &&
                 maxScore / totalMagnitude > COMPRESSION_THRESHOLD
             ) {
-                val compressed = newTopics.mapValues { (_, v) ->
-                    if (v > COMPRESSION_CEILING)
-                        COMPRESSION_CEILING +
-                            (v - COMPRESSION_CEILING) * COMPRESSION_FACTOR
-                    else v
-                }
+                val compressed =
+                    newTopics.mapValues { (_, v) ->
+                        if (v > COMPRESSION_CEILING) {
+                            COMPRESSION_CEILING +
+                                (v - COMPRESSION_CEILING) * COMPRESSION_FACTOR
+                        } else {
+                            v
+                        }
+                    }
                 newTopics.clear()
                 newTopics.putAll(compressed)
             }
@@ -191,11 +207,12 @@ internal object NeuroVectorMath {
 
         fun updateScalar(
             currentScalar: Double,
-            targetScalar: Double
-        ): Double {
-            return if (isNegative) {
-                val proportional = currentScalar * baseRate *
-                    NEGATIVE_SCALAR_PROPORTIONAL
+            targetScalar: Double,
+        ): Double =
+            if (isNegative) {
+                val proportional =
+                    currentScalar * baseRate *
+                        NEGATIVE_SCALAR_PROPORTIONAL
                 val floor = baseRate * NEGATIVE_SCALAR_FLOOR
                 currentScalar + minOf(proportional, floor)
             } else {
@@ -203,31 +220,59 @@ internal object NeuroVectorMath {
                 currentScalar + (targetScalar - currentScalar) *
                     baseRate * saturation
             }.coerceIn(0.0, 1.0)
-        }
 
         return current.copy(
             topics = newTopics,
             duration = updateScalar(current.duration, target.duration),
             pacing = updateScalar(current.pacing, target.pacing),
             complexity = updateScalar(current.complexity, target.complexity),
-            isLive = updateScalar(current.isLive, target.isLive)
+            isLive = updateScalar(current.isLive, target.isLive),
         )
     }
 
-    fun normalizeTopicVector(
-        topics: MutableMap<String, Double>
-    ): Map<String, Double> {
+    /**
+     * Plants the strongest topics of a STRONG-signal video (real watch, like,
+     * save, search) at a survivable weight. Fixes the acquisition wall: on
+     * mature brains, maturity damping × cold-topic damping left new topics
+     * gaining ~0.002/interaction against the 0.03 prune floor — new interests
+     * could mathematically never establish. A planted topic sits just above
+     * the prune line; sustained engagement grows it, abandonment lets the
+     * emerging-tier decay remove it within ~30 interactions.
+     */
+    fun plantTopics(
+        current: ContentVector,
+        source: ContentVector,
+        floor: Double,
+        topK: Int,
+    ): ContentVector {
+        if (source.topics.isEmpty()) return current
+        val planted = current.topics.toMutableMap()
+        source.topics.entries
+            .sortedByDescending { it.value }
+            .asSequence()
+            .filter { it.key.length >= 3 }
+            .take(topK)
+            .forEach { (topic, _) ->
+                if ((planted[topic] ?: 0.0) < floor) planted[topic] = floor
+            }
+        return current.copy(topics = planted)
+    }
+
+    fun normalizeTopicVector(topics: MutableMap<String, Double>): Map<String, Double> {
         if (topics.isEmpty()) return topics
         var magnitude = 0.0
         topics.values.forEach { magnitude += it * it }
         magnitude = sqrt(magnitude)
-        return if (magnitude > 0) topics.mapValues { (_, v) -> v / magnitude }
-        else topics
+        return if (magnitude > 0) {
+            topics.mapValues { (_, v) -> v / magnitude }
+        } else {
+            topics
+        }
     }
 
     fun calculateTitleSimilarity(
         tokens1: Set<String>,
-        tokens2: Set<String>
+        tokens2: Set<String>,
     ): Double {
         if (tokens1.isEmpty() || tokens2.isEmpty()) return 0.0
         val intersection = tokens1.intersect(tokens2).size

--- a/app/src/main/java/io/github/aedev/flow/data/repository/YouTubeRepository.kt
+++ b/app/src/main/java/io/github/aedev/flow/data/repository/YouTubeRepository.kt
@@ -13,6 +13,7 @@ import io.github.aedev.flow.innertube.YouTube
 import io.github.aedev.flow.innertube.models.SongItem
 import io.github.aedev.flow.innertube.models.response.WatchMetadataResponse
 import io.github.aedev.flow.utils.PerformanceDispatcher
+import io.github.aedev.flow.utils.RelativeUploadDateParser
 import io.github.aedev.flow.utils.ThumbnailUrlResolver
 import io.github.aedev.flow.utils.avatarImageIdentityKey
 import io.github.aedev.flow.utils.bestImageUrl
@@ -1687,6 +1688,7 @@ internal object WatchMetadataVideoMapper {
             val id = cv.videoId ?: return@mapNotNull null
             val viewText = cv.viewCountText?.text()
             val isLive = cv.isLive || viewText.isLiveViewCountText()
+            val uploadDateText = cv.publishedTimeText?.text() ?: ""
             Video(
                 id = id,
                 title = cv.title?.text() ?: "",
@@ -1697,7 +1699,11 @@ internal object WatchMetadataVideoMapper {
                         ?: ThumbnailUrlResolver.buildHighQualityYoutubeThumbnail(id),
                 duration = if (isLive) 0 else parseDurationTextToSeconds(cv.lengthText?.text()),
                 viewCount = parseAbbreviatedCount(viewText) ?: 0L,
-                uploadDate = cv.publishedTimeText?.text() ?: "",
+                uploadDate = uploadDateText,
+                // Video.timestamp defaults to now(), which made every related item
+                // look brand new — defeating the age filter and shorts-shelf sort.
+                // Parse the real age; 0 means unknown (callers fall back to text).
+                timestamp = RelativeUploadDateParser.parse(uploadDateText) ?: 0L,
                 isLive = isLive,
             )
         }

--- a/app/src/main/java/io/github/aedev/flow/data/repository/YouTubeRepository.kt
+++ b/app/src/main/java/io/github/aedev/flow/data/repository/YouTubeRepository.kt
@@ -764,6 +764,22 @@ class YouTubeRepository
             }
 
         /**
+         * Fetches a channel's creator-declared keyword tags (+ description) and
+         * feeds them to the recommendation engine — authored channel identity,
+         * used for topic profiles and interest clustering. Best-effort.
+         */
+        suspend fun learnChannelTags(
+            context: android.content.Context,
+            channelId: String,
+        ) {
+            val info = getChannelInfo(channelId) ?: return
+            val tags = info.tags.orEmpty()
+            if (tags.isEmpty() && info.description.isNullOrBlank()) return
+            io.github.aedev.flow.data.recommendation.FlowNeuroEngine
+                .onChannelTagsLearned(context, channelId, tags, info.description)
+        }
+
+        /**
          * PERFORMANCE OPTIMIZED: Aggregate uploads from multiple channels
          * Uses SupervisorScope for error isolation - one failed channel doesn't break others
          * Implements chunked parallel fetching to prevent overwhelming the network

--- a/app/src/main/java/io/github/aedev/flow/data/repository/YouTubeRepository.kt
+++ b/app/src/main/java/io/github/aedev/flow/data/repository/YouTubeRepository.kt
@@ -1530,50 +1530,12 @@ class YouTubeRepository
             textualDate: String?,
         ): Long {
             absoluteMillis?.let { if (it > 0L) return it }
-            val parsed = parseRelativeUploadDate(textualDate)
+            // Shared parser: the old private copy carried the plural-"s" bug
+            // ("3 days" matched the seconds branch), which stamped every
+            // plural-dated subs video as seconds old — stale uploads then won
+            // the recency sort and the fresh-subs slots over genuinely new ones.
+            val parsed = RelativeUploadDateParser.parse(textualDate)
             return parsed ?: System.currentTimeMillis()
-        }
-
-        private fun parseRelativeUploadDate(textualDate: String?): Long? {
-            val raw = textualDate?.trim().orEmpty()
-            if (raw.isBlank()) return null
-
-            val normalized =
-                raw
-                    .lowercase(Locale.US)
-                    .replace("streamed", "")
-                    .replace("premiered", "")
-                    .replace("ago", "")
-                    .trim()
-
-            if (normalized.contains("just now") || normalized.contains("today")) {
-                return System.currentTimeMillis()
-            }
-            if (normalized.contains("yesterday")) {
-                return System.currentTimeMillis() - 24L * 60L * 60L * 1000L
-            }
-
-            val value =
-                Regex("(\\d+)")
-                    .find(normalized)
-                    ?.groupValues
-                    ?.getOrNull(1)
-                    ?.toLongOrNull()
-                    ?: return null
-
-            val unitMillis =
-                when {
-                    normalized.contains("second") || normalized.endsWith("s") -> 1_000L
-                    normalized.contains("minute") || normalized.endsWith("m") -> 60_000L
-                    normalized.contains("hour") || normalized.endsWith("h") -> 3_600_000L
-                    normalized.contains("day") || normalized.endsWith("d") -> 86_400_000L
-                    normalized.contains("week") || normalized.endsWith("w") -> 7L * 86_400_000L
-                    normalized.contains("month") || normalized.endsWith("mo") -> 30L * 86_400_000L
-                    normalized.contains("year") || normalized.endsWith("y") -> 365L * 86_400_000L
-                    else -> return null
-                }
-
-            return System.currentTimeMillis() - (value * unitMillis)
         }
 
         private fun <T> takeRotatingWindow(

--- a/app/src/main/java/io/github/aedev/flow/data/shorts/ShortWatchClassifier.kt
+++ b/app/src/main/java/io/github/aedev/flow/data/shorts/ShortWatchClassifier.kt
@@ -13,7 +13,7 @@ data class ShortWatchSignal(
     val position: Long,
     val safeDuration: Long,
     val percent: Float,
-    val interaction: InteractionType
+    val interaction: InteractionType,
 )
 
 /** Pure watch-signal classification for Shorts, extracted from the ViewModel for testability. */
@@ -21,19 +21,61 @@ object ShortWatchClassifier {
     // Quick flicks below this count as skips, not watches.
     const val MIN_SHORT_WATCH_MS = 2_000L
 
-    fun classify(positionMs: Long, durationMs: Long, videoDurationSec: Int): ShortWatchSignal {
-        val safeDuration = when {
-            durationMs > 0L -> durationMs
-            videoDurationSec > 0 -> videoDurationSec * 1000L
-            else -> positionMs.coerceAtLeast(1_000L)
-        }
+    // Swiping away below this fraction (and before ABANDON_NEUTRAL_MS) reads as rejection.
+    const val ABANDON_SKIP_FRACTION = 0.30f
+
+    // Watching past this fraction before swiping away still counts as a watch.
+    const val ABANDON_WATCH_FRACTION = 0.60f
+
+    // Past this absolute position an early swipe is neutral, not a rejection.
+    const val ABANDON_NEUTRAL_MS = 15_000L
+
+    fun classify(
+        positionMs: Long,
+        durationMs: Long,
+        videoDurationSec: Int,
+    ): ShortWatchSignal {
+        val safeDuration =
+            when {
+                durationMs > 0L -> durationMs
+                videoDurationSec > 0 -> videoDurationSec * 1000L
+                else -> positionMs.coerceAtLeast(1_000L)
+            }
         val position = positionMs.coerceIn(0L, safeDuration)
         val percent = (position.toFloat() / safeDuration.toFloat()).coerceIn(0f, 1f)
-        val interaction = if (position < MIN_SHORT_WATCH_MS) {
-            InteractionType.SKIPPED
-        } else {
-            InteractionType.WATCHED
-        }
+        val interaction =
+            if (position < MIN_SHORT_WATCH_MS) {
+                InteractionType.SKIPPED
+            } else {
+                InteractionType.WATCHED
+            }
         return ShortWatchSignal(position, safeDuration, percent, interaction)
+    }
+
+    /**
+     * Classifies a short the user swiped away from BEFORE the terminal watch fired.
+     * Early abandonment is the clearest negative signal Shorts produce; a swipe
+     * after substantial watching is still positive; the middle band is neutral
+     * (returns null — no engine signal).
+     */
+    fun classifyAbandon(
+        positionMs: Long,
+        durationMs: Long,
+        videoDurationSec: Int,
+    ): ShortWatchSignal? {
+        val base = classify(positionMs, durationMs, videoDurationSec)
+        return when {
+            base.percent >= ABANDON_WATCH_FRACTION -> {
+                base.copy(interaction = InteractionType.WATCHED)
+            }
+
+            base.percent < ABANDON_SKIP_FRACTION && base.position < ABANDON_NEUTRAL_MS -> {
+                base.copy(interaction = InteractionType.SKIPPED)
+            }
+
+            else -> {
+                null
+            }
+        }
     }
 }

--- a/app/src/main/java/io/github/aedev/flow/data/shorts/ShortsDiscoveryEngine.kt
+++ b/app/src/main/java/io/github/aedev/flow/data/shorts/ShortsDiscoveryEngine.kt
@@ -13,6 +13,7 @@ import io.github.aedev.flow.data.model.Video
 import io.github.aedev.flow.data.recommendation.FlowNeuroEngine
 import io.github.aedev.flow.data.recommendation.FlowPersona
 import io.github.aedev.flow.data.repository.YouTubeRepository
+import io.github.aedev.flow.utils.RelativeUploadDateParser
 import io.github.aedev.flow.utils.distinctBestImageUrls
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
@@ -541,43 +542,7 @@ class ShortsDiscoveryEngine private constructor(
         return parseRelativeUploadDate(item.textualUploadDate)
     }
 
-    private fun parseRelativeUploadDate(textualDate: String?): Long? {
-        val raw = textualDate?.trim().orEmpty()
-        if (raw.isBlank()) return null
-
-        val normalized =
-            raw
-                .lowercase()
-                .replace("streamed", "")
-                .replace("premiered", "")
-                .replace("ago", "")
-                .trim()
-
-        val now = System.currentTimeMillis()
-        if (normalized.contains("just now") || normalized.contains("today")) return now
-        if (normalized.contains("yesterday")) return now - 24L * 60L * 60L * 1000L
-
-        val value =
-            Regex("(\\d+)")
-                .find(normalized)
-                ?.groupValues
-                ?.getOrNull(1)
-                ?.toLongOrNull()
-                ?: return null
-        val unitMillis =
-            when {
-                normalized.contains("second") || normalized.endsWith("s") -> 1_000L
-                normalized.contains("minute") || normalized.endsWith("m") -> 60_000L
-                normalized.contains("hour") || normalized.endsWith("h") -> 3_600_000L
-                normalized.contains("day") || normalized.endsWith("d") -> 86_400_000L
-                normalized.contains("week") || normalized.endsWith("w") -> 7L * 86_400_000L
-                normalized.contains("month") || normalized.endsWith("mo") -> 30L * 86_400_000L
-                normalized.contains("year") || normalized.endsWith("y") -> 365L * 86_400_000L
-                else -> return null
-            }
-
-        return now - (value * unitMillis)
-    }
+    private fun parseRelativeUploadDate(textualDate: String?): Long? = RelativeUploadDateParser.parse(textualDate)
 
     fun clearCaches() {
         synchronized(channelShortsCache) { channelShortsCache.clear() }

--- a/app/src/main/java/io/github/aedev/flow/ui/components/QuickActionsViewModel.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/components/QuickActionsViewModel.kt
@@ -4,19 +4,25 @@ import android.content.Context
 import android.widget.Toast
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
+import io.github.aedev.flow.R
 import io.github.aedev.flow.data.local.ChannelSubscription
 import io.github.aedev.flow.data.local.PlaylistRepository
 import io.github.aedev.flow.data.local.SubscriptionRepository
+import io.github.aedev.flow.data.local.entity.DownloadItemStatus
 import io.github.aedev.flow.data.model.Video
 import io.github.aedev.flow.data.recommendation.FlowNeuroEngine
 import io.github.aedev.flow.data.recommendation.InteractionType
 import io.github.aedev.flow.data.repository.YouTubeRepository
+import io.github.aedev.flow.data.video.VideoDownloadManager
+import io.github.aedev.flow.innertube.YouTube
+import io.github.aedev.flow.innertube.models.YouTubeClient
 import io.github.aedev.flow.player.quality.QualityManager
+import io.github.aedev.flow.player.sabr.integration.SabrUrlResolver
 import io.github.aedev.flow.player.stream.AudioStreamSelector
 import io.github.aedev.flow.player.stream.VideoCodecUtils
 import io.github.aedev.flow.utils.ThumbnailUrlResolver
-import dagger.hilt.android.lifecycle.HiltViewModel
-import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -28,16 +34,11 @@ import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
-import io.github.aedev.flow.data.video.VideoDownloadManager
-import io.github.aedev.flow.data.local.entity.DownloadItemStatus
-import io.github.aedev.flow.R
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeoutOrNull
-import io.github.aedev.flow.innertube.YouTube
-import io.github.aedev.flow.innertube.models.YouTubeClient
-import io.github.aedev.flow.player.sabr.integration.SabrUrlResolver
 import javax.inject.Inject
+import org.schabi.newpipe.extractor.stream.VideoStream as NPVideoStream
 
 /**
  * Lightweight singleton event bus for feed-visible state changes.
@@ -46,572 +47,660 @@ import javax.inject.Inject
  */
 object FeedInvalidationBus {
     sealed class Event {
-        data class ChannelBlocked(val channelId: String, val videoId: String) : Event()
-        data class NotInterested(val videoId: String, val channelId: String) : Event()
-        data class MarkedWatched(val videoId: String) : Event()
+        data class ChannelBlocked(
+            val channelId: String,
+            val videoId: String,
+        ) : Event()
+
+        data class NotInterested(
+            val videoId: String,
+            val channelId: String,
+        ) : Event()
+
+        data class MarkedWatched(
+            val videoId: String,
+        ) : Event()
     }
 
     private val _events = MutableSharedFlow<Event>(extraBufferCapacity = 8)
     val events: SharedFlow<Event> = _events.asSharedFlow()
 
-    fun emit(event: Event) { _events.tryEmit(event) }
+    fun emit(event: Event) {
+        _events.tryEmit(event)
+    }
 }
 
 @HiltViewModel
-class QuickActionsViewModel @Inject constructor(
-    private val repository: YouTubeRepository,
-    private val playlistRepository: PlaylistRepository,
-    private val playerPreferences: io.github.aedev.flow.data.local.PlayerPreferences,
-    private val videoDownloadManager: VideoDownloadManager,
-    @ApplicationContext private val context: Context
-) : ViewModel() {
+class QuickActionsViewModel
+    @Inject
+    constructor(
+        private val repository: YouTubeRepository,
+        private val playlistRepository: PlaylistRepository,
+        private val playerPreferences: io.github.aedev.flow.data.local.PlayerPreferences,
+        private val videoDownloadManager: VideoDownloadManager,
+        @ApplicationContext private val context: Context,
+    ) : ViewModel() {
+        private val subscriptionRepository = SubscriptionRepository.getInstance(context)
 
-    private val subscriptionRepository = SubscriptionRepository.getInstance(context)
+        val watchLaterIds =
+            playlistRepository
+                .getWatchLaterIdsFlow()
+                .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptySet())
 
-    val watchLaterIds = playlistRepository.getWatchLaterIdsFlow()
-        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptySet())
+        /** In-memory set of video IDs manually marked as watched this session */
+        private val _watchedVideoIds = MutableStateFlow<Set<String>>(emptySet())
+        val watchedVideoIds = _watchedVideoIds.asStateFlow()
 
-    /** In-memory set of video IDs manually marked as watched this session */
-    private val _watchedVideoIds = MutableStateFlow<Set<String>>(emptySet())
-    val watchedVideoIds = _watchedVideoIds.asStateFlow()
+        /** Per-video subscription state cache: channelId -> Boolean */
+        private val _subscribedChannelIds = MutableStateFlow<Set<String>>(emptySet())
+        val subscribedChannelIds = _subscribedChannelIds.asStateFlow()
 
-    /** Per-video subscription state cache: channelId -> Boolean */
-    private val _subscribedChannelIds = MutableStateFlow<Set<String>>(emptySet())
-    val subscribedChannelIds = _subscribedChannelIds.asStateFlow()
+        val downloadedVideoIds =
+            videoDownloadManager.allDownloads
+                .map { list ->
+                    list
+                        .filter { it.overallStatus == DownloadItemStatus.COMPLETED && it.items.isNotEmpty() }
+                        .map { it.download.videoId }
+                        .toSet()
+                }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptySet())
 
-    val downloadedVideoIds = videoDownloadManager.allDownloads
-        .map { list ->
-            list.filter { it.overallStatus == DownloadItemStatus.COMPLETED && it.items.isNotEmpty() }
-                .map { it.download.videoId }
-                .toSet()
-        }
-        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptySet())
-
-    fun loadSubscriptionState(channelId: String) {
-        viewModelScope.launch {
-            subscriptionRepository.isSubscribed(channelId).collect { subscribed ->
-                if (subscribed) {
-                    _subscribedChannelIds.update { it + channelId }
-                } else {
-                    _subscribedChannelIds.update { it - channelId }
-                }
-            }
-        }
-    }
-
-    fun toggleSubscription(channelId: String, channelName: String, channelThumbnail: String) {
-        viewModelScope.launch {
-            try {
-                val isCurrentlySubscribed = _subscribedChannelIds.value.contains(channelId)
-                if (isCurrentlySubscribed) {
-                    subscriptionRepository.unsubscribe(channelId)
-                    _subscribedChannelIds.update { it - channelId }
-                    Toast.makeText(context, context.getString(R.string.toast_unsubscribed_from, channelName), Toast.LENGTH_SHORT).show()
-                } else {
-                    val resolvedThumbnail = channelThumbnail
-                        .takeUnless { ThumbnailUrlResolver.isYoutubeVideoThumbnail(it) }
-                        ?.takeIf { it.isNotBlank() }
-                        ?: withContext(Dispatchers.IO) {
-                            repository.fetchChannelAvatarById(channelId)
-                        }
-                    subscriptionRepository.subscribe(
-                        ChannelSubscription(
-                            channelId = channelId,
-                            channelName = channelName,
-                            channelThumbnail = resolvedThumbnail,
-                            subscribedAt = System.currentTimeMillis()
-                        )
-                    )
-                    _subscribedChannelIds.update { it + channelId }
-                    Toast.makeText(context, context.getString(R.string.toast_subscribed_to, channelName), Toast.LENGTH_SHORT).show()
-                }
-            } catch (e: Exception) {
-                Toast.makeText(
-                    context,
-                    context.getString(io.github.aedev.flow.R.string.quick_actions_error_template, e.message),
-                    Toast.LENGTH_SHORT
-                ).show()
-            }
-        }
-    }
-
-    fun toggleWatchLater(video: Video) {
-        viewModelScope.launch {
-            try {
-                android.util.Log.d("QuickActionsViewModel", "Toggling Watch Later for video: ${video.id}")
-                val isInWatchLater = playlistRepository.isInWatchLater(video.id)
-                android.util.Log.d("QuickActionsViewModel", "Is currently in Watch Later: $isInWatchLater")
-                
-                if (isInWatchLater) {
-                    playlistRepository.removeFromWatchLater(video.id)
-                    android.util.Log.d("QuickActionsViewModel", "Removed from Watch Later")
-                    Toast.makeText(context, context.getString(R.string.toast_removed_from_watch_later), Toast.LENGTH_SHORT).show()
-                } else {
-                    playlistRepository.addToWatchLater(video)
-                    android.util.Log.d("QuickActionsViewModel", "Added to Watch Later")
-                    Toast.makeText(context, context.getString(R.string.toast_added_to_watch_later), Toast.LENGTH_SHORT).show()
-                }
-            } catch (e: Exception) {
-                android.util.Log.e("QuickActionsViewModel", "Error toggling Watch Later", e)
-                Toast.makeText(
-                    context,
-                    context.getString(io.github.aedev.flow.R.string.quick_actions_error_template, e.message),
-                    Toast.LENGTH_SHORT
-                ).show()
-            }
-        }
-    }
-
-    /**
-     * Block the channel of a video — the channel will never appear in the feed again.
-     * Uses FlowNeuroEngine.blockChannel to persist the block and scrub any existing
-     * channel score, mirroring the "Blocked Channels" UI in User Preferences.
-     */
-    fun blockChannel(video: Video) {
-        viewModelScope.launch {
-            try {
-                val metadata = if (video.channelId.startsWith("UC")) {
-                    null
-                } else {
-                    withContext(Dispatchers.IO) { repository.getLiveWatchMetadata(video.id) }
-                }
-                val channelId = metadata?.channelId.orEmpty().ifBlank { video.channelId }
-                check(channelId.isNotBlank()) {
-                    context.getString(io.github.aedev.flow.R.string.channel_metadata_unavailable)
-                }
-                FlowNeuroEngine.blockChannel(context, channelId)
-                FeedInvalidationBus.emit(
-                    FeedInvalidationBus.Event.ChannelBlocked(channelId, video.id)
-                )
-                Toast.makeText(
-                    context,
-                    context.getString(
-                        io.github.aedev.flow.R.string.channel_blocked_toast,
-                        metadata?.channelName.orEmpty().ifBlank { video.channelName }
-                    ),
-                    Toast.LENGTH_SHORT
-                ).show()
-            } catch (e: Exception) {
-                Toast.makeText(
-                    context,
-                    context.getString(io.github.aedev.flow.R.string.quick_actions_error_template, e.message),
-                    Toast.LENGTH_SHORT
-                ).show()
-            }
-        }
-    }
-
-    /**
-     * Mark a video as "Not Interested" - this strongly penalizes the video's topics
-     * and channel in the FlowNeuroEngine, making similar content much less likely to appear.
-     */
-    fun markNotInterested(video: Video) {
-        viewModelScope.launch {
-            try {
-                FlowNeuroEngine.markNotInterested(context, video)
-                FeedInvalidationBus.emit(
-                    FeedInvalidationBus.Event.NotInterested(video.id, video.channelId)
-                )
-                Toast.makeText(
-                    context,
-                    context.getString(io.github.aedev.flow.R.string.not_interested_toast),
-                    Toast.LENGTH_SHORT
-                ).show()
-            } catch (e: Exception) {
-                Toast.makeText(
-                    context,
-                    context.getString(io.github.aedev.flow.R.string.quick_actions_error_template, e.message),
-                    Toast.LENGTH_SHORT
-                ).show()
-            }
-        }
-    }
-
-    /**
-     * Mark a video as "Watched" - signals a positive WATCHED interaction to FlowNeuroEngine,
-     * boosting the video's topics and channel in recommendations. Useful for quick-starting
-     * the algorithm without replaying the whole video.
-     */
-    fun markAsWatched(video: Video) {
-        viewModelScope.launch {
-            try {
-                FlowNeuroEngine.onVideoInteraction(
-                    context,
-                    video,
-                    InteractionType.WATCHED,
-                    percentWatched = 1.0f
-                )
-                
-                val durationMs = if (video.duration > 0) video.duration * 1000L else 1000L
-                val thumbnailUrl = video.thumbnailUrl.takeIf { it.isNotEmpty() }
-                    ?: "https://i.ytimg.com/vi/${video.id}/hq720.jpg"
-                io.github.aedev.flow.data.local.ViewHistory.getInstance(context).savePlaybackPosition(
-                    videoId = video.id,
-                    position = durationMs,
-                    duration = durationMs,
-                    title = video.title,
-                    thumbnailUrl = thumbnailUrl,
-                    channelName = video.channelName,
-                    channelId = video.channelId,
-                    isMusic = false,
-                    isShort = video.isShort
-                )
-
-                _watchedVideoIds.update { it + video.id }
-                FeedInvalidationBus.emit(FeedInvalidationBus.Event.MarkedWatched(video.id))
-                Toast.makeText(
-                    context,
-                    context.getString(io.github.aedev.flow.R.string.mark_as_watched_toast),
-                    Toast.LENGTH_SHORT
-                ).show()
-            } catch (e: Exception) {
-                Toast.makeText(
-                    context,
-                    context.getString(io.github.aedev.flow.R.string.quick_actions_error_template, e.message),
-                    Toast.LENGTH_SHORT
-                ).show()
-            }
-        }
-    }
-
-    /**
-     * Mark a video as "I like this" - signals a positive LIKED interaction to FlowNeuroEngine,
-     * boosting the video's topics and channel. Helps users seed the algorithm with content
-     * they enjoy without watching the full video in Flow.
-     */
-    fun markAsInteresting(video: Video) {
-        viewModelScope.launch {
-            try {
-                FlowNeuroEngine.onVideoInteraction(
-                    context,
-                    video,
-                    InteractionType.LIKED,
-                    percentWatched = 0f
-                )
-                Toast.makeText(
-                    context,
-                    context.getString(io.github.aedev.flow.R.string.i_like_this_toast),
-                    Toast.LENGTH_SHORT
-                ).show()
-            } catch (e: Exception) {
-                Toast.makeText(
-                    context,
-                    context.getString(io.github.aedev.flow.R.string.quick_actions_error_template, e.message),
-                    Toast.LENGTH_SHORT
-                ).show()
-            }
-        }
-    }
-
-    /**
-     * Insert [video] immediately after the current position (Play Next).
-     */
-    fun playVideoNext(video: Video) {
-        io.github.aedev.flow.player.EnhancedPlayerManager.getInstance().addVideoToQueueNext(video)
-    }
-
-    /**
-     * Append [video] to the end of the current queue.
-     */
-    fun addVideoToQueue(video: Video) {
-        io.github.aedev.flow.player.EnhancedPlayerManager.getInstance().addVideoToQueue(video)
-    }
-
-    fun downloadVideo(video: Video) {
-        viewModelScope.launch {
-            try {
-                io.github.aedev.flow.ui.screens.player.util.VideoPlayerUtils.promptStoragePermissionIfNeeded(context)
-
-                val targetQuality = playerPreferences.defaultDownloadQuality.first()
-                val targetHeight = targetQuality.height
-
-                Toast.makeText(context, context.getString(R.string.toast_fetching_download_links), Toast.LENGTH_SHORT).show()
-
-                // Try innertube extraction first (HD+ quality, direct URLs)
-                val innerTubeResult = withContext(Dispatchers.IO) {
-                    kotlinx.coroutines.withTimeoutOrNull(8000L) {
-                        io.github.aedev.flow.player.stream.InnerTubeVideoStreamExtractor.extract(video.id)
-                    }
-                }
-
-                if (innerTubeResult != null && innerTubeResult.videoFormats.isNotEmpty() && innerTubeResult.audioFormats.isNotEmpty()) {
-                    downloadFromInnerTube(video, innerTubeResult, targetHeight)
-                    return@launch
-                }
-
-                // Fall back to NewPipe StreamInfo
-                val streamInfo = withContext(Dispatchers.IO) {
-                    repository.getVideoStreamInfo(video.id)
-                }
-
-                if (streamInfo != null) {
-                    val videoStreams = io.github.aedev.flow.player.stream.InnerTubeStreamBridge.convertVideoFormats(
-                        innerTubeResult?.videoFormats ?: emptyList()
-                    ).ifEmpty {
-                        (streamInfo.videoStreams + (streamInfo.videoOnlyStreams ?: emptyList()))
-                            .filterIsInstance<org.schabi.newpipe.extractor.stream.VideoStream>()
-                    }
-                    val audioStreams: List<org.schabi.newpipe.extractor.stream.AudioStream> =
-                        io.github.aedev.flow.player.stream.InnerTubeStreamBridge.convertAudioFormats(
-                            innerTubeResult?.audioFormats ?: emptyList()
-                        ).ifEmpty { streamInfo.audioStreams ?: emptyList() }
-
-                    fun isMp4Video(s: org.schabi.newpipe.extractor.stream.VideoStream): Boolean {
-                        val mime  = (s.format?.mimeType ?: "").lowercase()
-                        val fname = (s.format?.name ?: "").lowercase()
-                        return mime.contains("mp4") || fname.contains("mpeg") || fname.contains("mp4")
-                    }
-
-                    fun isVp9Video(s: org.schabi.newpipe.extractor.stream.VideoStream): Boolean {
-                        val mime  = (s.format?.mimeType ?: "").lowercase()
-                        val fname = (s.format?.name ?: "").lowercase()
-                        return mime.contains("vp9") || mime.contains("vp09") ||
-                               fname.contains("vp9") || fname.contains("webm")
-                    }
-
-                    fun qualityHeight(s: org.schabi.newpipe.extractor.stream.VideoStream): Int {
-                        return QualityManager.normalizeQualityHeight(VideoCodecUtils.qualityHeightFromStream(s))
-                    }
-
-                    fun List<org.schabi.newpipe.extractor.stream.VideoStream>.bestForTarget():
-                            org.schabi.newpipe.extractor.stream.VideoStream? {
-                        if (isEmpty()) return null
-                        if (targetHeight == 0) return maxByOrNull { qualityHeight(it) }
-                        return filter { qualityHeight(it) <= targetHeight }.maxByOrNull { qualityHeight(it) }
-                            ?: minByOrNull { qualityHeight(it) }
-                    }
-
-                    val videoOnlyStreams = videoStreams.filter { it.isVideoOnly }
-                    val combinedStreams = videoStreams.filter { !it.isVideoOnly }
-
-                    val bestMp4VideoOnly  = videoOnlyStreams.filter { isMp4Video(it) }.bestForTarget()
-                    val bestVp9VideoOnly  = videoOnlyStreams.filter { isVp9Video(it) }.bestForTarget()
-                    val bestCombined      = combinedStreams.bestForTarget()
-                    val preferredAudioLanguage = playerPreferences.preferredAudioLanguage.first()
-
-                    val allAudio = audioStreams
-
-                    fun isAacCompatible(a: org.schabi.newpipe.extractor.stream.AudioStream): Boolean {
-                        val mime  = (a.format?.mimeType ?: "").lowercase()
-                        val fname = (a.format?.name ?: "").lowercase()
-                        if (fname.contains("opus") || fname.contains("vorbis") ||
-                            mime.contains("opus") || mime.contains("vorbis") ||
-                            fname.contains("webm") || mime.contains("webm")) return false
-                        return true
-                    }
-
-                    fun isOpusCompatible(a: org.schabi.newpipe.extractor.stream.AudioStream): Boolean {
-                        val mime  = (a.format?.mimeType ?: "").lowercase()
-                        val fname = (a.format?.name ?: "").lowercase()
-                        return fname.contains("webm") || mime.contains("audio/webm") ||
-                               fname.contains("opus") || mime.contains("opus")
-                    }
-
-                    val selectedStream: org.schabi.newpipe.extractor.stream.VideoStream?
-                    val audioUrl: String?
-                    val videoCodec: String?
-
-                    when {
-                        bestMp4VideoOnly != null &&
-                                qualityHeight(bestMp4VideoOnly) > (bestCombined?.let(::qualityHeight) ?: 0) -> {
-                            selectedStream = bestMp4VideoOnly
-                            val aacAudio = AudioStreamSelector.selectPreferredAudioStream(
-                                streams = allAudio,
-                                preferredAudioLanguage = preferredAudioLanguage,
-                                compatibilityFilter = ::isAacCompatible
-                            )
-                            audioUrl = aacAudio?.content ?: aacAudio?.url
-                            videoCodec = null
-                        }
-                        bestCombined != null -> {
-                            selectedStream = bestCombined
-                            audioUrl = null
-                            videoCodec = null
-                        }
-                        bestVp9VideoOnly != null &&
-                                (qualityHeight(bestVp9VideoOnly) > (bestMp4VideoOnly?.let(::qualityHeight) ?: 0)) -> {
-                            selectedStream = bestVp9VideoOnly
-                            val opusAudio = AudioStreamSelector.selectPreferredAudioStream(
-                                streams = allAudio,
-                                preferredAudioLanguage = preferredAudioLanguage,
-                                compatibilityFilter = ::isOpusCompatible
-                            )
-                            audioUrl = opusAudio?.content ?: opusAudio?.url
-                            videoCodec = "vp9"
-                        }
-                        bestMp4VideoOnly != null -> {
-                            selectedStream = bestMp4VideoOnly
-                            val aacAudio = AudioStreamSelector.selectPreferredAudioStream(
-                                streams = allAudio,
-                                preferredAudioLanguage = preferredAudioLanguage,
-                                compatibilityFilter = ::isAacCompatible
-                            )
-                            audioUrl = aacAudio?.content ?: aacAudio?.url
-                            videoCodec = null
-                        }
-                        else -> {
-                            selectedStream = null
-                            audioUrl = null
-                            videoCodec = null
-                        }
-                    }
-
-                    val videoUrl = selectedStream?.content ?: selectedStream?.url
-
-                    val fullVideo = Video(
-                        id = video.id,
-                        title = video.title.ifBlank { streamInfo.name ?: "Unknown" },
-                        channelName = video.channelName.ifBlank { streamInfo.uploaderName ?: "" },
-                        channelId = video.channelId.ifBlank { streamInfo.uploaderUrl?.substringAfterLast("/") ?: "local" },
-                        thumbnailUrl = video.thumbnailUrl.ifBlank { streamInfo.thumbnails?.maxByOrNull { it.height }?.url ?: "" },
-                        duration = if (video.duration > 0) video.duration else streamInfo.duration.toInt(),
-                        viewCount = video.viewCount,
-                        uploadDate = video.uploadDate,
-                        description = video.description.ifBlank { streamInfo.description?.content ?: "" }
-                    )
-
-                    if (selectedStream != null && videoUrl != null) {
-                        io.github.aedev.flow.data.video.downloader.FlowDownloadService.startDownload(
-                            context = context,
-                            video = fullVideo,
-                            url = videoUrl,
-                            quality = "${qualityHeight(selectedStream)}p",
-                            audioUrl = audioUrl,
-                            videoCodec = videoCodec
-                        )
-                        Toast.makeText(context, context.getString(R.string.toast_download_started, fullVideo.title), Toast.LENGTH_SHORT).show()
+        fun loadSubscriptionState(channelId: String) {
+            viewModelScope.launch {
+                subscriptionRepository.isSubscribed(channelId).collect { subscribed ->
+                    if (subscribed) {
+                        _subscribedChannelIds.update { it + channelId }
                     } else {
-                        trySabrDownload(fullVideo, targetHeight)
+                        _subscribedChannelIds.update { it - channelId }
                     }
-                } else {
-                    trySabrDownload(video, 0)
-                }
-            } catch (e: Exception) {
-                Toast.makeText(
-                    context,
-                    context.getString(io.github.aedev.flow.R.string.quick_actions_error_template, e.message),
-                    Toast.LENGTH_SHORT
-                ).show()
-            }
-        }
-    }
-
-    private fun downloadFromInnerTube(
-        video: Video,
-        result: io.github.aedev.flow.player.stream.InnerTubeVideoStreamExtractor.VideoExtractionResult,
-        targetHeight: Int
-    ) {
-        val videoFormats = result.videoFormats.filter { it.url != null && it.height != null }
-        val audioFormats = result.audioFormats.filter { it.url != null }
-
-        val bestVideo = if (targetHeight == 0) {
-            videoFormats.maxByOrNull { (it.height ?: 0) * 10000 + it.bitrate }
-        } else {
-            videoFormats.filter { (it.height ?: 0) <= targetHeight }
-                .maxByOrNull { (it.height ?: 0) * 10000 + it.bitrate }
-                ?: videoFormats.minByOrNull { it.height ?: Int.MAX_VALUE }
-        }
-
-        if (bestVideo == null) return
-
-        val isMp4 = bestVideo.mimeType.contains("mp4", ignoreCase = true)
-        val bestAudio = if (isMp4) {
-            audioFormats.filter { it.mimeType.contains("mp4", ignoreCase = true) }
-                .maxByOrNull { it.bitrate }
-                ?: audioFormats.maxByOrNull { it.bitrate }
-        } else {
-            audioFormats.filter { it.mimeType.contains("webm", ignoreCase = true) }
-                .maxByOrNull { it.bitrate }
-                ?: audioFormats.maxByOrNull { it.bitrate }
-        }
-
-        val videoCodec = when {
-            bestVideo.mimeType.contains("vp9", true) || bestVideo.mimeType.contains("vp09", true) -> "vp9"
-            bestVideo.mimeType.contains("av01", true) -> "av1"
-            else -> null
-        }
-
-        var fallbackUrl: String? = null
-        var fallbackAudioUrl: String? = null
-        var fallbackCodec: String? = null
-        var fallbackQuality: String? = null
-        if (videoCodec == "av1") {
-            val fb = videoFormats
-                .filter { it.height == bestVideo.height && !it.mimeType.contains("av01", true) }
-                .maxByOrNull { it.bitrate }
-            if (fb?.url != null) {
-                val fbIsMp4 = fb.mimeType.contains("mp4", ignoreCase = true)
-                val fbAudio = if (fbIsMp4) {
-                    audioFormats.filter { it.mimeType.contains("mp4", true) }.maxByOrNull { it.bitrate }
-                        ?: audioFormats.maxByOrNull { it.bitrate }
-                } else {
-                    audioFormats.filter { it.mimeType.contains("webm", true) }.maxByOrNull { it.bitrate }
-                        ?: audioFormats.maxByOrNull { it.bitrate }
-                }
-                if (fbAudio?.url != null) {
-                    fallbackUrl = fb.url
-                    fallbackAudioUrl = fbAudio.url
-                    fallbackCodec = if (fb.mimeType.contains("vp9", true) || fb.mimeType.contains("vp09", true)) "vp9" else null
-                    fallbackQuality = "${fb.height}p"
                 }
             }
         }
 
-        io.github.aedev.flow.data.video.downloader.FlowDownloadService.startDownload(
-            context = context,
-            video = video,
-            url = bestVideo.url!!,
-            quality = "${bestVideo.height}p",
-            audioUrl = bestAudio?.url,
-            videoCodec = videoCodec,
-            fallbackUrl = fallbackUrl,
-            fallbackAudioUrl = fallbackAudioUrl,
-            fallbackCodec = fallbackCodec,
-            fallbackQuality = fallbackQuality
-        )
-        Toast.makeText(context, context.getString(R.string.toast_download_started, video.title), Toast.LENGTH_SHORT).show()
-    }
+        fun toggleSubscription(
+            channelId: String,
+            channelName: String,
+            channelThumbnail: String,
+        ) {
+            viewModelScope.launch {
+                try {
+                    val isCurrentlySubscribed = _subscribedChannelIds.value.contains(channelId)
+                    if (isCurrentlySubscribed) {
+                        subscriptionRepository.unsubscribe(channelId)
+                        _subscribedChannelIds.update { it - channelId }
+                        Toast.makeText(context, context.getString(R.string.toast_unsubscribed_from, channelName), Toast.LENGTH_SHORT).show()
+                    } else {
+                        val resolvedThumbnail =
+                            channelThumbnail
+                                .takeUnless { ThumbnailUrlResolver.isYoutubeVideoThumbnail(it) }
+                                ?.takeIf { it.isNotBlank() }
+                                ?: withContext(Dispatchers.IO) {
+                                    repository.fetchChannelAvatarById(channelId)
+                                }
+                        subscriptionRepository.subscribe(
+                            ChannelSubscription(
+                                channelId = channelId,
+                                channelName = channelName,
+                                channelThumbnail = resolvedThumbnail,
+                                subscribedAt = System.currentTimeMillis(),
+                            ),
+                        )
+                        _subscribedChannelIds.update { it + channelId }
+                        Toast.makeText(context, context.getString(R.string.toast_subscribed_to, channelName), Toast.LENGTH_SHORT).show()
+                    }
+                    runCatching {
+                        FlowNeuroEngine.onChannelSubscriptionChanged(
+                            context,
+                            channelId,
+                            channelName,
+                            subscribed = !isCurrentlySubscribed,
+                        )
+                    }
+                } catch (e: Exception) {
+                    Toast
+                        .makeText(
+                            context,
+                            context.getString(io.github.aedev.flow.R.string.quick_actions_error_template, e.message),
+                            Toast.LENGTH_SHORT,
+                        ).show()
+                }
+            }
+        }
 
-    private fun trySabrDownload(video: Video, targetHeight: Int) {
-        viewModelScope.launch {
-            try {
-                Toast.makeText(context, context.getString(R.string.toast_trying_sabr_download), Toast.LENGTH_SHORT).show()
-                val sabrInfo = withContext(Dispatchers.IO) {
-                    withTimeoutOrNull(8000L) {
-                        val playerResponse = YouTube.player(video.id, client = YouTubeClient.ANDROID)
-                            .getOrNull() ?: return@withTimeoutOrNull null
-                        if (targetHeight > 0) {
-                            SabrUrlResolver.resolveForQuality(playerResponse, targetHeight)
-                        } else {
-                            SabrUrlResolver.resolve(playerResponse)
+        fun toggleWatchLater(video: Video) {
+            viewModelScope.launch {
+                try {
+                    android.util.Log.d("QuickActionsViewModel", "Toggling Watch Later for video: ${video.id}")
+                    val isInWatchLater = playlistRepository.isInWatchLater(video.id)
+                    android.util.Log.d("QuickActionsViewModel", "Is currently in Watch Later: $isInWatchLater")
+
+                    if (isInWatchLater) {
+                        playlistRepository.removeFromWatchLater(video.id)
+                        android.util.Log.d("QuickActionsViewModel", "Removed from Watch Later")
+                        Toast.makeText(context, context.getString(R.string.toast_removed_from_watch_later), Toast.LENGTH_SHORT).show()
+                    } else {
+                        playlistRepository.addToWatchLater(video)
+                        android.util.Log.d("QuickActionsViewModel", "Added to Watch Later")
+                        runCatching {
+                            FlowNeuroEngine.onVideoInteraction(context, video, InteractionType.SAVED)
                         }
+                        Toast.makeText(context, context.getString(R.string.toast_added_to_watch_later), Toast.LENGTH_SHORT).show()
                     }
+                } catch (e: Exception) {
+                    android.util.Log.e("QuickActionsViewModel", "Error toggling Watch Later", e)
+                    Toast
+                        .makeText(
+                            context,
+                            context.getString(io.github.aedev.flow.R.string.quick_actions_error_template, e.message),
+                            Toast.LENGTH_SHORT,
+                        ).show()
+                }
+            }
+        }
+
+        /**
+         * Block the channel of a video — the channel will never appear in the feed again.
+         * Uses FlowNeuroEngine.blockChannel to persist the block and scrub any existing
+         * channel score, mirroring the "Blocked Channels" UI in User Preferences.
+         */
+        fun blockChannel(video: Video) {
+            viewModelScope.launch {
+                try {
+                    val metadata =
+                        if (video.channelId.startsWith("UC")) {
+                            null
+                        } else {
+                            withContext(Dispatchers.IO) { repository.getLiveWatchMetadata(video.id) }
+                        }
+                    val channelId = metadata?.channelId.orEmpty().ifBlank { video.channelId }
+                    check(channelId.isNotBlank()) {
+                        context.getString(io.github.aedev.flow.R.string.channel_metadata_unavailable)
+                    }
+                    FlowNeuroEngine.blockChannel(context, channelId)
+                    FeedInvalidationBus.emit(
+                        FeedInvalidationBus.Event.ChannelBlocked(channelId, video.id),
+                    )
+                    Toast
+                        .makeText(
+                            context,
+                            context.getString(
+                                io.github.aedev.flow.R.string.channel_blocked_toast,
+                                metadata?.channelName.orEmpty().ifBlank { video.channelName },
+                            ),
+                            Toast.LENGTH_SHORT,
+                        ).show()
+                } catch (e: Exception) {
+                    Toast
+                        .makeText(
+                            context,
+                            context.getString(io.github.aedev.flow.R.string.quick_actions_error_template, e.message),
+                            Toast.LENGTH_SHORT,
+                        ).show()
+                }
+            }
+        }
+
+        /**
+         * Mark a video as "Not Interested" - this strongly penalizes the video's topics
+         * and channel in the FlowNeuroEngine, making similar content much less likely to appear.
+         */
+        fun markNotInterested(video: Video) {
+            viewModelScope.launch {
+                try {
+                    FlowNeuroEngine.markNotInterested(context, video)
+                    FeedInvalidationBus.emit(
+                        FeedInvalidationBus.Event.NotInterested(video.id, video.channelId),
+                    )
+                    Toast
+                        .makeText(
+                            context,
+                            context.getString(io.github.aedev.flow.R.string.not_interested_toast),
+                            Toast.LENGTH_SHORT,
+                        ).show()
+                } catch (e: Exception) {
+                    Toast
+                        .makeText(
+                            context,
+                            context.getString(io.github.aedev.flow.R.string.quick_actions_error_template, e.message),
+                            Toast.LENGTH_SHORT,
+                        ).show()
+                }
+            }
+        }
+
+        /**
+         * Mark a video as "Watched" - signals a positive WATCHED interaction to FlowNeuroEngine,
+         * boosting the video's topics and channel in recommendations. Useful for quick-starting
+         * the algorithm without replaying the whole video.
+         */
+        fun markAsWatched(video: Video) {
+            viewModelScope.launch {
+                try {
+                    FlowNeuroEngine.onVideoInteraction(
+                        context,
+                        video,
+                        InteractionType.WATCHED,
+                        percentWatched = 1.0f,
+                    )
+
+                    val durationMs = if (video.duration > 0) video.duration * 1000L else 1000L
+                    val thumbnailUrl =
+                        video.thumbnailUrl.takeIf { it.isNotEmpty() }
+                            ?: "https://i.ytimg.com/vi/${video.id}/hq720.jpg"
+                    io.github.aedev.flow.data.local.ViewHistory.getInstance(context).savePlaybackPosition(
+                        videoId = video.id,
+                        position = durationMs,
+                        duration = durationMs,
+                        title = video.title,
+                        thumbnailUrl = thumbnailUrl,
+                        channelName = video.channelName,
+                        channelId = video.channelId,
+                        isMusic = false,
+                        isShort = video.isShort,
+                    )
+
+                    _watchedVideoIds.update { it + video.id }
+                    FeedInvalidationBus.emit(FeedInvalidationBus.Event.MarkedWatched(video.id))
+                    Toast
+                        .makeText(
+                            context,
+                            context.getString(io.github.aedev.flow.R.string.mark_as_watched_toast),
+                            Toast.LENGTH_SHORT,
+                        ).show()
+                } catch (e: Exception) {
+                    Toast
+                        .makeText(
+                            context,
+                            context.getString(io.github.aedev.flow.R.string.quick_actions_error_template, e.message),
+                            Toast.LENGTH_SHORT,
+                        ).show()
+                }
+            }
+        }
+
+        /**
+         * Mark a video as "I like this" - signals a positive LIKED interaction to FlowNeuroEngine,
+         * boosting the video's topics and channel. Helps users seed the algorithm with content
+         * they enjoy without watching the full video in Flow.
+         */
+        fun markAsInteresting(video: Video) {
+            viewModelScope.launch {
+                try {
+                    FlowNeuroEngine.onVideoInteraction(
+                        context,
+                        video,
+                        InteractionType.LIKED,
+                        percentWatched = 0f,
+                    )
+                    Toast
+                        .makeText(
+                            context,
+                            context.getString(io.github.aedev.flow.R.string.i_like_this_toast),
+                            Toast.LENGTH_SHORT,
+                        ).show()
+                } catch (e: Exception) {
+                    Toast
+                        .makeText(
+                            context,
+                            context.getString(io.github.aedev.flow.R.string.quick_actions_error_template, e.message),
+                            Toast.LENGTH_SHORT,
+                        ).show()
+                }
+            }
+        }
+
+        /**
+         * Insert [video] immediately after the current position (Play Next).
+         */
+        fun playVideoNext(video: Video) {
+            io.github.aedev.flow.player.EnhancedPlayerManager
+                .getInstance()
+                .addVideoToQueueNext(video)
+        }
+
+        /**
+         * Append [video] to the end of the current queue.
+         */
+        fun addVideoToQueue(video: Video) {
+            io.github.aedev.flow.player.EnhancedPlayerManager
+                .getInstance()
+                .addVideoToQueue(video)
+        }
+
+        fun downloadVideo(video: Video) {
+            viewModelScope.launch {
+                try {
+                    io.github.aedev.flow.ui.screens.player.util.VideoPlayerUtils
+                        .promptStoragePermissionIfNeeded(context)
+
+                    // Downloading is a high-intent save signal for the engine.
+                    runCatching {
+                        FlowNeuroEngine.onVideoInteraction(context, video, InteractionType.SAVED)
+                    }
+
+                    val targetQuality = playerPreferences.defaultDownloadQuality.first()
+                    val targetHeight = targetQuality.height
+
+                    Toast.makeText(context, context.getString(R.string.toast_fetching_download_links), Toast.LENGTH_SHORT).show()
+
+                    // Try innertube extraction first (HD+ quality, direct URLs)
+                    val innerTubeResult =
+                        withContext(Dispatchers.IO) {
+                            kotlinx.coroutines.withTimeoutOrNull(8000L) {
+                                io.github.aedev.flow.player.stream.InnerTubeVideoStreamExtractor
+                                    .extract(video.id)
+                            }
+                        }
+
+                    if (innerTubeResult != null && innerTubeResult.videoFormats.isNotEmpty() && innerTubeResult.audioFormats.isNotEmpty()) {
+                        downloadFromInnerTube(video, innerTubeResult, targetHeight)
+                        return@launch
+                    }
+
+                    // Fall back to NewPipe StreamInfo
+                    val streamInfo =
+                        withContext(Dispatchers.IO) {
+                            repository.getVideoStreamInfo(video.id)
+                        }
+
+                    if (streamInfo != null) {
+                        val videoStreams =
+                            io.github.aedev.flow.player.stream.InnerTubeStreamBridge
+                                .convertVideoFormats(
+                                    innerTubeResult?.videoFormats ?: emptyList(),
+                                ).ifEmpty {
+                                    (streamInfo.videoStreams + (streamInfo.videoOnlyStreams ?: emptyList()))
+                                        .filterIsInstance<org.schabi.newpipe.extractor.stream.VideoStream>()
+                                }
+                        val audioStreams: List<org.schabi.newpipe.extractor.stream.AudioStream> =
+                            io.github.aedev.flow.player.stream.InnerTubeStreamBridge
+                                .convertAudioFormats(
+                                    innerTubeResult?.audioFormats ?: emptyList(),
+                                ).ifEmpty { streamInfo.audioStreams ?: emptyList() }
+
+                        fun isMp4Video(s: org.schabi.newpipe.extractor.stream.VideoStream): Boolean {
+                            val mime = (s.format?.mimeType ?: "").lowercase()
+                            val fname = (s.format?.name ?: "").lowercase()
+                            return mime.contains("mp4") || fname.contains("mpeg") || fname.contains("mp4")
+                        }
+
+                        fun isVp9Video(s: org.schabi.newpipe.extractor.stream.VideoStream): Boolean {
+                            val mime = (s.format?.mimeType ?: "").lowercase()
+                            val fname = (s.format?.name ?: "").lowercase()
+                            return mime.contains("vp9") || mime.contains("vp09") ||
+                                fname.contains("vp9") || fname.contains("webm")
+                        }
+
+                        fun qualityHeight(s: org.schabi.newpipe.extractor.stream.VideoStream): Int =
+                            QualityManager.normalizeQualityHeight(VideoCodecUtils.qualityHeightFromStream(s))
+
+                        fun List<NPVideoStream>.bestForTarget(): NPVideoStream? {
+                            if (isEmpty()) return null
+                            if (targetHeight == 0) return maxByOrNull { qualityHeight(it) }
+                            return filter { qualityHeight(it) <= targetHeight }.maxByOrNull { qualityHeight(it) }
+                                ?: minByOrNull { qualityHeight(it) }
+                        }
+
+                        val videoOnlyStreams = videoStreams.filter { it.isVideoOnly }
+                        val combinedStreams = videoStreams.filter { !it.isVideoOnly }
+
+                        val bestMp4VideoOnly = videoOnlyStreams.filter { isMp4Video(it) }.bestForTarget()
+                        val bestVp9VideoOnly = videoOnlyStreams.filter { isVp9Video(it) }.bestForTarget()
+                        val bestCombined = combinedStreams.bestForTarget()
+                        val preferredAudioLanguage = playerPreferences.preferredAudioLanguage.first()
+
+                        val allAudio = audioStreams
+
+                        fun isAacCompatible(a: org.schabi.newpipe.extractor.stream.AudioStream): Boolean {
+                            val mime = (a.format?.mimeType ?: "").lowercase()
+                            val fname = (a.format?.name ?: "").lowercase()
+                            if (fname.contains("opus") || fname.contains("vorbis") ||
+                                mime.contains("opus") || mime.contains("vorbis") ||
+                                fname.contains("webm") || mime.contains("webm")
+                            ) {
+                                return false
+                            }
+                            return true
+                        }
+
+                        fun isOpusCompatible(a: org.schabi.newpipe.extractor.stream.AudioStream): Boolean {
+                            val mime = (a.format?.mimeType ?: "").lowercase()
+                            val fname = (a.format?.name ?: "").lowercase()
+                            return fname.contains("webm") || mime.contains("audio/webm") ||
+                                fname.contains("opus") || mime.contains("opus")
+                        }
+
+                        val selectedStream: org.schabi.newpipe.extractor.stream.VideoStream?
+                        val audioUrl: String?
+                        val videoCodec: String?
+
+                        val mp4Height = bestMp4VideoOnly?.let(::qualityHeight) ?: 0
+                        val combinedHeight = bestCombined?.let(::qualityHeight) ?: 0
+                        val vp9Height = bestVp9VideoOnly?.let(::qualityHeight) ?: 0
+
+                        when {
+                            bestMp4VideoOnly != null && mp4Height > combinedHeight -> {
+                                selectedStream = bestMp4VideoOnly
+                                val aacAudio =
+                                    AudioStreamSelector.selectPreferredAudioStream(
+                                        streams = allAudio,
+                                        preferredAudioLanguage = preferredAudioLanguage,
+                                        compatibilityFilter = ::isAacCompatible,
+                                    )
+                                audioUrl = aacAudio?.content ?: aacAudio?.url
+                                videoCodec = null
+                            }
+
+                            bestCombined != null -> {
+                                selectedStream = bestCombined
+                                audioUrl = null
+                                videoCodec = null
+                            }
+
+                            bestVp9VideoOnly != null && vp9Height > mp4Height -> {
+                                selectedStream = bestVp9VideoOnly
+                                val opusAudio =
+                                    AudioStreamSelector.selectPreferredAudioStream(
+                                        streams = allAudio,
+                                        preferredAudioLanguage = preferredAudioLanguage,
+                                        compatibilityFilter = ::isOpusCompatible,
+                                    )
+                                audioUrl = opusAudio?.content ?: opusAudio?.url
+                                videoCodec = "vp9"
+                            }
+
+                            bestMp4VideoOnly != null -> {
+                                selectedStream = bestMp4VideoOnly
+                                val aacAudio =
+                                    AudioStreamSelector.selectPreferredAudioStream(
+                                        streams = allAudio,
+                                        preferredAudioLanguage = preferredAudioLanguage,
+                                        compatibilityFilter = ::isAacCompatible,
+                                    )
+                                audioUrl = aacAudio?.content ?: aacAudio?.url
+                                videoCodec = null
+                            }
+
+                            else -> {
+                                selectedStream = null
+                                audioUrl = null
+                                videoCodec = null
+                            }
+                        }
+
+                        val videoUrl = selectedStream?.content ?: selectedStream?.url
+
+                        val fullVideo =
+                            Video(
+                                id = video.id,
+                                title = video.title.ifBlank { streamInfo.name ?: "Unknown" },
+                                channelName = video.channelName.ifBlank { streamInfo.uploaderName ?: "" },
+                                channelId = video.channelId.ifBlank { streamInfo.uploaderUrl?.substringAfterLast("/") ?: "local" },
+                                thumbnailUrl = video.thumbnailUrl.ifBlank { streamInfo.thumbnails?.maxByOrNull { it.height }?.url ?: "" },
+                                duration = if (video.duration > 0) video.duration else streamInfo.duration.toInt(),
+                                viewCount = video.viewCount,
+                                uploadDate = video.uploadDate,
+                                description = video.description.ifBlank { streamInfo.description?.content ?: "" },
+                            )
+
+                        if (selectedStream != null && videoUrl != null) {
+                            io.github.aedev.flow.data.video.downloader.FlowDownloadService.startDownload(
+                                context = context,
+                                video = fullVideo,
+                                url = videoUrl,
+                                quality = "${qualityHeight(selectedStream)}p",
+                                audioUrl = audioUrl,
+                                videoCodec = videoCodec,
+                            )
+                            val startedMessage = context.getString(R.string.toast_download_started, fullVideo.title)
+                            Toast.makeText(context, startedMessage, Toast.LENGTH_SHORT).show()
+                        } else {
+                            trySabrDownload(fullVideo, targetHeight)
+                        }
+                    } else {
+                        trySabrDownload(video, 0)
+                    }
+                } catch (e: Exception) {
+                    Toast
+                        .makeText(
+                            context,
+                            context.getString(io.github.aedev.flow.R.string.quick_actions_error_template, e.message),
+                            Toast.LENGTH_SHORT,
+                        ).show()
+                }
+            }
+        }
+
+        private fun downloadFromInnerTube(
+            video: Video,
+            result: io.github.aedev.flow.player.stream.InnerTubeVideoStreamExtractor.VideoExtractionResult,
+            targetHeight: Int,
+        ) {
+            val videoFormats = result.videoFormats.filter { it.url != null && it.height != null }
+            val audioFormats = result.audioFormats.filter { it.url != null }
+
+            val bestVideo =
+                if (targetHeight == 0) {
+                    videoFormats.maxByOrNull { (it.height ?: 0) * 10000 + it.bitrate }
+                } else {
+                    videoFormats
+                        .filter { (it.height ?: 0) <= targetHeight }
+                        .maxByOrNull { (it.height ?: 0) * 10000 + it.bitrate }
+                        ?: videoFormats.minByOrNull { it.height ?: Int.MAX_VALUE }
                 }
 
-                if (sabrInfo != null) {
-                    val codecHint = if (sabrInfo.videoItag in listOf(313, 271, 308, 248, 303, 247, 302, 244, 243, 242)) "vp9" else null
-                    io.github.aedev.flow.data.video.downloader.FlowDownloadService.startSabrDownload(
-                        context = context,
-                        video = video,
-                        quality = "${targetHeight.takeIf { it > 0 } ?: "best"}p",
-                        sabrStreamingUrl = sabrInfo.streamingUrl,
-                        audioItag = sabrInfo.audioItag,
-                        audioLmt = sabrInfo.audioLmt,
-                        videoItag = sabrInfo.videoItag,
-                        videoLmt = sabrInfo.videoLmt,
-                        poToken = sabrInfo.poToken,
-                        visitorId = sabrInfo.visitorId,
-                        ustreamerConfig = sabrInfo.ustreamerConfig,
-                        durationMs = sabrInfo.durationMs,
-                        videoCodec = codecHint
-                    )
-                    Toast.makeText(context, context.getString(R.string.toast_sabr_download_started_for_video, video.title), Toast.LENGTH_SHORT).show()
+            if (bestVideo == null) return
+
+            val isMp4 = bestVideo.mimeType.contains("mp4", ignoreCase = true)
+            val bestAudio =
+                if (isMp4) {
+                    audioFormats
+                        .filter { it.mimeType.contains("mp4", ignoreCase = true) }
+                        .maxByOrNull { it.bitrate }
+                        ?: audioFormats.maxByOrNull { it.bitrate }
                 } else {
-                    Toast.makeText(context, context.getString(R.string.toast_no_download_source), Toast.LENGTH_SHORT).show()
+                    audioFormats
+                        .filter { it.mimeType.contains("webm", ignoreCase = true) }
+                        .maxByOrNull { it.bitrate }
+                        ?: audioFormats.maxByOrNull { it.bitrate }
                 }
-            } catch (e: Exception) {
-                Toast.makeText(context, context.getString(R.string.toast_sabr_download_failed, e.message), Toast.LENGTH_SHORT).show()
+
+            val videoCodec =
+                when {
+                    bestVideo.mimeType.contains("vp9", true) || bestVideo.mimeType.contains("vp09", true) -> "vp9"
+                    bestVideo.mimeType.contains("av01", true) -> "av1"
+                    else -> null
+                }
+
+            var fallbackUrl: String? = null
+            var fallbackAudioUrl: String? = null
+            var fallbackCodec: String? = null
+            var fallbackQuality: String? = null
+            if (videoCodec == "av1") {
+                val fb =
+                    videoFormats
+                        .filter { it.height == bestVideo.height && !it.mimeType.contains("av01", true) }
+                        .maxByOrNull { it.bitrate }
+                if (fb?.url != null) {
+                    val fbIsMp4 = fb.mimeType.contains("mp4", ignoreCase = true)
+                    val fbAudio =
+                        if (fbIsMp4) {
+                            audioFormats.filter { it.mimeType.contains("mp4", true) }.maxByOrNull { it.bitrate }
+                                ?: audioFormats.maxByOrNull { it.bitrate }
+                        } else {
+                            audioFormats.filter { it.mimeType.contains("webm", true) }.maxByOrNull { it.bitrate }
+                                ?: audioFormats.maxByOrNull { it.bitrate }
+                        }
+                    if (fbAudio?.url != null) {
+                        fallbackUrl = fb.url
+                        fallbackAudioUrl = fbAudio.url
+                        fallbackCodec = if (fb.mimeType.contains("vp9", true) || fb.mimeType.contains("vp09", true)) "vp9" else null
+                        fallbackQuality = "${fb.height}p"
+                    }
+                }
+            }
+
+            io.github.aedev.flow.data.video.downloader.FlowDownloadService.startDownload(
+                context = context,
+                video = video,
+                url = bestVideo.url!!,
+                quality = "${bestVideo.height}p",
+                audioUrl = bestAudio?.url,
+                videoCodec = videoCodec,
+                fallbackUrl = fallbackUrl,
+                fallbackAudioUrl = fallbackAudioUrl,
+                fallbackCodec = fallbackCodec,
+                fallbackQuality = fallbackQuality,
+            )
+            Toast.makeText(context, context.getString(R.string.toast_download_started, video.title), Toast.LENGTH_SHORT).show()
+        }
+
+        private fun trySabrDownload(
+            video: Video,
+            targetHeight: Int,
+        ) {
+            viewModelScope.launch {
+                try {
+                    Toast.makeText(context, context.getString(R.string.toast_trying_sabr_download), Toast.LENGTH_SHORT).show()
+                    val sabrInfo =
+                        withContext(Dispatchers.IO) {
+                            withTimeoutOrNull(8000L) {
+                                val playerResponse =
+                                    YouTube
+                                        .player(video.id, client = YouTubeClient.ANDROID)
+                                        .getOrNull() ?: return@withTimeoutOrNull null
+                                if (targetHeight > 0) {
+                                    SabrUrlResolver.resolveForQuality(playerResponse, targetHeight)
+                                } else {
+                                    SabrUrlResolver.resolve(playerResponse)
+                                }
+                            }
+                        }
+
+                    if (sabrInfo != null) {
+                        val codecHint = if (sabrInfo.videoItag in listOf(313, 271, 308, 248, 303, 247, 302, 244, 243, 242)) "vp9" else null
+                        io.github.aedev.flow.data.video.downloader.FlowDownloadService.startSabrDownload(
+                            context = context,
+                            video = video,
+                            quality = "${targetHeight.takeIf { it > 0 } ?: "best"}p",
+                            sabrStreamingUrl = sabrInfo.streamingUrl,
+                            audioItag = sabrInfo.audioItag,
+                            audioLmt = sabrInfo.audioLmt,
+                            videoItag = sabrInfo.videoItag,
+                            videoLmt = sabrInfo.videoLmt,
+                            poToken = sabrInfo.poToken,
+                            visitorId = sabrInfo.visitorId,
+                            ustreamerConfig = sabrInfo.ustreamerConfig,
+                            durationMs = sabrInfo.durationMs,
+                            videoCodec = codecHint,
+                        )
+                        val sabrMessage = context.getString(R.string.toast_sabr_download_started_for_video, video.title)
+                        Toast.makeText(context, sabrMessage, Toast.LENGTH_SHORT).show()
+                    } else {
+                        Toast.makeText(context, context.getString(R.string.toast_no_download_source), Toast.LENGTH_SHORT).show()
+                    }
+                } catch (e: Exception) {
+                    Toast.makeText(context, context.getString(R.string.toast_sabr_download_failed, e.message), Toast.LENGTH_SHORT).show()
+                }
             }
         }
     }
-}

--- a/app/src/main/java/io/github/aedev/flow/ui/components/QuickActionsViewModel.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/components/QuickActionsViewModel.kt
@@ -155,6 +155,10 @@ class QuickActionsViewModel
                             subscribed = !isCurrentlySubscribed,
                         )
                     }
+                    if (!isCurrentlySubscribed) {
+                        // Newly subscribed: learn the channel's declared keyword tags.
+                        runCatching { repository.learnChannelTags(context, channelId) }
+                    }
                 } catch (e: Exception) {
                     Toast
                         .makeText(

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/home/HomeViewModel.kt
@@ -565,6 +565,7 @@ class HomeViewModel
     constructor(
         private val repository: YouTubeRepository,
         private val subscriptionRepository: SubscriptionRepository,
+        private val subscriptionFeedRepository: io.github.aedev.flow.data.subscriptions.SubscriptionFeedRepository,
         private val shortsRepository: ShortsRepository,
         private val playerPreferences: io.github.aedev.flow.data.local.PlayerPreferences,
         private val shortsQueueHandoff: io.github.aedev.flow.data.shorts.queue.ShortsQueueHandoff,
@@ -1045,6 +1046,10 @@ class HomeViewModel
                     val relatedFetch = results.related
                     val rawRelated = relatedFetch.candidates
 
+                    // Passive channel profiling: the upload titles we just fetched
+                    // teach the engine what each subscribed channel is about.
+                    runCatching { FlowNeuroEngine.onChannelUploadsObserved(rawSubs) }
+
                     // Stale-query feedback: queries whose results are mostly
                     // already-shown get skipped by the next generation cycle.
                     reportQueryNovelty(discoveryPairs)
@@ -1126,9 +1131,24 @@ class HomeViewModel
 
                     val subsByRecency = subsPool.sortedByDescending { it.timestamp }
                     val freshSlotTarget = dynamicFreshSubSlots(userSubs.size)
+
+                    // Fresh-subs lane is RSS-FIRST: the subscription feed store covers
+                    // ALL subscribed channels with real publish timestamps, so a fresh
+                    // upload is visible even when its channel missed this refresh's
+                    // rotating 10-18 channel fetch window.
+                    val rssFresh =
+                        runCatching { subscriptionFeedRepository.observeFeed().first() }
+                            .getOrDefault(emptyList())
+                            .asSequence()
+                            .filter { !it.isShort && !it.isUpcoming && (it.duration > 0 || it.isLive) }
+                            .filter { (now - it.timestamp) in 0..FRESH_SUB_WINDOW_MS }
+                            .filter { it.channelId.isBlank() || it.channelId !in excludedChannels }
+                            .toList()
                     val freshSubsLane =
-                        subsByRecency
-                            .filter { isFreshSubscribedCandidate(it, now) }
+                        (rssFresh + subsByRecency.filter { isFreshSubscribedCandidate(it, now) })
+                            .filterWatched(watched)
+                            .distinctBy { it.id }
+                            .sortedByDescending { it.timestamp }
                             .take(freshSlotTarget)
                     val freshIds = freshSubsLane.map { it.id }.toHashSet()
 

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/home/HomeViewModel.kt
@@ -949,7 +949,9 @@ class HomeViewModel
             viewModelScope.launch(PerformanceDispatcher.networkIO) {
                 try {
                     discoveryQueries.clear()
-                    discoveryQueries.addAll(FlowNeuroEngine.generateDiscoveryQueries())
+                    // A refresh restarts the discovery tree at its roots (broad pass);
+                    // load-more regenerations then dig deeper per cluster.
+                    discoveryQueries.addAll(FlowNeuroEngine.generateDiscoveryQueries(resetDepth = true))
                     currentQueryIndex = 0
 
                     val userSubs = subscriptionRepository.getAllSubscriptionIds()

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/home/HomeViewModel.kt
@@ -168,7 +168,7 @@ internal fun applyGraphBoost(
 
 private data class Wave1FeedResults(
     val subs: List<Video>,
-    val discovery: List<Video>,
+    val discovery: List<Pair<String, List<Video>>>,
     val viral: List<Video>,
     val related: RelatedGraphFetchResult,
 )
@@ -981,12 +981,12 @@ class HomeViewModel
                                     wave1Queries
                                         .map { query ->
                                             async {
-                                                runCatching {
-                                                    repository.searchVideos(query).first
-                                                }.getOrElse { emptyList() }
+                                                query to
+                                                    runCatching {
+                                                        repository.searchVideos(query).first
+                                                    }.getOrElse { emptyList() }
                                             }
                                         }.awaitAll()
-                                        .flatten()
                                 }
 
                             val deferredViral =
@@ -1037,10 +1037,15 @@ class HomeViewModel
                         }
 
                     val rawSubs = results.subs
-                    val rawDiscovery = results.discovery
+                    val discoveryPairs = results.discovery
+                    val rawDiscovery = discoveryPairs.flatMap { it.second }
                     val rawViral = results.viral
                     val relatedFetch = results.related
                     val rawRelated = relatedFetch.candidates
+
+                    // Stale-query feedback: queries whose results are mostly
+                    // already-shown get skipped by the next generation cycle.
+                    reportQueryNovelty(discoveryPairs)
 
                     Log.d(TAG, "Wave 1 fetch completed in ${System.currentTimeMillis() - fetchStart}ms")
 
@@ -1143,6 +1148,19 @@ class HomeViewModel
                     val usedVideoIds = mutableSetOf<String>()
                     var freshAdded = 0
 
+                    // A refresh should produce a fresh feed: exclude what is on
+                    // screen right now, unless the lanes are too thin to afford it.
+                    val onScreenIds = _uiState.value.videos.mapTo(HashSet()) { it.id }
+                    if (onScreenIds.isNotEmpty()) {
+                        val laneCandidates =
+                            freshSubsLane.asSequence() + bestSubs.asSequence() +
+                                bestRelated.asSequence() + bestDiscovery.asSequence() + bestViral.asSequence()
+                        val freshCandidateCount = laneCandidates.distinctBy { it.id }.count { it.id !in onScreenIds }
+                        if (freshCandidateCount >= HOME_TARGET_SIZE / 2) {
+                            usedVideoIds += onScreenIds
+                        }
+                    }
+
                     freshSubsLane.forEach { video ->
                         if (addUnique(video, finalMix, usedChannelCounts, usedVideoIds)) freshAdded++
                     }
@@ -1242,23 +1260,27 @@ class HomeViewModel
                                         wave2Queries
                                             .map { q ->
                                                 async {
-                                                    withTimeoutOrNull(6_000L) {
-                                                        try {
-                                                            repository.searchVideos(q).first
-                                                        } catch (cancellation: CancellationException) {
-                                                            throw cancellation
-                                                        } catch (error: Exception) {
-                                                            Log.d(TAG, "Wave 2 query failed for $q: ${error.message}")
-                                                            emptyList()
-                                                        }
-                                                    } ?: emptyList()
+                                                    q to (
+                                                        withTimeoutOrNull(6_000L) {
+                                                            try {
+                                                                repository.searchVideos(q).first
+                                                            } catch (cancellation: CancellationException) {
+                                                                throw cancellation
+                                                            } catch (error: Exception) {
+                                                                Log.d(TAG, "Wave 2 query failed for $q: ${error.message}")
+                                                                emptyList()
+                                                            }
+                                                        } ?: emptyList()
+                                                    )
                                                 }
                                             }.awaitAll()
-                                            .flatten()
+
+                                    reportQueryNovelty(wave2Raw)
 
                                     val wave2Watched = watchedVideoIds.value
                                     val wave2Valid =
                                         wave2Raw
+                                            .flatMap { it.second }
                                             .filterValid()
                                             .filterWatched(wave2Watched)
                                             .filter { !wave2FinalMixIds.contains(it.id) }
@@ -1307,6 +1329,28 @@ class HomeViewModel
             }
         }
 
+        /**
+         * Reports per-query result novelty to the engine: a query whose results
+         * are mostly videos already shown recently gets marked stale and skipped
+         * by the next discovery-generation cycle.
+         */
+        private suspend fun reportQueryNovelty(pairs: List<Pair<String, List<Video>>>) {
+            if (pairs.isEmpty()) return
+            runCatching {
+                val recentlyShown = FlowNeuroEngine.getRecentlyShownVideoIds(48L)
+                if (recentlyShown.isEmpty()) return
+                pairs.forEach { (query, queryResults) ->
+                    if (queryResults.size >= 5) {
+                        val novel = queryResults.count { it.id !in recentlyShown }
+                        FlowNeuroEngine.reportQueryResultNovelty(
+                            query,
+                            novel.toDouble() / queryResults.size,
+                        )
+                    }
+                }
+            }
+        }
+
         private suspend fun loadNextPrefetchPage(generation: Int): Boolean {
             try {
                 val now = System.currentTimeMillis()
@@ -1339,6 +1383,11 @@ class HomeViewModel
                         usedVideoIds = pageIds,
                         targetSize = MIN_PAGE_SIZE,
                     )
+                if (reserveAdded > 0) {
+                    runCatching {
+                        persistentHomeFeedCache.consumeReserve(page.take(reserveAdded).map { it.id })
+                    }
+                }
                 if (page.size >= MIN_PAGE_SIZE) {
                     val appended = appendLoadMorePage(page, generation)
                     appended?.let { persistentHomeFeedCache.saveLastFeed(it) }

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/home/HomeViewModel.kt
@@ -584,10 +584,17 @@ class HomeViewModel
             private const val RELATED_TTL_MS = 45L * 60L * 1000L
             private const val MAX_RELATED_SEEDS = 4
             private const val MIN_PAGE_SIZE = 8
-            private const val LOAD_MORE_GRAPH_SEEDS = 2
+            private const val LOAD_MORE_GRAPH_SEEDS = 3
             private const val MAX_SAVED_SEEDS = 5
             private const val SAVED_RELATED_SLOTS = 8
             private const val SAVED_SEED_COOLDOWN_MS = 3L * 60L * 60L * 1000L
+
+            // Fresh subs pinned to the very top; the rest interleave via the SUBS lane.
+            private const val FRESH_SUBS_PIN_TOP = 2
+
+            // Never-dry load-more: fallback related pass seeded from feed + saved interests.
+            private const val LOAD_MORE_FALLBACK_SEEDS = 4
+            private const val FEED_SEED_POOL = 30
         }
 
         // Saved-interest enrichment sources (history/liked/playlists) + per-seed cooldown.
@@ -1149,8 +1156,17 @@ class HomeViewModel
                             .filterWatched(watched)
                             .distinctBy { it.id }
                             .sortedByDescending { it.timestamp }
+                            // One fresh slot per channel — a channel that uploaded three
+                            // times today must not occupy three fresh slots.
+                            .distinctBy { it.channelId.ifBlank { it.id } }
                             .take(freshSlotTarget)
                     val freshIds = freshSubsLane.map { it.id }.toHashSet()
+
+                    // Only a couple of fresh subs are pinned to the very top; the rest
+                    // ride the SUBS lane so the first screen is a real source MIX
+                    // instead of a wall of subscriptions.
+                    val pinnedFresh = freshSubsLane.take(FRESH_SUBS_PIN_TOP)
+                    val overflowFresh = freshSubsLane.drop(FRESH_SUBS_PIN_TOP)
 
                     val rankedSubs = FlowNeuroEngine.rank(subsPool, userSubs)
                     val bestSubs =
@@ -1192,7 +1208,7 @@ class HomeViewModel
                         }
                     }
 
-                    freshSubsLane.forEach { video ->
+                    pinnedFresh.forEach { video ->
                         if (addUnique(video, finalMix, usedChannelCounts, usedVideoIds)) freshAdded++
                     }
 
@@ -1202,7 +1218,7 @@ class HomeViewModel
                         blendFeedSources(
                             lanes =
                                 mapOf(
-                                    FeedSource.SUBS to bestSubs,
+                                    FeedSource.SUBS to (overflowFresh + bestSubs),
                                     FeedSource.RELATED to bestRelated,
                                     FeedSource.DISCOVERY to bestDiscovery,
                                     FeedSource.VIRAL to bestViral,
@@ -1426,7 +1442,9 @@ class HomeViewModel
                     return appended != null
                 }
 
-                val seedInputs = buildSeedInputs()
+                // Load-more digs related lanes from the widest seed universe:
+                // history + liked + playlists + the feed videos on screen.
+                val seedInputs = loadMoreSeedInputs()
                 val seedIds = FlowNeuroEngine.selectRelatedSeeds(seedInputs, LOAD_MORE_GRAPH_SEEDS)
                 if (seedIds.isNotEmpty()) {
                     val graphFetch = fetchRelatedGraph(seedInputs, seedIds)
@@ -1552,6 +1570,44 @@ class HomeViewModel
                         targetSize = MIN_PAGE_SIZE,
                     )
                     subsBacklog = subsBacklog.filterNot { pageIds.contains(it.id) }
+                }
+
+                // Never run dry: when every other source thinned out, escalate with a
+                // wider related pass — more seeds, drawn from the feed itself and saved
+                // interests. The engine's seed cooldown keeps the lanes rotating, and
+                // its scarcity fallback re-admits cooled seeds when the pool is thin.
+                if (page.size < MIN_PAGE_SIZE) {
+                    val fallbackInputs = loadMoreSeedInputs()
+                    val fallbackSeeds =
+                        FlowNeuroEngine.selectRelatedSeeds(fallbackInputs, LOAD_MORE_FALLBACK_SEEDS)
+                    if (fallbackSeeds.isNotEmpty() && homePrefetchQueue.isCurrent(generation)) {
+                        val fallbackFetch = fetchRelatedGraph(fallbackInputs, fallbackSeeds)
+                        val fallbackCandidates =
+                            fallbackFetch.candidates
+                                .filterValidGraph()
+                                .filterWatchedGraph(watchedVideoIds.value)
+                                .filterRecentHomeSuggestionGraph(now)
+                        val fallbackMetadata = fallbackCandidates.associateBy { it.video.id }
+                        val fallbackRanked =
+                            demoteByFit(
+                                applyGraphBoost(
+                                    FlowNeuroEngine.rank(fallbackCandidates.map { it.video }, userSubs),
+                                    fallbackMetadata,
+                                ),
+                                taste,
+                            )
+                        addUniquePageVideos(
+                            candidates = fallbackRanked,
+                            targetList = page,
+                            channelCounts = channelCounts,
+                            usedVideoIds = pageIds,
+                            targetSize = MIN_PAGE_SIZE,
+                        )
+                        persistentHomeFeedCache.saveReserve(
+                            cacheRelatedCandidates(fallbackRanked, fallbackMetadata, pageIds),
+                        )
+                        Log.d(TAG, "Load-more fallback: ${fallbackSeeds.size} feed/saved seeds → page=${page.size}")
+                    }
                 }
 
                 if (page.isNotEmpty()) {
@@ -1735,6 +1791,36 @@ class HomeViewModel
             val history = viewHistory?.getVideoHistoryFlow()?.first() ?: return emptyList()
             return graphSeedInputsFromHistory(history)
         }
+
+        /** Videos currently on screen, usable as related-graph seeds for load-more. */
+        private fun feedSeedInputs(max: Int = FEED_SEED_POOL): List<GraphSeedInput> {
+            val now = System.currentTimeMillis()
+            return _uiState.value.videos
+                .asSequence()
+                .filter { !it.isShort && it.id.isNotBlank() }
+                .take(max)
+                .map { video ->
+                    GraphSeedInput(
+                        id = video.id,
+                        title = video.title,
+                        channelId = video.channelId,
+                        source = GraphSeedSource.FEED,
+                        engagementWeight = 0.6,
+                        timestamp = now,
+                        durationSec = video.duration,
+                        percentWatched = 0.0,
+                    )
+                }.toList()
+        }
+
+        /**
+         * The load-more seed universe: saved interests (history, liked, playlists)
+         * PLUS the feed itself — so paging can always dig another related lane and
+         * the feed never runs dry. The engine's seed cooldown rotates them.
+         */
+        private suspend fun loadMoreSeedInputs(): List<GraphSeedInput> =
+            (savedInterestSeedInputs(gatherSavedSeedSources(), emptySet()) + feedSeedInputs())
+                .distinctBy { it.id }
 
         private suspend fun fetchRelatedVideos(seedId: String): List<Video> {
             val ts = System.currentTimeMillis()

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/home/HomeViewModel.kt
@@ -1096,7 +1096,16 @@ class HomeViewModel
 
                     // Filter to regular videos for the main feed
                     val watched = watchedVideoIds.value
-                    val subsPool = rawSubs.filterValid().filterWatched(watched).enrichAvatars()
+                    // The fresh-subs lane bypasses rank(): exclude blocked/suppressed
+                    // channels here so they cannot resurface through it.
+                    val excludedChannels =
+                        runCatching { FlowNeuroEngine.getExcludedChannelIds() }.getOrDefault(emptySet())
+                    val subsPool =
+                        rawSubs
+                            .filterValid()
+                            .filterWatched(watched)
+                            .filter { it.channelId.isBlank() || it.channelId !in excludedChannels }
+                            .enrichAvatars()
                     val discoveryPool =
                         rawDiscovery
                             .filterValid()

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/player/VideoPlayerViewModel.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/player/VideoPlayerViewModel.kt
@@ -3188,6 +3188,10 @@ class VideoPlayerViewModel
                         subscribed = !isSubscribed,
                     )
                 }.onFailure { Log.w("VideoPlayerViewModel", "Failed to record subscription signal", it) }
+                if (!isSubscribed) {
+                    // Newly subscribed: learn the channel's declared keyword tags.
+                    runCatching { repository.learnChannelTags(context, channelId) }
+                }
             }
         }
 

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/player/VideoPlayerViewModel.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/player/VideoPlayerViewModel.kt
@@ -115,6 +115,17 @@ class VideoPlayerViewModel
 
         // One terminal watch signal per video view; ignores repeat dispose fires.
         private var lastReportedVideoId: String? = null
+
+        // Tracks the max playback position of the current video so a terminal
+        // watch/skip signal can be reported when the session ends (video swap,
+        // ViewModel teardown). Fed by the periodic savePlaybackPosition calls.
+        private class WatchSessionSnapshot(
+            val video: Video,
+            var maxPositionMs: Long,
+            var durationMs: Long,
+        )
+
+        private var watchSession: WatchSessionSnapshot? = null
         private var activeLoadJob: Job? = null
         private var playbackLoadToken: Long = 0L
         private var loadingVideoId: String? = null
@@ -136,6 +147,10 @@ class VideoPlayerViewModel
 
         private companion object {
             const val MAX_STREAM_EXPIRY_RETRIES = 3
+
+            // Minimum playback before an early abandonment counts as a SKIPPED
+            // signal rather than navigation noise.
+            const val MIN_SKIP_SIGNAL_POSITION_MS = 10_000L
 
             const val MAX_LIVE_CHAT_MESSAGES = 200
             const val MAX_LIVE_CHAT_SEEN_IDS = 1500
@@ -268,6 +283,8 @@ class VideoPlayerViewModel
 
         override fun onCleared() {
             super.onCleared()
+            watchSession?.let { finalizeWatchSession(it) }
+            watchSession = null
             stopLiveChat()
         }
 
@@ -3012,6 +3029,9 @@ class VideoPlayerViewModel
                     isLocal = isLocal,
                 )
             }
+            if (!isLocal && !isShort && duration > 0) {
+                trackWatchSession(videoId, position, duration, title, thumbnailUrl, channelName, channelId)
+            }
             maybePrewarmRelatedForPlayback(
                 videoId = videoId,
                 positionMs = position,
@@ -3068,6 +3088,47 @@ class VideoPlayerViewModel
             return if (belongsToCurrentVideo) state.relatedVideos else emptyList()
         }
 
+        private fun trackWatchSession(
+            videoId: String,
+            positionMs: Long,
+            durationMs: Long,
+            title: String,
+            thumbnailUrl: String,
+            channelName: String,
+            channelId: String,
+        ) {
+            val session = watchSession
+            if (session != null && session.video.id == videoId) {
+                session.maxPositionMs = maxOf(session.maxPositionMs, positionMs)
+                session.durationMs = maxOf(session.durationMs, durationMs)
+                return
+            }
+            session?.let { finalizeWatchSession(it) }
+            watchSession =
+                WatchSessionSnapshot(
+                    video =
+                        Video(
+                            id = videoId,
+                            title = title,
+                            channelName = channelName,
+                            channelId = channelId,
+                            thumbnailUrl = thumbnailUrl,
+                            duration = (durationMs / 1000L).toInt(),
+                            viewCount = 0,
+                            uploadDate = "",
+                        ),
+                    maxPositionMs = positionMs,
+                    durationMs = durationMs,
+                )
+        }
+
+        // Reports the terminal watch/skip signal for a finished viewing session.
+        // Uses the rich (tags/description) video when the UI state still has it.
+        private fun finalizeWatchSession(session: WatchSessionSnapshot) {
+            val video = resolveRichVideo(session.video.id) ?: session.video
+            reportWatchProgress(video, session.maxPositionMs, session.durationMs)
+        }
+
         fun reportWatchProgress(
             video: io.github.aedev.flow.data.model.Video,
             position: Long,
@@ -3078,25 +3139,25 @@ class VideoPlayerViewModel
             val watchFraction = position.toDouble() / duration
             // One terminal signal per video view; ignore repeat dispose fires.
             if (video.id == lastReportedVideoId) return
-            if (watchFraction < 0.20) return
+            // Below 20% watched: a meaningful attempt that was abandoned is a skip;
+            // an instant bounce (< 10s of playback) is navigation noise, not signal.
+            if (watchFraction < 0.20 && position < MIN_SKIP_SIGNAL_POSITION_MS) return
 
             lastReportedVideoId = video.id
 
+            // >= 20% routes through WATCHED, whose percent-scaled learning already
+            // grades a 20-40% view as weak-positive "sampled" — no cliff needed.
+            // < 20% after a real attempt is the explicit abandonment signal.
             val interactionType =
-                when {
-                    watchFraction >= 0.85 -> InteractionType.WATCHED
-                    watchFraction >= 0.40 -> InteractionType.WATCHED
-                    else -> InteractionType.SKIPPED
-                }
+                if (watchFraction >= 0.20) InteractionType.WATCHED else InteractionType.SKIPPED
 
-            viewModelScope.launch {
-                FlowNeuroEngine.onVideoInteraction(
-                    context,
-                    video,
-                    interactionType,
-                    percentWatched = watchFraction.toFloat(),
-                )
-            }
+            // Engine-scope dispatch: survives ViewModel teardown (onCleared).
+            FlowNeuroEngine.onVideoInteractionAsync(
+                context,
+                video,
+                interactionType,
+                percentWatched = watchFraction.toFloat(),
+            )
         }
 
         fun toggleSubscription(
@@ -3119,6 +3180,14 @@ class VideoPlayerViewModel
                     )
                     _uiState.value = _uiState.value.copy(isSubscribed = true)
                 }
+                runCatching {
+                    FlowNeuroEngine.onChannelSubscriptionChanged(
+                        context,
+                        channelId,
+                        channelName,
+                        subscribed = !isSubscribed,
+                    )
+                }.onFailure { Log.w("VideoPlayerViewModel", "Failed to record subscription signal", it) }
             }
         }
 
@@ -3184,6 +3253,7 @@ class VideoPlayerViewModel
                         )
                     FlowNeuroEngine.onVideoInteraction(context, video, InteractionType.LIKED)
                 } catch (e: Exception) {
+                    Log.w("VideoPlayerViewModel", "Failed to record like signal", e)
                 }
             }
         }

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/search/SearchViewModel.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/search/SearchViewModel.kt
@@ -2,6 +2,7 @@
 
 package io.github.aedev.flow.ui.screens.search
 
+import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.paging.Pager
@@ -9,11 +10,13 @@ import androidx.paging.PagingConfig
 import androidx.paging.PagingData
 import androidx.paging.cachedIn
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
 import io.github.aedev.flow.data.local.ContentType
 import io.github.aedev.flow.data.local.SearchFilter
 import io.github.aedev.flow.data.model.Video
 import io.github.aedev.flow.data.paging.SearchPagingSource
 import io.github.aedev.flow.data.paging.SearchResultItem
+import io.github.aedev.flow.data.recommendation.FlowNeuroEngine
 import io.github.aedev.flow.data.repository.YouTubeRepository
 import io.github.aedev.flow.data.shorts.ShortsContentFilter
 import io.github.aedev.flow.data.shorts.queue.ShortsQueueHandoff
@@ -27,6 +30,7 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 // ── UI state ─────────────────────────────────────────────────────────────────
@@ -43,10 +47,13 @@ data class SearchUiState(
 class SearchViewModel
     @Inject
     constructor(
+        @ApplicationContext private val context: Context,
         private val repository: YouTubeRepository,
         private val shortsContentFilter: ShortsContentFilter,
         private val shortsQueueHandoff: ShortsQueueHandoff,
     ) : ViewModel() {
+        // Signal each distinct submitted query once — typing/filter churn stays silent.
+        private var lastSignaledQuery: String? = null
         private val _uiState = MutableStateFlow(SearchUiState())
         val uiState: StateFlow<SearchUiState> = _uiState.asStateFlow()
 
@@ -104,6 +111,15 @@ class SearchViewModel
             }
             _uiState.value = SearchUiState(query = query, filters = filters)
             _searchKey.value = SearchKey(query, buildContentFilters(filters), filters)
+
+            // A typed search is the most explicit interest statement the user makes.
+            val normalized = query.trim().lowercase()
+            if (normalized != lastSignaledQuery) {
+                lastSignaledQuery = normalized
+                viewModelScope.launch {
+                    runCatching { FlowNeuroEngine.onSearchQuery(context, query) }
+                }
+            }
         }
 
         fun updateFilters(filters: SearchFilter) {

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/shorts/ShortVideoPlayer.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/shorts/ShortVideoPlayer.kt
@@ -299,6 +299,9 @@ internal fun ShortVideoPage(
                 (latestHasStartedPlaying || latestPosition >= 1_000L)
             ) {
                 viewModel.recordShortProgress(video.toShortVideo(), latestPosition, latestDuration)
+                // Swiped away before the terminal watch fired — classify the
+                // abandonment so early swipes become negative engine evidence.
+                viewModel.recordShortAbandoned(video.toShortVideo(), latestPosition, latestDuration)
             }
         }
     }

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/shorts/ShortsViewModel.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/shorts/ShortsViewModel.kt
@@ -349,6 +349,14 @@ class ShortsViewModel
                     ),
                 )
             }
+            runCatching {
+                FlowNeuroEngine.onChannelSubscriptionChanged(
+                    context,
+                    channelId,
+                    channelName,
+                    subscribed = !isSubscribed,
+                )
+            }
         }
 
         fun toggleSaveShort(short: ShortVideo) {
@@ -358,6 +366,12 @@ class ShortsViewModel
                     playlistRepository.removeFromSavedShorts(video.id)
                 } else {
                     playlistRepository.addToSavedShorts(video)
+                    runCatching {
+                        FlowNeuroEngine.onVideoInteraction(
+                            video.copy(isShort = true),
+                            InteractionType.SAVED,
+                        )
+                    }
                 }
             }
         }
@@ -391,6 +405,34 @@ class ShortsViewModel
                     isMusic = false,
                     isShort = true,
                 )
+            }
+        }
+
+        /**
+         * Terminal signal for a short the user swiped away from before the watch
+         * threshold fired. Early abandonment emits SKIPPED — the engine's main
+         * source of negative watch evidence on Shorts.
+         */
+        fun recordShortAbandoned(
+            short: ShortVideo,
+            positionMs: Long,
+            durationMs: Long,
+        ) {
+            viewModelScope.launch(PerformanceDispatcher.diskIO) {
+                val video = short.toVideo()
+                val signal = ShortWatchClassifier.classifyAbandon(positionMs, durationMs, video.duration)
+                if (signal != null) {
+                    runCatching {
+                        FlowNeuroEngine.onVideoInteraction(
+                            video.copy(isShort = true),
+                            signal.interaction,
+                            percentWatched = signal.percent,
+                        )
+                        FlowNeuroEngine.recordSeenShorts(listOf(video.id))
+                    }.onFailure { e ->
+                        Log.w(TAG, "Failed to record abandoned short in FlowNeuro", e)
+                    }
+                }
             }
         }
 

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/shorts/ShortsViewModel.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/shorts/ShortsViewModel.kt
@@ -357,6 +357,10 @@ class ShortsViewModel
                     subscribed = !isSubscribed,
                 )
             }
+            if (!isSubscribed) {
+                // Newly subscribed: learn the channel's declared keyword tags.
+                runCatching { repository.learnChannelTags(context, channelId) }
+            }
         }
 
         fun toggleSaveShort(short: ShortVideo) {

--- a/app/src/main/java/io/github/aedev/flow/utils/RelativeUploadDateParser.kt
+++ b/app/src/main/java/io/github/aedev/flow/utils/RelativeUploadDateParser.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2025-2026 Flow | A-EDev
+ *
+ * This file is part of Flow (https://github.com/A-EDev/Flow).
+ */
+
+package io.github.aedev.flow.utils
+
+/**
+ * Parses relative upload-date text ("3 weeks ago", "Streamed 2 days ago") into an
+ * epoch-millis timestamp. Returns null when the text carries no parsable age —
+ * callers must NOT substitute "now" for unknown, or every stale item reads as new.
+ */
+object RelativeUploadDateParser {
+    fun parse(
+        textualDate: String?,
+        now: Long = System.currentTimeMillis(),
+    ): Long? {
+        val raw = textualDate?.trim().orEmpty()
+        if (raw.isBlank()) return null
+
+        val normalized =
+            raw
+                .lowercase()
+                .replace("streamed", "")
+                .replace("premiered", "")
+                .replace("ago", "")
+                .trim()
+
+        if (normalized.contains("just now") || normalized.contains("today")) return now
+        if (normalized.contains("yesterday")) return now - DAY_MS
+
+        val value =
+            Regex("(\\d+)")
+                .find(normalized)
+                ?.groupValues
+                ?.getOrNull(1)
+                ?.toLongOrNull()
+                ?: return null
+        // Word units MUST be checked before compact suffixes: after stripping
+        // "ago", "3 days" ends with "s" and would otherwise parse as seconds.
+        // (This exact bug shipped in the original shorts-path parser.)
+        val unitMillis =
+            when {
+                normalized.contains("second") -> 1_000L
+                normalized.contains("minute") -> 60_000L
+                normalized.contains("hour") -> 3_600_000L
+                normalized.contains("day") -> DAY_MS
+                normalized.contains("week") -> 7L * DAY_MS
+                normalized.contains("month") -> 30L * DAY_MS
+                normalized.contains("year") -> 365L * DAY_MS
+                normalized.endsWith("mo") -> 30L * DAY_MS
+                normalized.endsWith("s") -> 1_000L
+                normalized.endsWith("m") -> 60_000L
+                normalized.endsWith("h") -> 3_600_000L
+                normalized.endsWith("d") -> DAY_MS
+                normalized.endsWith("w") -> 7L * DAY_MS
+                normalized.endsWith("y") -> 365L * DAY_MS
+                else -> return null
+            }
+
+        return now - (value * unitMillis)
+    }
+
+    private const val DAY_MS = 86_400_000L
+}

--- a/app/src/test/java/io/github/aedev/flow/data/recommendation/GraphSeedSelectorTest.kt
+++ b/app/src/test/java/io/github/aedev/flow/data/recommendation/GraphSeedSelectorTest.kt
@@ -15,7 +15,7 @@ class GraphSeedSelectorTest {
         timestamp: Long = now,
         durationSec: Int = 600,
         percentWatched: Double = 100.0,
-        isShort: Boolean = false
+        isShort: Boolean = false,
     ) = GraphSeedInput(
         id = id,
         title = title,
@@ -25,64 +25,70 @@ class GraphSeedSelectorTest {
         timestamp = timestamp,
         durationSec = durationSec,
         percentWatched = percentWatched,
-        isShort = isShort
+        isShort = isShort,
     )
 
     @Test
     fun `explicit liked seeds outrank equally recent watch seeds`() {
-        val selected = GraphSeedSelector.select(
-            listOf(
-                seed("watch", source = GraphSeedSource.WATCH_HISTORY),
-                seed("liked", source = GraphSeedSource.LIKED)
-            ),
-            maxSeeds = 1,
-            now = now
-        )
+        val selected =
+            GraphSeedSelector.select(
+                listOf(
+                    seed("watch", source = GraphSeedSource.WATCH_HISTORY),
+                    seed("liked", source = GraphSeedSource.LIKED),
+                ),
+                maxSeeds = 1,
+                now = now,
+            )
 
         assertThat(selected).containsExactly("liked")
     }
 
     @Test
     fun `long partial watches qualify while short partial watches do not`() {
-        val selected = GraphSeedSelector.select(
-            listOf(
-                seed("long_partial", durationSec = 600, percentWatched = 40.0, engagementWeight = 0.4),
-                seed("short_partial", durationSec = 200, percentWatched = 40.0, engagementWeight = 0.4)
-            ),
-            maxSeeds = 4,
-            now = now
-        )
+        val selected =
+            GraphSeedSelector.select(
+                listOf(
+                    seed("long_partial", durationSec = 600, percentWatched = 40.0, engagementWeight = 0.4),
+                    seed("short_partial", durationSec = 200, percentWatched = 40.0, engagementWeight = 0.4),
+                ),
+                maxSeeds = 4,
+                now = now,
+            )
 
         assertThat(selected).containsExactly("long_partial")
     }
 
     @Test
     fun `selection caps dense title clusters at two seeds`() {
-        val selected = GraphSeedSelector.select(
-            listOf(
-                seed("a1", title = "alpha one", engagementWeight = 1.0),
-                seed("a2", title = "alpha two", engagementWeight = 0.9),
-                seed("a3", title = "alpha three", engagementWeight = 0.8),
-                seed("b1", title = "beta one", engagementWeight = 0.1)
-            ),
-            maxSeeds = 4,
-            now = now
-        )
+        val selected =
+            GraphSeedSelector.select(
+                listOf(
+                    seed("a1", title = "alpha one", engagementWeight = 1.0),
+                    seed("a2", title = "alpha two", engagementWeight = 0.9),
+                    seed("a3", title = "alpha three", engagementWeight = 0.8),
+                    seed("b1", title = "beta one", engagementWeight = 0.1),
+                ),
+                maxSeeds = 4,
+                now = now,
+            )
 
-        assertThat(selected).containsExactly("a1", "a2", "b1").inOrder()
+        // Progressive fill: every cluster gets its first seed (a1, b1) before any
+        // cluster gets a second (a2); the dense cluster stays capped at two.
+        assertThat(selected).containsExactly("a1", "b1", "a2").inOrder()
     }
 
     @Test
     fun `selection excludes known blocked or suppressed channels`() {
-        val selected = GraphSeedSelector.select(
-            listOf(
-                seed("blocked", channelId = "UC_blocked", engagementWeight = 1.0),
-                seed("allowed", channelId = "UC_allowed", engagementWeight = 0.5)
-            ),
-            maxSeeds = 2,
-            now = now,
-            excludedChannelIds = setOf("UC_blocked")
-        )
+        val selected =
+            GraphSeedSelector.select(
+                listOf(
+                    seed("blocked", channelId = "UC_blocked", engagementWeight = 1.0),
+                    seed("allowed", channelId = "UC_allowed", engagementWeight = 0.5),
+                ),
+                maxSeeds = 2,
+                now = now,
+                excludedChannelIds = setOf("UC_blocked"),
+            )
 
         assertThat(selected).containsExactly("allowed")
     }

--- a/app/src/test/java/io/github/aedev/flow/data/recommendation/NeuroBlockingTest.kt
+++ b/app/src/test/java/io/github/aedev/flow/data/recommendation/NeuroBlockingTest.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2025-2026 Flow | A-EDev
+ *
+ * This file is part of Flow (https://github.com/A-EDev/Flow).
+ */
+
+package io.github.aedev.flow.data.recommendation
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class NeuroBlockingTest {
+    private val tokenizer = NeuroTokenizer()
+    private val lemma: (String) -> String = tokenizer::normalizeLemma
+
+    private fun matchers(vararg blocked: String) =
+        NeuroScoring.buildBlockedMatchers(blocked.toSet(), NeuroTopicCatalog.TOPIC_CATEGORIES, lemma)
+
+    private fun blocked(
+        title: String,
+        channel: String = "",
+        vararg blockedTopics: String,
+    ) = NeuroScoring.isBlockedByText(title, channel, matchers(*blockedTopics), lemma)
+
+    @Test
+    fun `blocking one topic does not block its category siblings`() {
+        // The old expansion nuked ALL of Gaming when any Gaming topic was blocked.
+        assertThat(blocked("Minecraft castle build", "", "fortnite")).isFalse()
+        assertThat(blocked("Best esports moments", "", "fortnite")).isFalse()
+        assertThat(blocked("Fortnite chapter 5 gameplay", "", "fortnite")).isTrue()
+    }
+
+    @Test
+    fun `blocking the category NAME still blocks the whole category`() {
+        assertThat(blocked("Fortnite chapter 5", "", "gaming")).isTrue()
+        assertThat(blocked("Minecraft survival ep 1", "", "gaming")).isTrue()
+        assertThat(blocked("Sourdough baking basics", "", "gaming")).isFalse()
+    }
+
+    @Test
+    fun `token boundaries - art does not block startup`() {
+        assertThat(blocked("My startup journey", "", "art")).isFalse()
+        assertThat(blocked("Watercolor art tutorial", "", "art")).isTrue()
+    }
+
+    @Test
+    fun `single-word block matches by token and lemma`() {
+        assertThat(blocked("Digital art timelapse", "", "art")).isTrue()
+        assertThat(blocked("ART SHOWCASE 2026", "", "art")).isTrue()
+        assertThat(blocked("Gaming setup tour", "", "game")).isTrue()
+        assertThat(blocked("Cartography for beginners", "", "art")).isFalse()
+    }
+
+    @Test
+    fun `multi-word block matches as phrase`() {
+        assertThat(blocked("Best hip hop tracks of 2026", "", "hip hop")).isTrue()
+        assertThat(blocked("Hip mobility exercises", "", "hip hop")).isFalse()
+    }
+
+    @Test
+    fun `channel names are matched too`() {
+        assertThat(blocked("Weekly recap", "Crypto Daily", "crypto")).isTrue()
+        assertThat(blocked("Weekly recap", "Cooking Daily", "crypto")).isFalse()
+    }
+}

--- a/app/src/test/java/io/github/aedev/flow/data/recommendation/NeuroChannelKnowledgeTest.kt
+++ b/app/src/test/java/io/github/aedev/flow/data/recommendation/NeuroChannelKnowledgeTest.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2025-2026 Flow | A-EDev
+ *
+ * This file is part of Flow (https://github.com/A-EDev/Flow).
+ */
+
+package io.github.aedev.flow.data.recommendation
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class NeuroChannelKnowledgeTest {
+    private val tokenizer = NeuroTokenizer()
+
+    @Test
+    fun `creator tags become weighted profile topics`() {
+        val profile =
+            NeuroChannelKnowledge.profileFromChannelTags(
+                tags = listOf("claude", "coding agents", "ai tools"),
+                description = "Deep dives into claude and coding agents.",
+                tokenizer = tokenizer,
+            )
+        assertThat(profile).containsKey("claude")
+        assertThat(profile.keys.any { it.contains("agent") }).isTrue()
+        // Repeated across tags+description → weighted above single mentions.
+        assertThat(profile.getValue("claude")).isAtLeast(profile.values.min())
+        assertThat(profile.values.max()).isAtMost(NeuroChannelKnowledge.TAG_SEED_WEIGHT)
+    }
+
+    @Test
+    fun `noise tags are filtered`() {
+        val profile =
+            NeuroChannelKnowledge.profileFromChannelTags(
+                tags = listOf("2026", "use", "right", "mma"),
+                description = null,
+                tokenizer = tokenizer,
+            )
+        assertThat(profile.keys).containsExactly("mma")
+    }
+
+    @Test
+    fun `upload titles need repetition to count as channel identity`() {
+        val profile =
+            NeuroChannelKnowledge.profileFromUploadTitles(
+                titles =
+                    listOf(
+                        "McLaren 720S engine swap part 1",
+                        "McLaren P1 vs Ferrari drag race",
+                        "Why the McLaren F1 is special",
+                        "My dog ate my homework",
+                    ),
+                tokenizer = tokenizer,
+            )
+        assertThat(profile).containsKey("mclaren")
+        // One-off words from a single title are not channel identity.
+        assertThat(profile).doesNotContainKey("dog")
+        assertThat(profile.values.max()).isAtMost(NeuroChannelKnowledge.PASSIVE_MAX_WEIGHT)
+    }
+
+    @Test
+    fun `merge never lowers learned weights and respects the topic cap`() {
+        val existing = mapOf("claude" to 0.6, "coding" to 0.2)
+        val merged =
+            NeuroChannelKnowledge.mergeProfile(
+                existing,
+                mapOf("claude" to 0.35, "cursor" to 0.3),
+            )
+        assertThat(merged.getValue("claude")).isEqualTo(0.6)
+        assertThat(merged.getValue("cursor")).isEqualTo(0.3)
+        assertThat(merged.size).isAtMost(NeuroScoring.CHANNEL_PROFILE_MAX_TOPICS)
+    }
+
+    @Test
+    fun `progressive seed pick spreads one per community before doubling up`() {
+        val seeds =
+            listOf(
+                SeedRank("dev1", "android", 10.0),
+                SeedRank("dev2", "android", 9.0),
+                SeedRank("dev3", "android", 8.0),
+                SeedRank("mma1", "mma", 5.0),
+                SeedRank("anime1", "anime", 3.0),
+            )
+        val picked = NeuroScoring.pickDiverseSeeds(seeds, maxSeeds = 4, maxPerCluster = 2)
+        // Pass 1 covers every community; only then does android get its second seed.
+        assertThat(picked).containsExactly("dev1", "mma1", "anime1", "dev2").inOrder()
+    }
+}

--- a/app/src/test/java/io/github/aedev/flow/data/recommendation/NeuroClustersTest.kt
+++ b/app/src/test/java/io/github/aedev/flow/data/recommendation/NeuroClustersTest.kt
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) 2025-2026 Flow | A-EDev
+ *
+ * This file is part of Flow (https://github.com/A-EDev/Flow).
+ */
+
+package io.github.aedev.flow.data.recommendation
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class NeuroClustersTest {
+    private val now = 1_700_000_000_000L
+    private val noLemma: (String) -> String = { it.lowercase() }
+
+    private fun build(
+        scores: Map<String, Double>,
+        affinities: Map<String, Double> = emptyMap(),
+        profiles: Map<String, Map<String, Double>> = emptyMap(),
+        categories: List<TopicCategory> = emptyList(),
+    ) = NeuroClusters.buildClusters(scores, affinities, profiles, categories, noLemma)
+
+    @Test
+    fun `affinity edges group co-watched topics into one cluster`() {
+        val clusters =
+            build(
+                scores = mapOf("minecraft" to 0.6, "speedrun" to 0.4, "cooking" to 0.5, "recipe" to 0.3),
+                affinities =
+                    mapOf(
+                        NeuroScoring.makeAffinityKey("minecraft", "speedrun") to 0.3,
+                        NeuroScoring.makeAffinityKey("cooking", "recipe") to 0.3,
+                    ),
+            )
+        assertThat(clusters).hasSize(2)
+        val gaming = clusters.first { it.representative == "minecraft" }
+        assertThat(gaming.topics).containsExactly("minecraft", "speedrun")
+        val cookingCluster = clusters.first { it.representative == "cooking" }
+        assertThat(cookingCluster.topics).containsExactly("cooking", "recipe")
+    }
+
+    @Test
+    fun `channel profiles link topics taught by the same channel`() {
+        val clusters =
+            build(
+                scores = mapOf("guitar" to 0.5, "chord" to 0.2, "physics" to 0.3),
+                profiles = mapOf("chMusic" to mapOf("guitar" to 0.6, "chord" to 0.5)),
+            )
+        assertThat(clusters.first { it.representative == "guitar" }.topics).contains("chord")
+        assertThat(clusters.first { it.representative == "physics" }.topics).containsExactly("physics")
+    }
+
+    @Test
+    fun `unconnected topics stay singleton clusters`() {
+        val clusters = build(scores = mapOf("chess" to 0.2, "woodworking" to 0.15))
+        assertThat(clusters).hasSize(2)
+    }
+
+    @Test
+    fun `clustering is deterministic`() {
+        val scores = mapOf("a1" to 0.5, "b2" to 0.5, "c3" to 0.3, "d4" to 0.3)
+        val affinities = mapOf("a1|b2" to 0.2, "c3|d4" to 0.2)
+        val first = build(scores, affinities)
+        val second = build(scores, affinities)
+        assertThat(first).isEqualTo(second)
+    }
+
+    @Test
+    fun `schedule boosts never-served clusters over a just-served giant`() {
+        val big = NeuroClusters.TopicCluster("gaming", listOf("gaming"), mass = 1.5)
+        val small = NeuroClusters.TopicCluster("chess", listOf("chess"), mass = 0.2)
+        val justServed = mapOf("gaming" to now - 60_000L)
+
+        val order = NeuroClusters.schedule(listOf(big, small), justServed, now)
+        assertThat(order.first().representative).isEqualTo("chess")
+    }
+
+    @Test
+    fun `schedule lets a big cluster reclaim priority as staleness accrues`() {
+        val big = NeuroClusters.TopicCluster("gaming", listOf("gaming"), mass = 1.5)
+        val small = NeuroClusters.TopicCluster("chess", listOf("chess"), mass = 0.2)
+        val bothServedLongAgo =
+            mapOf(
+                "gaming" to now - 48L * 3_600_000L,
+                "chess" to now - 48L * 3_600_000L,
+            )
+        val order = NeuroClusters.schedule(listOf(big, small), bothServedLongAgo, now)
+        assertThat(order.first().representative).isEqualTo("gaming")
+    }
+
+    @Test
+    fun `every cluster is served within a bounded number of sessions`() {
+        val clusters =
+            listOf(
+                NeuroClusters.TopicCluster("gaming", listOf("gaming"), 1.5),
+                NeuroClusters.TopicCluster("cooking", listOf("cooking"), 0.9),
+                NeuroClusters.TopicCluster("guitar", listOf("guitar"), 0.8),
+                NeuroClusters.TopicCluster("physics", listOf("physics"), 0.4),
+                NeuroClusters.TopicCluster("chess", listOf("chess"), 0.25),
+                NeuroClusters.TopicCluster("woodworking", listOf("woodworking"), 0.15),
+            )
+        var rotation = mapOf<String, Long>()
+        var clock = now
+        val servedEver = mutableSetOf<String>()
+        val slotsPerSession = 3
+
+        repeat(4) {
+            val served = NeuroClusters.schedule(clusters, rotation, clock).take(slotsPerSession)
+            servedEver += served.map { it.representative }
+            rotation = rotation + served.associate { it.representative to clock }
+            clock += 4L * 3_600_000L
+        }
+
+        // 6 clusters, 3 slots, 4 sessions: rotation must have cycled through all.
+        assertThat(servedEver).hasSize(clusters.size)
+    }
+}

--- a/app/src/test/java/io/github/aedev/flow/data/recommendation/NeuroLearningFixesTest.kt
+++ b/app/src/test/java/io/github/aedev/flow/data/recommendation/NeuroLearningFixesTest.kt
@@ -1,0 +1,147 @@
+/*
+ * Copyright (C) 2025-2026 Flow | A-EDev
+ *
+ * This file is part of Flow (https://github.com/A-EDev/Flow).
+ */
+
+package io.github.aedev.flow.data.recommendation
+
+import com.google.common.truth.Truth.assertThat
+import io.github.aedev.flow.data.recommendation.eval.NeuroBenchmark
+import io.github.aedev.flow.data.recommendation.eval.NeuroEval
+import org.junit.Test
+
+class NeuroLearningFixesTest {
+    private val tokenizer = NeuroTokenizer()
+
+    // ── F2: topic acquisition floor ──
+
+    @Test
+    fun `plantTopics lifts new topics to a survivable weight`() {
+        val current = ContentVector(topics = mapOf("android" to 0.4))
+        val source = ContentVector(topics = mapOf("claude" to 0.8, "cursor" to 0.5, "android" to 0.3))
+        val planted = NeuroVectorMath.plantTopics(current, source, floor = 0.05, topK = 3)
+        assertThat(planted.topics["claude"]).isEqualTo(0.05)
+        assertThat(planted.topics["cursor"]).isEqualTo(0.05)
+        // Established scores are never lowered.
+        assertThat(planted.topics["android"]).isEqualTo(0.4)
+    }
+
+    @Test
+    fun `planted topics survive the prune threshold`() {
+        val planted =
+            NeuroVectorMath.plantTopics(
+                ContentVector(),
+                ContentVector(topics = mapOf("woodworking" to 0.9)),
+                floor = NeuroScoring.TOPIC_ACQUISITION_FLOOR,
+                topK = 3,
+            )
+        assertThat(planted.topics.getValue("woodworking"))
+            .isGreaterThan(NeuroVectorMath.TOPIC_PRUNE_THRESHOLD)
+    }
+
+    // ── F4: noise-topic detection ──
+
+    @Test
+    fun `noise topics are recognized`() {
+        assertThat(tokenizer.isNoiseTopic("right")).isTrue()
+        assertThat(tokenizer.isNoiseTopic("laptops right")).isTrue()
+        assertThat(tokenizer.isNoiseTopic("2026")).isTrue()
+        assertThat(tokenizer.isNoiseTopic("ok")).isTrue()
+        assertThat(tokenizer.isNoiseTopic("machine learning")).isFalse()
+        assertThat(tokenizer.isNoiseTopic("claude")).isFalse()
+        assertThat(tokenizer.isNoiseTopic("metal:music")).isFalse()
+    }
+
+    // ── F3: V15 maintenance ──
+
+    private fun fossilBrain() =
+        UserBrain(
+            totalInteractions = 3000,
+            schemaVersion = 14,
+            globalVector =
+                ContentVector(
+                    topics =
+                        mapOf(
+                            "android" to 0.39,
+                            "laptops right" to 0.001,
+                            "right" to 0.0,
+                        ),
+                ),
+            channelScores = mapOf("chClaude" to 0.7, "chCars" to 0.6, "chBad" to 0.2),
+            channelTopicProfiles =
+                mapOf(
+                    "chClaude" to mapOf("claude" to 0.6, "coding agents" to 0.4, "ai" to 0.3),
+                    "chCars" to mapOf("cars" to 0.5, "engine swap" to 0.3),
+                    "chBad" to mapOf("spam" to 0.9),
+                ),
+        )
+
+    @Test
+    fun `v15 maintenance scrubs junk and rehydrates from channel profiles`() {
+        val updated = NeuroMaintenance.runV15IfNeeded(fossilBrain(), tokenizer)
+
+        assertThat(updated.schemaVersion).isEqualTo(NeuroMaintenance.TARGET_SCHEMA_VERSION)
+        // Junk scrubbed.
+        assertThat(updated.globalVector.topics).doesNotContainKey("right")
+        assertThat(updated.globalVector.topics).doesNotContainKey("laptops right")
+        // Real interests recovered from profiles, capped below established.
+        assertThat(updated.globalVector.topics).containsKey("claude")
+        assertThat(updated.globalVector.topics).containsKey("cars")
+        assertThat(updated.globalVector.topics.getValue("claude")).isAtMost(0.30)
+        // Low-quality channels contribute nothing.
+        assertThat(updated.globalVector.topics).doesNotContainKey("spam")
+        // Affinity structure seeded from co-taught topics.
+        assertThat(updated.topicAffinities).isNotEmpty()
+        assertThat(updated.topicAffinities.keys.any { it.contains("claude") }).isTrue()
+        // Existing scores never lowered.
+        assertThat(updated.globalVector.topics.getValue("android")).isEqualTo(0.39)
+    }
+
+    @Test
+    fun `v15 maintenance is a no-op on current brains`() {
+        val brain = fossilBrain().copy(schemaVersion = 15)
+        assertThat(NeuroMaintenance.runV15IfNeeded(brain, tokenizer)).isSameInstanceAs(brain)
+    }
+
+    // ── F5: every cluster in every feed + tree-depth descent ──
+
+    @Test
+    fun `depth zero queries cover every interest cluster in one feed`() {
+        val universe = NeuroBenchmark.multiInterestUniverse()
+        val brain = NeuroBenchmark.brainFor(universe)
+        val discovery = NeuroDiscovery(NeuroTopicCatalog.TOPIC_CATEGORIES, tokenizer)
+
+        val queries =
+            discovery.generateQueries(brain, NeuroEval.FIXED_NOW, depth = 0) { FlowPersona.EXPLORER }
+        val servedClusters = queries.mapNotNull { it.clusterKey }.toSet()
+
+        // All six groups (gaming, cooking, guitar, physics, chess, woodworking)
+        // must contribute to the SAME feed — coverage is no longer rotated away.
+        assertThat(servedClusters).hasSize(universe.groups.size)
+    }
+
+    @Test
+    fun `deeper rounds dig different branches of the same clusters`() {
+        val universe = NeuroBenchmark.multiInterestUniverse()
+        val brain = NeuroBenchmark.brainFor(universe)
+        val discovery = NeuroDiscovery(NeuroTopicCatalog.TOPIC_CATEGORIES, tokenizer)
+
+        fun deepDives(depth: Int) =
+            discovery
+                .generateQueries(brain, NeuroEval.FIXED_NOW, depth) { FlowPersona.EXPLORER }
+                .filter { it.strategy == QueryStrategy.DEEP_DIVE }
+                .map { it.query }
+                .toSet()
+
+        val surface = deepDives(0)
+        val page2 = deepDives(1)
+        val page3 = deepDives(2)
+
+        // Tree descent: page 2 combines anchors with branch members, so its
+        // query set differs from the surface pass and from page 3.
+        assertThat(page2).isNotEqualTo(surface)
+        assertThat(page2.any { it.contains(' ') }).isTrue()
+        assertThat(page3).isNotEqualTo(page2)
+    }
+}

--- a/app/src/test/java/io/github/aedev/flow/data/recommendation/NeuroScoringTest.kt
+++ b/app/src/test/java/io/github/aedev/flow/data/recommendation/NeuroScoringTest.kt
@@ -12,7 +12,6 @@ import io.github.aedev.flow.data.recommendation.eval.NeuroEval.video
 import org.junit.Test
 
 class NeuroScoringTest {
-
     private val now = 1_700_000_000_000L
 
     // ── Relevance floor ──
@@ -67,9 +66,12 @@ class NeuroScoringTest {
 
     @Test
     fun `jitter is high at cold start and rises with feed staleness`() {
+        // Values are FRACTIONS of the median candidate score (rank() multiplies).
         assertThat(NeuroScoring.calculateAdaptiveJitter(10, 0.0)).isEqualTo(NeuroScoring.JITTER_COLD_START)
-        assertThat(NeuroScoring.calculateAdaptiveJitter(100, 0.6)).isEqualTo(0.12)
+        assertThat(NeuroScoring.calculateAdaptiveJitter(100, 0.6)).isEqualTo(0.25)
         assertThat(NeuroScoring.calculateAdaptiveJitter(100, 0.0)).isEqualTo(NeuroScoring.JITTER_NORMAL)
+        assertThat(NeuroScoring.calculateAdaptiveJitter(100, 0.6))
+            .isGreaterThan(NeuroScoring.calculateAdaptiveJitter(100, 0.0))
     }
 
     // ── Topic affinity key ──
@@ -84,35 +86,44 @@ class NeuroScoringTest {
 
     @Test
     fun `probation damps unconfirmed mid-weight topics on mature brains`() {
-        val brain = UserBrain(
-            totalInteractions = 200,
-            globalVector = ContentVector(topics = mapOf("foo" to 0.1))
-        )
-        val penalty = NeuroScoring.calculateTopicProbationPenalty(
-            vec("foo" to 0.9), brain, emptySet()
-        )
+        val brain =
+            UserBrain(
+                totalInteractions = 200,
+                globalVector = ContentVector(topics = mapOf("foo" to 0.1)),
+            )
+        val penalty =
+            NeuroScoring.calculateTopicProbationPenalty(
+                vec("foo" to 0.9),
+                brain,
+                emptySet(),
+            )
         assertThat(penalty).isLessThan(1.0)
     }
 
     @Test
     fun `confirmed topic evidence lifts probation`() {
-        val brain = UserBrain(
-            totalInteractions = 200,
-            globalVector = ContentVector(topics = mapOf("foo" to 0.1)),
-            topicEvidence = mapOf("foo" to TopicEvidence(explicitSignals = 1))
-        )
-        val penalty = NeuroScoring.calculateTopicProbationPenalty(
-            vec("foo" to 0.9), brain, emptySet()
-        )
+        val brain =
+            UserBrain(
+                totalInteractions = 200,
+                globalVector = ContentVector(topics = mapOf("foo" to 0.1)),
+                topicEvidence = mapOf("foo" to TopicEvidence(explicitSignals = 1)),
+            )
+        val penalty =
+            NeuroScoring.calculateTopicProbationPenalty(
+                vec("foo" to 0.9),
+                brain,
+                emptySet(),
+            )
         assertThat(penalty).isEqualTo(1.0)
     }
 
     @Test
     fun `probation is inactive during cold start`() {
-        val brain = UserBrain(
-            totalInteractions = 10,
-            globalVector = ContentVector(topics = mapOf("foo" to 0.1))
-        )
+        val brain =
+            UserBrain(
+                totalInteractions = 10,
+                globalVector = ContentVector(topics = mapOf("foo" to 0.1)),
+            )
         assertThat(NeuroScoring.calculateTopicProbationPenalty(vec("foo" to 0.9), brain, emptySet()))
             .isEqualTo(1.0)
     }
@@ -131,10 +142,11 @@ class NeuroScoringTest {
 
     @Test
     fun `novel topics get a larger exploration bonus than well-explored ones`() {
-        val brain = UserBrain(
-            totalInteractions = 200,
-            topicEvidence = mapOf("known" to TopicEvidence(positiveSignals = 50))
-        )
+        val brain =
+            UserBrain(
+                totalInteractions = 200,
+                topicEvidence = mapOf("known" to TopicEvidence(positiveSignals = 50)),
+            )
         val known = NeuroScoring.explorationBonus(vec("known" to 0.9), brain, 1.0)
         val novel = NeuroScoring.explorationBonus(vec("novel" to 0.9), brain, 1.0)
         assertThat(novel).isGreaterThan(known)
@@ -148,10 +160,11 @@ class NeuroScoringTest {
 
     @Test
     fun `repeatedly disliked topics are not explored`() {
-        val brain = UserBrain(
-            totalInteractions = 200,
-            topicEvidence = mapOf("hated" to TopicEvidence(negativeSignals = 40))
-        )
+        val brain =
+            UserBrain(
+                totalInteractions = 200,
+                topicEvidence = mapOf("hated" to TopicEvidence(negativeSignals = 40)),
+            )
         val hated = NeuroScoring.explorationBonus(vec("hated" to 0.9), brain, 1.0)
         val fresh = NeuroScoring.explorationBonus(vec("brandnew" to 0.9), brain, 1.0)
         assertThat(hated).isLessThan(fresh)

--- a/app/src/test/java/io/github/aedev/flow/data/recommendation/NeuroSeenGateTest.kt
+++ b/app/src/test/java/io/github/aedev/flow/data/recommendation/NeuroSeenGateTest.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2025-2026 Flow | A-EDev
+ *
+ * This file is part of Flow (https://github.com/A-EDev/Flow).
+ */
+
+package io.github.aedev.flow.data.recommendation
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class NeuroSeenGateTest {
+    private val now = 1_700_000_000_000L
+
+    private fun items(n: Int): List<String> = (0 until n).map { "v$it" }
+
+    private fun shownRecently(
+        showCount: Int,
+        hoursAgo: Double = 1.0,
+    ) = FeedEntry(lastShown = now - (hoursAgo * 3_600_000L).toLong(), showCount = showCount)
+
+    @Test
+    fun `repeatedly shown items are filtered out of a rich pool`() {
+        val pool = items(40)
+        val history = mapOf("v0" to shownRecently(3), "v1" to shownRecently(2))
+        val kept = NeuroScoring.applySeenGate(pool, history, now) { it }
+        assertThat(kept).doesNotContain("v0")
+        assertThat(kept).doesNotContain("v1")
+        assertThat(kept).hasSize(38)
+    }
+
+    @Test
+    fun `single showing is hidden briefly then returns`() {
+        val pool = items(40)
+        val justShown = mapOf("v0" to shownRecently(1, hoursAgo = 1.0))
+        assertThat(NeuroScoring.applySeenGate(pool, justShown, now) { it }).doesNotContain("v0")
+
+        val pastWindow =
+            mapOf("v0" to shownRecently(1, hoursAgo = NeuroScoring.SEEN_GATE_SINGLE_SHOW_WINDOW_HOURS + 1))
+        assertThat(NeuroScoring.applySeenGate(pool, pastWindow, now) { it }).contains("v0")
+    }
+
+    @Test
+    fun `gate releases items after the recovery window`() {
+        val pool = items(40)
+        val history = mapOf("v0" to shownRecently(5, hoursAgo = NeuroScoring.SEEN_GATE_WINDOW_HOURS + 1))
+        val kept = NeuroScoring.applySeenGate(pool, history, now) { it }
+        assertThat(kept).contains("v0")
+    }
+
+    @Test
+    fun `small pools skip the gate entirely`() {
+        val pool = items(NeuroScoring.SEEN_GATE_MIN_POOL - 1)
+        val history = pool.associateWith { shownRecently(5) }
+        val kept = NeuroScoring.applySeenGate(pool, history, now) { it }
+        assertThat(kept).isEqualTo(pool)
+    }
+
+    @Test
+    fun `gate backs off rather than starving the result`() {
+        val pool = items(30)
+        // All but 5 items over-shown: gating would leave < SEEN_GATE_MIN_RESULTS.
+        val history = pool.drop(5).associateWith { shownRecently(4) }
+        val kept = NeuroScoring.applySeenGate(pool, history, now) { it }
+        assertThat(kept).isEqualTo(pool)
+    }
+}

--- a/app/src/test/java/io/github/aedev/flow/data/recommendation/eval/BrainDiagnostic.kt
+++ b/app/src/test/java/io/github/aedev/flow/data/recommendation/eval/BrainDiagnostic.kt
@@ -10,6 +10,7 @@ package io.github.aedev.flow.data.recommendation.eval
 import io.github.aedev.flow.data.recommendation.FlowPersona
 import io.github.aedev.flow.data.recommendation.NeuroClusters
 import io.github.aedev.flow.data.recommendation.NeuroDiscovery
+import io.github.aedev.flow.data.recommendation.NeuroMaintenance
 import io.github.aedev.flow.data.recommendation.NeuroScoring
 import io.github.aedev.flow.data.recommendation.NeuroStorage
 import io.github.aedev.flow.data.recommendation.NeuroTokenizer
@@ -69,6 +70,9 @@ internal object BrainDiagnostic {
     data class ReportDto(
         val totalInteractions: Int,
         val persona: String,
+        val maintenanceApplied: Boolean = false,
+        val topicsBeforeMaintenance: Int = 0,
+        val affinitiesBeforeMaintenance: Int = 0,
         val topicCount: Int,
         val clusterCount: Int,
         val effectiveClusterCount: Double,
@@ -90,11 +94,14 @@ internal object BrainDiagnostic {
     )
 
     fun diagnose(
-        brain: UserBrain,
+        rawBrain: UserBrain,
         now: Long = System.currentTimeMillis(),
         sessions: Int = 3,
     ): ReportDto {
         val tokenizer = NeuroTokenizer()
+        // Diagnose the brain AS THE APP WILL RUN IT: apply pending maintenance
+        // migrations first (identical code path to engine initialize()).
+        val brain = NeuroMaintenance.runV15IfNeeded(rawBrain, tokenizer)
         val discovery = NeuroDiscovery(NeuroTopicCatalog.TOPIC_CATEGORIES, tokenizer)
         val persona =
             FlowPersona.entries.find { it.name == brain.lastPersona } ?: FlowPersona.EXPLORER
@@ -137,9 +144,10 @@ internal object BrainDiagnostic {
         var rotation = brain.clusterRotation
         var clock = now
         val sessionDtos = mutableListOf<SessionDto>()
-        repeat(sessions) {
+        repeat(sessions) { round ->
+            // Round index doubles as tree depth: refresh (0), then deeper pages.
             val queries =
-                discovery.generateQueries(brain.copy(clusterRotation = rotation), clock) { persona }
+                discovery.generateQueries(brain.copy(clusterRotation = rotation), clock, depth = round) { persona }
             val served = queries.mapNotNull { it.clusterKey }.distinct()
             sessionDtos +=
                 SessionDto(
@@ -168,6 +176,9 @@ internal object BrainDiagnostic {
         return ReportDto(
             totalInteractions = brain.totalInteractions,
             persona = persona.name,
+            maintenanceApplied = brain !== rawBrain,
+            topicsBeforeMaintenance = rawBrain.globalVector.topics.size,
+            affinitiesBeforeMaintenance = rawBrain.topicAffinities.size,
             topicCount = brain.globalVector.topics.size,
             clusterCount = clusters.size,
             effectiveClusterCount = if (herfindahl > 0) 1.0 / herfindahl else 0.0,
@@ -205,6 +216,12 @@ internal object BrainDiagnostic {
         buildString {
             appendLine("═══ Brain Diagnostic ═══")
             appendLine("interactions=${r.totalInteractions}  persona=${r.persona}  topics=${r.topicCount}")
+            if (r.maintenanceApplied) {
+                appendLine(
+                    "V15 maintenance applied: topics ${r.topicsBeforeMaintenance} → ${r.topicCount}, " +
+                        "affinities ${r.affinitiesBeforeMaintenance} → ${r.topicAffinityEdges}",
+                )
+            }
             appendLine(
                 "clusters=${r.clusterCount}  effectiveClusters=%.1f  topClusterShare=%.0f%%"
                     .format(r.effectiveClusterCount, r.topClusterMassShare * 100),

--- a/app/src/test/java/io/github/aedev/flow/data/recommendation/eval/BrainDiagnostic.kt
+++ b/app/src/test/java/io/github/aedev/flow/data/recommendation/eval/BrainDiagnostic.kt
@@ -1,0 +1,250 @@
+/*
+ * Copyright (C) 2025-2026 Flow | A-EDev
+ *
+ * This file is part of Flow (https://github.com/A-EDev/Flow).
+ * Test-source-set only — never shipped in the APK.
+ */
+
+package io.github.aedev.flow.data.recommendation.eval
+
+import io.github.aedev.flow.data.recommendation.FlowPersona
+import io.github.aedev.flow.data.recommendation.NeuroClusters
+import io.github.aedev.flow.data.recommendation.NeuroDiscovery
+import io.github.aedev.flow.data.recommendation.NeuroScoring
+import io.github.aedev.flow.data.recommendation.NeuroStorage
+import io.github.aedev.flow.data.recommendation.NeuroTokenizer
+import io.github.aedev.flow.data.recommendation.NeuroTopicCatalog
+import io.github.aedev.flow.data.recommendation.UserBrain
+import io.github.aedev.flow.data.recommendation.toUserBrain
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+/**
+ * Offline diagnostic over a REAL exported brain (Settings → Export Data →
+ * engine profile, or Flow Personality → export). Runs the production
+ * clustering, scheduling, and discovery code on the user's actual data so
+ * cluster shape, rotation state, and repetition defenses can be inspected
+ * instead of guessed at.
+ */
+internal object BrainDiagnostic {
+    fun parseBrain(json: String): UserBrain =
+        Json { ignoreUnknownKeys = true }
+            .decodeFromString<NeuroStorage.SerializableBrain>(json)
+            .toUserBrain()
+
+    // ── Machine-readable report (for visualization) ──
+
+    @Serializable
+    data class TopicDto(
+        val name: String,
+        val score: Double,
+    )
+
+    @Serializable
+    data class ClusterDto(
+        val representative: String,
+        val mass: Double,
+        val massShare: Double,
+        val lastServedHoursAgo: Double?,
+        val scheduledPosition: Int,
+        val topics: List<TopicDto>,
+    )
+
+    @Serializable
+    data class SessionDto(
+        val queries: List<String>,
+        val servedClusters: List<String>,
+    )
+
+    @Serializable
+    data class GateStatsDto(
+        val feedHistoryEntries: Int,
+        val impressedWithin6h: Int,
+        val gatedByRepeatWindow: Int,
+        val showCountHistogram: Map<Int, Int>,
+    )
+
+    @Serializable
+    data class ReportDto(
+        val totalInteractions: Int,
+        val persona: String,
+        val topicCount: Int,
+        val clusterCount: Int,
+        val effectiveClusterCount: Double,
+        val topClusterMassShare: Double,
+        val clusters: List<ClusterDto>,
+        val sessions: List<SessionDto>,
+        val gate: GateStatsDto,
+        val topTopics: List<TopicDto>,
+        val preferredTopics: List<String>,
+        val staleQueriesActive: Int,
+        val recentRelatedSeeds: Int,
+        val suppressedVideos: Int,
+        val suppressedChannels: Int,
+        val blockedChannels: Int,
+        val blockedTopics: List<String>,
+        val watchHistoryEntries: Int,
+        val tagAffinityEdges: Int,
+        val topicAffinityEdges: Int,
+    )
+
+    fun diagnose(
+        brain: UserBrain,
+        now: Long = System.currentTimeMillis(),
+        sessions: Int = 3,
+    ): ReportDto {
+        val tokenizer = NeuroTokenizer()
+        val discovery = NeuroDiscovery(NeuroTopicCatalog.TOPIC_CATEGORIES, tokenizer)
+        val persona =
+            FlowPersona.entries.find { it.name == brain.lastPersona } ?: FlowPersona.EXPLORER
+
+        // ── Clusters, exactly as production builds them ──
+        val clusters =
+            NeuroClusters.buildClusters(
+                topicScores = brain.globalVector.topics,
+                affinities = brain.topicAffinities,
+                channelTopicProfiles = brain.channelTopicProfiles,
+                categories = NeuroTopicCatalog.TOPIC_CATEGORIES,
+                normalizeLemma = tokenizer::normalizeLemma,
+                tagAffinities = brain.tagAffinities,
+            )
+        val scheduled = NeuroClusters.schedule(clusters, brain.clusterRotation, now)
+        val totalMass = clusters.sumOf { it.mass }.coerceAtLeast(1e-9)
+        val herfindahl = clusters.sumOf { (it.mass / totalMass) * (it.mass / totalMass) }
+
+        val scoreOf = { topic: String -> brain.globalVector.topics[topic] ?: 0.0 }
+        val baseScores = HashMap<String, Double>()
+        brain.globalVector.topics.forEach { (k, v) ->
+            baseScores.merge(NeuroScoring.stripDomainTag(k), v, ::maxOf)
+        }
+
+        val clusterDtos =
+            scheduled.mapIndexed { index, cluster ->
+                val lastServed = brain.clusterRotation[cluster.representative]
+                ClusterDto(
+                    representative = cluster.representative,
+                    mass = cluster.mass,
+                    massShare = cluster.mass / totalMass,
+                    lastServedHoursAgo = lastServed?.let { (now - it) / 3_600_000.0 },
+                    scheduledPosition = index + 1,
+                    topics =
+                        cluster.topics.map { TopicDto(it, baseScores[it] ?: 0.0) },
+                )
+            }
+
+        // ── Discovery simulation: what the NEXT refreshes would actually query ──
+        var rotation = brain.clusterRotation
+        var clock = now
+        val sessionDtos = mutableListOf<SessionDto>()
+        repeat(sessions) {
+            val queries =
+                discovery.generateQueries(brain.copy(clusterRotation = rotation), clock) { persona }
+            val served = queries.mapNotNull { it.clusterKey }.distinct()
+            sessionDtos +=
+                SessionDto(
+                    queries = queries.map { "[${it.strategy}] ${it.query}" },
+                    servedClusters = served,
+                )
+            if (served.isNotEmpty()) rotation = rotation + served.associateWith { clock }
+            clock += 4L * 3_600_000L
+        }
+
+        // ── Seen-gate state over the real feed history ──
+        val histogram =
+            brain.feedHistory.values
+                .groupingBy { it.showCount.coerceAtMost(9) }
+                .eachCount()
+        val within6h =
+            brain.feedHistory.values.count { (now - it.lastShown) / 3_600_000.0 < NeuroScoring.SEEN_GATE_SINGLE_SHOW_WINDOW_HOURS }
+        val gatedRepeats =
+            brain.feedHistory.values.count {
+                it.showCount >= NeuroScoring.SEEN_GATE_SHOW_COUNT &&
+                    (now - it.lastShown) / 3_600_000.0 < NeuroScoring.SEEN_GATE_WINDOW_HOURS
+            }
+
+        val staleCutoff = now - NeuroScoring.STALE_QUERY_EXPIRY_HOURS * 3_600_000L
+
+        return ReportDto(
+            totalInteractions = brain.totalInteractions,
+            persona = persona.name,
+            topicCount = brain.globalVector.topics.size,
+            clusterCount = clusters.size,
+            effectiveClusterCount = if (herfindahl > 0) 1.0 / herfindahl else 0.0,
+            topClusterMassShare = clusters.maxOfOrNull { it.mass / totalMass } ?: 0.0,
+            clusters = clusterDtos,
+            sessions = sessionDtos,
+            gate =
+                GateStatsDto(
+                    feedHistoryEntries = brain.feedHistory.size,
+                    impressedWithin6h = within6h,
+                    gatedByRepeatWindow = gatedRepeats,
+                    showCountHistogram = histogram,
+                ),
+            topTopics =
+                brain.globalVector.topics.entries
+                    .sortedByDescending { it.value }
+                    .take(40)
+                    .map { TopicDto(it.key, it.value) },
+            preferredTopics = brain.preferredTopics.sorted(),
+            staleQueriesActive = brain.staleQueries.count { it.value > staleCutoff },
+            recentRelatedSeeds = brain.recentRelatedSeeds.size,
+            suppressedVideos = brain.suppressedVideoIds.size,
+            suppressedChannels = brain.suppressedChannels.size,
+            blockedChannels = brain.blockedChannels.size,
+            blockedTopics = brain.blockedTopics.sorted(),
+            watchHistoryEntries = brain.watchHistoryMap.size,
+            tagAffinityEdges = brain.tagAffinities.size,
+            topicAffinityEdges = brain.topicAffinities.size,
+        )
+    }
+
+    fun toJson(report: ReportDto): String = Json { prettyPrint = true }.encodeToString(report)
+
+    fun renderText(r: ReportDto): String =
+        buildString {
+            appendLine("═══ Brain Diagnostic ═══")
+            appendLine("interactions=${r.totalInteractions}  persona=${r.persona}  topics=${r.topicCount}")
+            appendLine(
+                "clusters=${r.clusterCount}  effectiveClusters=%.1f  topClusterShare=%.0f%%"
+                    .format(r.effectiveClusterCount, r.topClusterMassShare * 100),
+            )
+            appendLine()
+            appendLine("CLUSTERS (scheduled order for the NEXT refresh):")
+            r.clusters.forEach { c ->
+                val served =
+                    c.lastServedHoursAgo?.let { "served %.1fh ago".format(it) } ?: "never served"
+                appendLine(
+                    "  #%d %-18s mass=%.2f (%2.0f%%) [%s]"
+                        .format(c.scheduledPosition, c.representative, c.mass, c.massShare * 100, served),
+                )
+                val members =
+                    c.topics.take(12).joinToString(", ") { "%s(%.2f)".format(it.name, it.score) }
+                appendLine("      $members${if (c.topics.size > 12) " … +${c.topics.size - 12}" else ""}")
+            }
+            appendLine()
+            appendLine("DISCOVERY SIMULATION (rotation advancing):")
+            r.sessions.forEachIndexed { i, s ->
+                appendLine("  session ${i + 1}: clusters=${s.servedClusters}")
+                s.queries.forEach { appendLine("    $it") }
+            }
+            appendLine()
+            appendLine("SEEN-GATE STATE:")
+            appendLine("  feedHistory entries        = ${r.gate.feedHistoryEntries}")
+            appendLine("  hidden by 6h single-show   = ${r.gate.impressedWithin6h}")
+            appendLine("  hidden by 60h repeat gate  = ${r.gate.gatedByRepeatWindow}")
+            appendLine("  showCount histogram        = ${r.gate.showCountHistogram.toSortedMap()}")
+            appendLine()
+            appendLine("STATE: staleQueries=${r.staleQueriesActive} relatedSeedCooldowns=${r.recentRelatedSeeds}")
+            appendLine(
+                "       suppressedVideos=${r.suppressedVideos} suppressedChannels=${r.suppressedChannels} " +
+                    "blockedChannels=${r.blockedChannels} watchHistory=${r.watchHistoryEntries}",
+            )
+            appendLine("       affinityEdges=${r.topicAffinityEdges} tagAffinityEdges=${r.tagAffinityEdges}")
+            appendLine("       blockedTopics=${r.blockedTopics}")
+            appendLine("       preferredTopics=${r.preferredTopics}")
+            appendLine()
+            appendLine("TOP 40 TOPICS:")
+            r.topTopics.forEach { appendLine("  %-28s %.3f".format(it.name, it.score)) }
+        }
+}

--- a/app/src/test/java/io/github/aedev/flow/data/recommendation/eval/BrainDiagnosticTest.kt
+++ b/app/src/test/java/io/github/aedev/flow/data/recommendation/eval/BrainDiagnosticTest.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2025-2026 Flow | A-EDev
+ *
+ * This file is part of Flow (https://github.com/A-EDev/Flow).
+ */
+
+package io.github.aedev.flow.data.recommendation.eval
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Assume.assumeTrue
+import org.junit.Test
+import java.io.File
+
+/**
+ * Runs [BrainDiagnostic] against a real exported brain when one is present.
+ *
+ * Usage: export the engine profile on the device (Settings → Export Data →
+ * engine profile, or Flow Personality → export), copy the JSON to
+ * `diagnostics/brain.json` at the repo root (or pass -Dflow.brainPath=...),
+ * then run this test. Reports land in app/build/reports/neuro-benchmark/
+ * as brain-diagnostic.txt and brain-diagnostic.json.
+ *
+ * Skips silently when no brain file is present, so CI is unaffected.
+ */
+class BrainDiagnosticTest {
+    private fun locateBrainFile(): File? {
+        System.getProperty("flow.brainPath")?.let { override ->
+            val f = File(override)
+            if (f.isFile) return f
+        }
+        return listOf(
+            File("../diagnostics/brain.json"),
+            File("diagnostics/brain.json"),
+        ).firstOrNull { it.isFile }
+    }
+
+    @Test
+    fun `diagnose exported brain`() {
+        val brainFile = locateBrainFile()
+        assumeTrue("No diagnostics/brain.json present — skipping", brainFile != null)
+
+        val brain = BrainDiagnostic.parseBrain(brainFile!!.readText())
+        val report = BrainDiagnostic.diagnose(brain)
+        val text = BrainDiagnostic.renderText(report)
+
+        println(text)
+        val out = File("build/reports/neuro-benchmark").apply { mkdirs() }
+        File(out, "brain-diagnostic.txt").writeText(text)
+        File(out, "brain-diagnostic.json").writeText(BrainDiagnostic.toJson(report))
+
+        assertThat(report.topicCount).isGreaterThan(0)
+    }
+
+    @Test
+    fun `diagnostic runs on a synthetic brain`() {
+        // Keeps the diagnostic itself regression-tested even when no export exists.
+        val universe = NeuroBenchmark.multiInterestUniverse()
+        val report = BrainDiagnostic.diagnose(NeuroBenchmark.brainFor(universe), now = NeuroEval.FIXED_NOW)
+        assertThat(report.clusterCount).isEqualTo(universe.groups.size)
+        assertThat(report.sessions).isNotEmpty()
+        assertThat(report.clusters.first().scheduledPosition).isEqualTo(1)
+    }
+}

--- a/app/src/test/java/io/github/aedev/flow/data/recommendation/eval/NeuroBenchmark.kt
+++ b/app/src/test/java/io/github/aedev/flow/data/recommendation/eval/NeuroBenchmark.kt
@@ -128,7 +128,11 @@ internal object NeuroBenchmark {
             topicAffinities = affinities,
             topicEvidence = evidence,
             channelScores = channelScores,
-            preferredTopics = universe.groups.filter { it.strength >= 0.40 }.map { it.topics[0] }.toSet(),
+            preferredTopics =
+                universe.groups
+                    .filter { it.strength >= 0.40 }
+                    .map { it.topics[0] }
+                    .toSet(),
             totalInteractions = 200,
             hasCompletedOnboarding = true,
         )
@@ -239,13 +243,23 @@ internal object NeuroBenchmark {
         val discovery = NeuroDiscovery(NeuroTopicCatalog.TOPIC_CATEGORIES, tokenizer)
         val catalog = Catalog(universe, seed)
         var brain = brainFor(universe)
-        val userSubs = setOf(universe.groups.first().channels.first())
+        val userSubs =
+            setOf(
+                universe.groups
+                    .first()
+                    .channels
+                    .first(),
+            )
         val preferredLemmas = brain.preferredTopics.map { tokenizer.normalizeLemma(it) }.toSet()
 
         val feedHistory = mutableMapOf<String, FeedEntry>()
         val watchHistory = mutableMapOf<String, WatchEntry>()
         val servedSoFar = mutableSetOf<String>()
-        val weakGroups = universe.groups.filter { it.strength < 0.30 }.map { it.name }.toSet()
+        val weakGroups =
+            universe.groups
+                .filter { it.strength < 0.30 }
+                .map { it.name }
+                .toSet()
         val servedGroupsCumulative = mutableSetOf<String>()
 
         val perRefresh = mutableListOf<RefreshMetrics>()
@@ -313,7 +327,10 @@ internal object NeuroBenchmark {
             }
             feedIds
                 .firstOrNull { id ->
-                    universe.groups.firstOrNull { it.name == groupOf(id) }?.strength?.let { it >= 0.40 } == true &&
+                    universe.groups
+                        .firstOrNull { it.name == groupOf(id) }
+                        ?.strength
+                        ?.let { it >= 0.40 } == true &&
                         id !in watchHistory
                 }?.let { watchedId -> watchHistory[watchedId] = WatchEntry(0.9f, now) }
 
@@ -405,7 +422,13 @@ internal object NeuroBenchmark {
             serving.perRefresh.forEach { m ->
                 appendLine(
                     "  %7d | %6.2f | %8.2f | %5.3f | %5.3f | %5.3f | %s".format(
-                        m.refresh, m.repeatRate, m.groupCoverage, m.ndcg, m.ild, m.concentration, m.servedGroups,
+                        m.refresh,
+                        m.repeatRate,
+                        m.groupCoverage,
+                        m.ndcg,
+                        m.ild,
+                        m.concentration,
+                        m.servedGroups,
                     ),
                 )
             }

--- a/app/src/test/java/io/github/aedev/flow/data/recommendation/eval/NeuroBenchmark.kt
+++ b/app/src/test/java/io/github/aedev/flow/data/recommendation/eval/NeuroBenchmark.kt
@@ -270,14 +270,21 @@ internal object NeuroBenchmark {
 
         val perRefresh = mutableListOf<RefreshMetrics>()
         val queriesPerRefresh = mutableListOf<List<String>>()
+        var clusterRotation = mapOf<String, Long>()
         var now = NeuroEval.FIXED_NOW
 
         repeat(refreshes) { r ->
-            // 1. Discovery decides what to search for (the real production selector).
-            val rawQueries = discovery.generateQueries(brain) { FlowPersona.EXPLORER }.map { it.query }
+            // 1. Discovery decides what to search for (the real production selector),
+            //    with cluster rotation advanced between refreshes as the engine does.
+            val discoveryBrain = brain.copy(clusterRotation = clusterRotation)
+            val discoveryQueries = discovery.generateQueries(discoveryBrain, now) { FlowPersona.EXPLORER }.take(8)
             val queries =
-                rawQueries.ifEmpty { universe.groups.take(4).map { it.topics[0] } }.take(8)
+                discoveryQueries.map { it.query }.ifEmpty { universe.groups.take(4).map { it.topics[0] } }
             queriesPerRefresh += queries
+            val servedClusters = discoveryQueries.mapNotNull { it.clusterKey }.toSet()
+            if (servedClusters.isNotEmpty()) {
+                clusterRotation = clusterRotation + servedClusters.associateWith { now }
+            }
 
             // 2. Each query pulls from the finite catalog of whatever group it targets.
             val pool = LinkedHashMap<String, NeuroEval.Labeled>()
@@ -395,9 +402,18 @@ internal object NeuroBenchmark {
         val perSessionCoverage = mutableListOf<Double>()
         val cumulativeGroups = mutableSetOf<String>()
         val overlaps = mutableListOf<Double>()
+        var clusterRotation = mapOf<String, Long>()
+        var now = NeuroEval.FIXED_NOW
 
         repeat(sessions) {
-            val queries = discovery.generateQueries(brain) { FlowPersona.EXPLORER }.map { it.query }
+            val discoveryBrain = brain.copy(clusterRotation = clusterRotation)
+            val sessionResult = discovery.generateQueries(discoveryBrain, now) { FlowPersona.EXPLORER }
+            val queries = sessionResult.map { it.query }
+            val servedClusters = sessionResult.mapNotNull { it.clusterKey }.toSet()
+            if (servedClusters.isNotEmpty()) {
+                clusterRotation = clusterRotation + servedClusters.associateWith { now }
+            }
+            now += REFRESH_INTERVAL_MS
             val groups =
                 queries
                     .mapNotNull { q ->

--- a/app/src/test/java/io/github/aedev/flow/data/recommendation/eval/NeuroBenchmark.kt
+++ b/app/src/test/java/io/github/aedev/flow/data/recommendation/eval/NeuroBenchmark.kt
@@ -195,7 +195,10 @@ internal object NeuroBenchmark {
 
     data class RefreshMetrics(
         val refresh: Int,
-        val repeatRate: Double,
+        /** Share of this refresh the user had ALREADY SEEN (impressed) before — the UX repeat. */
+        val seenRepeatRate: Double,
+        /** Share previously served anywhere (incl. below the fold the user never saw). */
+        val servedRepeatRate: Double,
         val groupCoverage: Double,
         val ndcg: Double,
         val ild: Double,
@@ -204,7 +207,8 @@ internal object NeuroBenchmark {
     )
 
     data class ServingSummary(
-        val meanRepeatRate: Double,
+        val meanSeenRepeatRate: Double,
+        val meanServedRepeatRate: Double,
         val uniqueServedRatio: Double,
         val meanGroupCoverage: Double,
         val cumulativeGroupCoverage: Double,
@@ -238,6 +242,7 @@ internal object NeuroBenchmark {
         perQueryCandidates: Int = 12,
         noisePerRefresh: Int = 6,
         seed: Long = 42L,
+        seenGateEnabled: Boolean = true,
     ): ServingResult {
         val tokenizer = NeuroTokenizer()
         val discovery = NeuroDiscovery(NeuroTopicCatalog.TOPIC_CATEGORIES, tokenizer)
@@ -255,6 +260,7 @@ internal object NeuroBenchmark {
         val feedHistory = mutableMapOf<String, FeedEntry>()
         val watchHistory = mutableMapOf<String, WatchEntry>()
         val servedSoFar = mutableSetOf<String>()
+        val impressedSoFar = mutableSetOf<String>()
         val weakGroups =
             universe.groups
                 .filter { it.strength < 0.30 }
@@ -285,18 +291,25 @@ internal object NeuroBenchmark {
             catalog.sampleNoise(noisePerRefresh).forEach { pool.putIfAbsent(it.video.id, it) }
 
             // 3. Score + diversity re-rank through the production pipeline (no jitter).
+            // Mirrors rank(): the hard seen-gate runs before scoring.
             val brainNow = brain.copy(feedHistory = feedHistory.toMap())
+            val gatedPool =
+                if (seenGateEnabled) {
+                    NeuroScoring.applySeenGate(pool.values.toList(), brainNow.feedHistory, now) { it.video.id }
+                } else {
+                    pool.values.toList()
+                }
             val params =
                 NeuroEval.params(
                     brain = brainNow,
                     userSubs = userSubs,
                     preferredLemmas = preferredLemmas,
-                    poolSize = pool.size,
+                    poolSize = gatedPool.size,
                     watchHistory = watchHistory.toMap(),
                     now = now,
                 )
             val scored =
-                pool.values
+                gatedPool
                     .map { ScoredVideo(it.video, NeuroScoring.scoreCandidate(it.video, it.vector, params), it.vector) }
                     .toMutableList()
             val feed = NeuroScoring.applySmartDiversity(scored, tokenizer).take(topK)
@@ -304,14 +317,16 @@ internal object NeuroBenchmark {
 
             // 4. Metrics for this refresh.
             val feedIds = feed.map { it.id }
-            val repeats = feedIds.count { it in servedSoFar }
+            val seenRepeats = feedIds.count { it in impressedSoFar }
+            val servedRepeats = feedIds.count { it in servedSoFar }
             val groupsInFeed = feedIds.map { groupOf(it) }.filter { g -> universe.groups.any { it.name == g } }
             val servedGroupCounts = groupsInFeed.groupingBy { it }.eachCount()
             servedGroupsCumulative += servedGroupCounts.keys
             perRefresh +=
                 RefreshMetrics(
                     refresh = r + 1,
-                    repeatRate = if (r == 0) 0.0 else repeats.toDouble() / feedIds.size,
+                    seenRepeatRate = if (r == 0) 0.0 else seenRepeats.toDouble() / feedIds.size,
+                    servedRepeatRate = if (r == 0) 0.0 else servedRepeats.toDouble() / feedIds.size,
                     groupCoverage = servedGroupCounts.size.toDouble() / universe.groups.size,
                     ndcg = NeuroEval.ndcg(feedLabeled, feedIds.size),
                     ild = NeuroEval.ild(feedLabeled, feedIds.size),
@@ -319,6 +334,7 @@ internal object NeuroBenchmark {
                     servedGroups = servedGroupCounts,
                 )
             servedSoFar += feedIds
+            impressedSoFar += feedIds.take(viewportK)
 
             // 5. Feedback: viewport impressions + one watch from a strong interest.
             feedIds.take(viewportK).forEach { id ->
@@ -339,7 +355,8 @@ internal object NeuroBenchmark {
 
         val summary =
             ServingSummary(
-                meanRepeatRate = perRefresh.drop(1).map { it.repeatRate }.averageOrZero(),
+                meanSeenRepeatRate = perRefresh.drop(1).map { it.seenRepeatRate }.averageOrZero(),
+                meanServedRepeatRate = perRefresh.drop(1).map { it.servedRepeatRate }.averageOrZero(),
                 uniqueServedRatio = servedSoFar.size.toDouble() / (refreshes * topK),
                 meanGroupCoverage = perRefresh.map { it.groupCoverage }.averageOrZero(),
                 cumulativeGroupCoverage = servedGroupsCumulative.size.toDouble() / universe.groups.size,
@@ -418,12 +435,13 @@ internal object NeuroBenchmark {
             appendLine("═══ NeuroBenchmark [$label] ═══")
             appendLine()
             appendLine("SERVING (8 refreshes, top-20, finite catalogs)")
-            appendLine("  refresh | repeat | coverage | ndcg  | ild   | conc  | groups")
+            appendLine("  refresh | seenRep | servedRep | coverage | ndcg  | ild   | conc  | groups")
             serving.perRefresh.forEach { m ->
                 appendLine(
-                    "  %7d | %6.2f | %8.2f | %5.3f | %5.3f | %5.3f | %s".format(
+                    "  %7d | %7.2f | %9.2f | %8.2f | %5.3f | %5.3f | %5.3f | %s".format(
                         m.refresh,
-                        m.repeatRate,
+                        m.seenRepeatRate,
+                        m.servedRepeatRate,
                         m.groupCoverage,
                         m.ndcg,
                         m.ild,
@@ -434,7 +452,8 @@ internal object NeuroBenchmark {
             }
             val s = serving.summary
             appendLine()
-            appendLine("  meanRepeatRate (r2+)     = %.3f".format(s.meanRepeatRate))
+            appendLine("  meanSeenRepeatRate (r2+) = %.3f".format(s.meanSeenRepeatRate))
+            appendLine("  meanServedRepeatRate     = %.3f".format(s.meanServedRepeatRate))
             appendLine("  uniqueServedRatio        = %.3f".format(s.uniqueServedRatio))
             appendLine("  meanGroupCoverage        = %.3f".format(s.meanGroupCoverage))
             appendLine("  cumulativeGroupCoverage  = %.3f".format(s.cumulativeGroupCoverage))

--- a/app/src/test/java/io/github/aedev/flow/data/recommendation/eval/NeuroBenchmark.kt
+++ b/app/src/test/java/io/github/aedev/flow/data/recommendation/eval/NeuroBenchmark.kt
@@ -405,9 +405,10 @@ internal object NeuroBenchmark {
         var clusterRotation = mapOf<String, Long>()
         var now = NeuroEval.FIXED_NOW
 
-        repeat(sessions) {
+        repeat(sessions) { round ->
             val discoveryBrain = brain.copy(clusterRotation = clusterRotation)
-            val sessionResult = discovery.generateQueries(discoveryBrain, now) { FlowPersona.EXPLORER }
+            // Round index doubles as tree depth — models refresh + successive pages.
+            val sessionResult = discovery.generateQueries(discoveryBrain, now, depth = round) { FlowPersona.EXPLORER }
             val queries = sessionResult.map { it.query }
             val servedClusters = sessionResult.mapNotNull { it.clusterKey }.toSet()
             if (servedClusters.isNotEmpty()) {

--- a/app/src/test/java/io/github/aedev/flow/data/recommendation/eval/NeuroBenchmark.kt
+++ b/app/src/test/java/io/github/aedev/flow/data/recommendation/eval/NeuroBenchmark.kt
@@ -1,0 +1,431 @@
+/*
+ * Copyright (C) 2025-2026 Flow | A-EDev
+ *
+ * This file is part of Flow (https://github.com/A-EDev/Flow).
+ * Test-source-set only — never shipped in the APK.
+ */
+
+package io.github.aedev.flow.data.recommendation.eval
+
+import io.github.aedev.flow.data.recommendation.ContentVector
+import io.github.aedev.flow.data.recommendation.FeedEntry
+import io.github.aedev.flow.data.recommendation.FlowPersona
+import io.github.aedev.flow.data.recommendation.NeuroDiscovery
+import io.github.aedev.flow.data.recommendation.NeuroScoring
+import io.github.aedev.flow.data.recommendation.NeuroTokenizer
+import io.github.aedev.flow.data.recommendation.NeuroTopicCatalog
+import io.github.aedev.flow.data.recommendation.ScoredVideo
+import io.github.aedev.flow.data.recommendation.TopicEvidence
+import io.github.aedev.flow.data.recommendation.UserBrain
+import io.github.aedev.flow.data.recommendation.WatchEntry
+import java.util.Random
+
+/**
+ * End-to-end offline benchmark for the recommendation pipeline.
+ *
+ * Simulates a multi-interest user across N home-feed refreshes, driving the REAL
+ * production path (NeuroDiscovery.generateQueries → NeuroScoring.scoreCandidate →
+ * applySmartDiversity) against a finite candidate universe, with impressions and
+ * watches fed back between refreshes exactly as the engine records them.
+ *
+ * Finite per-group candidate catalogs model the reality that repeating the same
+ * search query returns largely the same results — the repetition pressure the
+ * engine must fight.
+ *
+ * Metrics answer the two product questions directly:
+ *  - repeatRate@K: how much of each refresh the user has already been shown
+ *  - groupCoverage / weakGroupServiceRate: do ALL saved interests reach the feed,
+ *    or do the top interests monopolize it
+ */
+internal object NeuroBenchmark {
+    private const val REFRESH_INTERVAL_MS = 4L * 60 * 60 * 1000
+
+    // ── Universe ──
+
+    data class InterestGroup(
+        val name: String,
+        val topics: List<String>,
+        val strength: Double,
+        val channels: List<String>,
+    )
+
+    data class Universe(
+        val groups: List<InterestGroup>,
+        val noiseTopics: List<String>,
+        val catalogPerGroup: Int,
+    )
+
+    /**
+     * Six interests of graded strength — the "diverse user" the product promises
+     * to serve. Weak-tail groups (physics, chess, woodworking) are the canary:
+     * a healthy engine cycles them into the feed; a looping engine never does.
+     */
+    fun multiInterestUniverse(): Universe =
+        Universe(
+            groups =
+                listOf(
+                    InterestGroup("gaming", listOf("minecraft", "speedrun", "roblox"), 0.65, listOf("chG1", "chG2", "chG3")),
+                    InterestGroup("cooking", listOf("cooking", "recipe", "baking"), 0.45, listOf("chC1", "chC2", "chC3")),
+                    InterestGroup("guitar", listOf("guitar", "chord", "acoustic"), 0.40, listOf("chU1", "chU2", "chU3")),
+                    InterestGroup("physics", listOf("physics", "quantum", "astronomy"), 0.25, listOf("chP1", "chP2")),
+                    InterestGroup("chess", listOf("chess", "opening", "endgame"), 0.18, listOf("chS1", "chS2")),
+                    InterestGroup("woodworking", listOf("woodworking", "joinery", "sawmill"), 0.12, listOf("chW1", "chW2")),
+                ),
+            noiseTopics = listOf("celebrity", "gossip", "prank", "unboxing", "lottery"),
+            catalogPerGroup = 50,
+        )
+
+    fun brainFor(universe: Universe): UserBrain {
+        val topics = mutableMapOf<String, Double>()
+        val affinities = mutableMapOf<String, Double>()
+        val evidence = mutableMapOf<String, TopicEvidence>()
+        val channelScores = mutableMapOf<String, Double>()
+
+        universe.groups.forEach { group ->
+            group.topics.forEachIndexed { i, topic ->
+                val scale =
+                    when (i) {
+                        0 -> 1.0
+                        1 -> 0.75
+                        else -> 0.55
+                    }
+                topics[topic] = group.strength * scale
+            }
+            for (i in group.topics.indices) {
+                for (j in i + 1 until group.topics.size) {
+                    affinities[NeuroScoring.makeAffinityKey(group.topics[i], group.topics[j])] = 0.20
+                }
+            }
+            // Strong interests carry confirmed evidence; the weak tail stays thin —
+            // realistic for interests picked up from a handful of watches.
+            if (group.strength >= 0.40) {
+                evidence[group.topics[0]] =
+                    TopicEvidence(
+                        positiveSignals = 6,
+                        watchSignals = 3,
+                        explicitSignals = 1,
+                        positiveScore = 3.0,
+                        videoIds = setOf("${group.name}#seed1", "${group.name}#seed2"),
+                        firstSeenAt = 1L,
+                        lastSeenAt = NeuroEval.FIXED_NOW,
+                    )
+            } else {
+                evidence[group.topics[0]] =
+                    TopicEvidence(
+                        positiveSignals = 2,
+                        watchSignals = 1,
+                        positiveScore = 0.8,
+                        videoIds = setOf("${group.name}#seed1"),
+                        firstSeenAt = 1L,
+                        lastSeenAt = NeuroEval.FIXED_NOW,
+                    )
+            }
+            group.channels.forEach { ch -> channelScores[ch] = if (group.strength >= 0.40) 0.60 else 0.50 }
+        }
+
+        return UserBrain(
+            globalVector = ContentVector(topics = topics),
+            topicAffinities = affinities,
+            topicEvidence = evidence,
+            channelScores = channelScores,
+            preferredTopics = universe.groups.filter { it.strength >= 0.40 }.map { it.topics[0] }.toSet(),
+            totalInteractions = 200,
+            hasCompletedOnboarding = true,
+        )
+    }
+
+    // ── Candidate catalog ──
+
+    class Catalog(
+        private val universe: Universe,
+        seed: Long,
+    ) {
+        private val rng = Random(seed)
+        private val byGroup: Map<String, List<NeuroEval.Labeled>> =
+            universe.groups.associate { group -> group.name to (0 until universe.catalogPerGroup).map { i -> item(group, i) } }
+        private val noise: List<NeuroEval.Labeled> =
+            (0 until 30).map { i ->
+                val topic = universe.noiseTopics[i % universe.noiseTopics.size]
+                NeuroEval.Labeled(
+                    NeuroEval.video(id = "noise#$i", title = "$topic clip $i", channelId = "chN${i % 5}"),
+                    NeuroEval.vec(topic to 0.9),
+                    relevance = 0.0,
+                )
+            }
+
+        private fun item(
+            group: InterestGroup,
+            i: Int,
+        ): NeuroEval.Labeled {
+            val primary = group.topics[i % group.topics.size]
+            val secondary = group.topics[(i + 1) % group.topics.size]
+            return NeuroEval.Labeled(
+                NeuroEval.video(
+                    id = "${group.name}#$i",
+                    title = "$primary $secondary session $i",
+                    channelId = group.channels[i % group.channels.size],
+                ),
+                NeuroEval.vec(
+                    primary to 0.70 + (i % 5) * 0.04,
+                    secondary to 0.35,
+                ),
+                relevance = group.strength,
+            )
+        }
+
+        fun sampleGroup(
+            groupName: String,
+            n: Int,
+        ): List<NeuroEval.Labeled> {
+            val catalog = byGroup[groupName] ?: return emptyList()
+            // Queries surface a stable head plus a rotating tail — like real search.
+            val head = catalog.take(n / 2)
+            val tail = (0 until n - head.size).map { catalog[rng.nextInt(catalog.size)] }
+            return head + tail
+        }
+
+        fun sampleNoise(n: Int): List<NeuroEval.Labeled> = (0 until n).map { noise[rng.nextInt(noise.size)] }
+    }
+
+    // ── Metrics ──
+
+    data class RefreshMetrics(
+        val refresh: Int,
+        val repeatRate: Double,
+        val groupCoverage: Double,
+        val ndcg: Double,
+        val ild: Double,
+        val concentration: Double,
+        val servedGroups: Map<String, Int>,
+    )
+
+    data class ServingSummary(
+        val meanRepeatRate: Double,
+        val uniqueServedRatio: Double,
+        val meanGroupCoverage: Double,
+        val cumulativeGroupCoverage: Double,
+        val weakGroupServiceRate: Double,
+        val meanNdcg: Double,
+        val meanIld: Double,
+        val meanConcentration: Double,
+    )
+
+    data class ServingResult(
+        val perRefresh: List<RefreshMetrics>,
+        val summary: ServingSummary,
+        val queriesPerRefresh: List<List<String>>,
+    )
+
+    private fun groupOf(id: String): String = id.substringBefore('#')
+
+    private fun herfindahl(counts: Collection<Int>): Double {
+        val total = counts.sum().toDouble()
+        if (total <= 0) return 0.0
+        return counts.sumOf { (it / total) * (it / total) }
+    }
+
+    // ── Serving simulation ──
+
+    fun simulateServing(
+        universe: Universe = multiInterestUniverse(),
+        refreshes: Int = 8,
+        topK: Int = 20,
+        viewportK: Int = 12,
+        perQueryCandidates: Int = 12,
+        noisePerRefresh: Int = 6,
+        seed: Long = 42L,
+    ): ServingResult {
+        val tokenizer = NeuroTokenizer()
+        val discovery = NeuroDiscovery(NeuroTopicCatalog.TOPIC_CATEGORIES, tokenizer)
+        val catalog = Catalog(universe, seed)
+        var brain = brainFor(universe)
+        val userSubs = setOf(universe.groups.first().channels.first())
+        val preferredLemmas = brain.preferredTopics.map { tokenizer.normalizeLemma(it) }.toSet()
+
+        val feedHistory = mutableMapOf<String, FeedEntry>()
+        val watchHistory = mutableMapOf<String, WatchEntry>()
+        val servedSoFar = mutableSetOf<String>()
+        val weakGroups = universe.groups.filter { it.strength < 0.30 }.map { it.name }.toSet()
+        val servedGroupsCumulative = mutableSetOf<String>()
+
+        val perRefresh = mutableListOf<RefreshMetrics>()
+        val queriesPerRefresh = mutableListOf<List<String>>()
+        var now = NeuroEval.FIXED_NOW
+
+        repeat(refreshes) { r ->
+            // 1. Discovery decides what to search for (the real production selector).
+            val rawQueries = discovery.generateQueries(brain) { FlowPersona.EXPLORER }.map { it.query }
+            val queries =
+                rawQueries.ifEmpty { universe.groups.take(4).map { it.topics[0] } }.take(8)
+            queriesPerRefresh += queries
+
+            // 2. Each query pulls from the finite catalog of whatever group it targets.
+            val pool = LinkedHashMap<String, NeuroEval.Labeled>()
+            queries.forEach { q ->
+                val tokens = tokenizer.tokenize(q).map { tokenizer.normalizeLemma(it) }.toSet()
+                val group = universe.groups.firstOrNull { g -> g.topics.any { tokenizer.normalizeLemma(it) in tokens } }
+                val sampled =
+                    if (group != null) catalog.sampleGroup(group.name, perQueryCandidates) else catalog.sampleNoise(perQueryCandidates / 2)
+                sampled.forEach { pool.putIfAbsent(it.video.id, it) }
+            }
+            catalog.sampleNoise(noisePerRefresh).forEach { pool.putIfAbsent(it.video.id, it) }
+
+            // 3. Score + diversity re-rank through the production pipeline (no jitter).
+            val brainNow = brain.copy(feedHistory = feedHistory.toMap())
+            val params =
+                NeuroEval.params(
+                    brain = brainNow,
+                    userSubs = userSubs,
+                    preferredLemmas = preferredLemmas,
+                    poolSize = pool.size,
+                    watchHistory = watchHistory.toMap(),
+                    now = now,
+                )
+            val scored =
+                pool.values
+                    .map { ScoredVideo(it.video, NeuroScoring.scoreCandidate(it.video, it.vector, params), it.vector) }
+                    .toMutableList()
+            val feed = NeuroScoring.applySmartDiversity(scored, tokenizer).take(topK)
+            val feedLabeled = feed.mapNotNull { v -> pool[v.id] }
+
+            // 4. Metrics for this refresh.
+            val feedIds = feed.map { it.id }
+            val repeats = feedIds.count { it in servedSoFar }
+            val groupsInFeed = feedIds.map { groupOf(it) }.filter { g -> universe.groups.any { it.name == g } }
+            val servedGroupCounts = groupsInFeed.groupingBy { it }.eachCount()
+            servedGroupsCumulative += servedGroupCounts.keys
+            perRefresh +=
+                RefreshMetrics(
+                    refresh = r + 1,
+                    repeatRate = if (r == 0) 0.0 else repeats.toDouble() / feedIds.size,
+                    groupCoverage = servedGroupCounts.size.toDouble() / universe.groups.size,
+                    ndcg = NeuroEval.ndcg(feedLabeled, feedIds.size),
+                    ild = NeuroEval.ild(feedLabeled, feedIds.size),
+                    concentration = herfindahl(servedGroupCounts.values),
+                    servedGroups = servedGroupCounts,
+                )
+            servedSoFar += feedIds
+
+            // 5. Feedback: viewport impressions + one watch from a strong interest.
+            feedIds.take(viewportK).forEach { id ->
+                val prev = feedHistory[id]
+                feedHistory[id] = FeedEntry(lastShown = now, showCount = (prev?.showCount ?: 0) + 1)
+            }
+            feedIds
+                .firstOrNull { id ->
+                    universe.groups.firstOrNull { it.name == groupOf(id) }?.strength?.let { it >= 0.40 } == true &&
+                        id !in watchHistory
+                }?.let { watchedId -> watchHistory[watchedId] = WatchEntry(0.9f, now) }
+
+            now += REFRESH_INTERVAL_MS
+        }
+
+        val summary =
+            ServingSummary(
+                meanRepeatRate = perRefresh.drop(1).map { it.repeatRate }.averageOrZero(),
+                uniqueServedRatio = servedSoFar.size.toDouble() / (refreshes * topK),
+                meanGroupCoverage = perRefresh.map { it.groupCoverage }.averageOrZero(),
+                cumulativeGroupCoverage = servedGroupsCumulative.size.toDouble() / universe.groups.size,
+                weakGroupServiceRate =
+                    weakGroups.count { it in servedGroupsCumulative }.toDouble() / weakGroups.size.coerceAtLeast(1),
+                meanNdcg = perRefresh.map { it.ndcg }.averageOrZero(),
+                meanIld = perRefresh.map { it.ild }.averageOrZero(),
+                meanConcentration = perRefresh.map { it.concentration }.averageOrZero(),
+            )
+        return ServingResult(perRefresh, summary, queriesPerRefresh)
+    }
+
+    // ── Discovery coverage benchmark ──
+
+    data class DiscoveryResult(
+        val sessions: List<List<String>>,
+        val perSessionGroupCoverage: List<Double>,
+        val cumulativeGroupCoverage: Double,
+        val meanSessionOverlap: Double,
+    )
+
+    /**
+     * Runs the query selector across simulated sessions and measures which of the
+     * user's interest groups its queries ever target, plus session-over-session
+     * query overlap. This is the direct measurement of "stuck on top topics".
+     */
+    fun discoveryCoverage(
+        universe: Universe = multiInterestUniverse(),
+        sessions: Int = 6,
+    ): DiscoveryResult {
+        val tokenizer = NeuroTokenizer()
+        val discovery = NeuroDiscovery(NeuroTopicCatalog.TOPIC_CATEGORIES, tokenizer)
+        val brain = brainFor(universe)
+
+        val sessionQueries = mutableListOf<List<String>>()
+        val perSessionCoverage = mutableListOf<Double>()
+        val cumulativeGroups = mutableSetOf<String>()
+        val overlaps = mutableListOf<Double>()
+
+        repeat(sessions) {
+            val queries = discovery.generateQueries(brain) { FlowPersona.EXPLORER }.map { it.query }
+            val groups =
+                queries
+                    .mapNotNull { q ->
+                        val tokens = tokenizer.tokenize(q).map { tokenizer.normalizeLemma(it) }.toSet()
+                        universe.groups.firstOrNull { g -> g.topics.any { tokenizer.normalizeLemma(it) in tokens } }?.name
+                    }.toSet()
+            perSessionCoverage += groups.size.toDouble() / universe.groups.size
+            cumulativeGroups += groups
+            sessionQueries.lastOrNull()?.let { prev ->
+                val a = prev.toSet()
+                val b = queries.toSet()
+                if (a.isNotEmpty() || b.isNotEmpty()) {
+                    overlaps += a.intersect(b).size.toDouble() / a.union(b).size
+                }
+            }
+            sessionQueries += queries
+        }
+
+        return DiscoveryResult(
+            sessions = sessionQueries,
+            perSessionGroupCoverage = perSessionCoverage,
+            cumulativeGroupCoverage = cumulativeGroups.size.toDouble() / universe.groups.size,
+            meanSessionOverlap = overlaps.averageOrZero(),
+        )
+    }
+
+    // ── Report rendering ──
+
+    fun renderReport(
+        label: String,
+        serving: ServingResult,
+        discoveryResult: DiscoveryResult,
+    ): String =
+        buildString {
+            appendLine("═══ NeuroBenchmark [$label] ═══")
+            appendLine()
+            appendLine("SERVING (8 refreshes, top-20, finite catalogs)")
+            appendLine("  refresh | repeat | coverage | ndcg  | ild   | conc  | groups")
+            serving.perRefresh.forEach { m ->
+                appendLine(
+                    "  %7d | %6.2f | %8.2f | %5.3f | %5.3f | %5.3f | %s".format(
+                        m.refresh, m.repeatRate, m.groupCoverage, m.ndcg, m.ild, m.concentration, m.servedGroups,
+                    ),
+                )
+            }
+            val s = serving.summary
+            appendLine()
+            appendLine("  meanRepeatRate (r2+)     = %.3f".format(s.meanRepeatRate))
+            appendLine("  uniqueServedRatio        = %.3f".format(s.uniqueServedRatio))
+            appendLine("  meanGroupCoverage        = %.3f".format(s.meanGroupCoverage))
+            appendLine("  cumulativeGroupCoverage  = %.3f".format(s.cumulativeGroupCoverage))
+            appendLine("  weakGroupServiceRate     = %.3f".format(s.weakGroupServiceRate))
+            appendLine("  meanNdcg                 = %.3f".format(s.meanNdcg))
+            appendLine("  meanIld                  = %.3f".format(s.meanIld))
+            appendLine("  meanConcentration        = %.3f".format(s.meanConcentration))
+            appendLine()
+            appendLine("DISCOVERY (6 sessions)")
+            discoveryResult.sessions.forEachIndexed { i, q -> appendLine("  s${i + 1}: $q") }
+            appendLine("  perSessionGroupCoverage  = ${discoveryResult.perSessionGroupCoverage.map { "%.2f".format(it) }}")
+            appendLine("  cumulativeGroupCoverage  = %.3f".format(discoveryResult.cumulativeGroupCoverage))
+            appendLine("  meanSessionOverlap       = %.3f".format(discoveryResult.meanSessionOverlap))
+        }
+
+    private fun List<Double>.averageOrZero(): Double = if (isEmpty()) 0.0 else average()
+}

--- a/app/src/test/java/io/github/aedev/flow/data/recommendation/eval/NeuroBenchmarkTest.kt
+++ b/app/src/test/java/io/github/aedev/flow/data/recommendation/eval/NeuroBenchmarkTest.kt
@@ -39,9 +39,12 @@ class NeuroBenchmarkTest {
         // Relevance and diversity must never collapse.
         assertThat(s.meanNdcg).isAtLeast(0.55)
         assertThat(s.meanIld).isAtLeast(0.20)
-        // The user's interests must not vanish from the feed entirely.
-        assertThat(s.meanGroupCoverage).isAtLeast(0.30)
-        assertThat(s.cumulativeGroupCoverage).isAtLeast(0.50)
+        // Interest coverage: the cluster scheduler must keep cycling ALL saved
+        // interests into the feed (baseline before R3 was flat 0.50 / 0.50 with
+        // weak-tail groups never served at all).
+        assertThat(s.meanGroupCoverage).isAtLeast(0.55)
+        assertThat(s.cumulativeGroupCoverage).isAtLeast(0.65)
+        assertThat(s.weakGroupServiceRate).isAtLeast(0.30)
         // User-experienced repetition (already-impressed items reappearing) must
         // stay low — the seen-gate's whole job. Served-repeat is looser: items the
         // user never actually saw may legitimately return.

--- a/app/src/test/java/io/github/aedev/flow/data/recommendation/eval/NeuroBenchmarkTest.kt
+++ b/app/src/test/java/io/github/aedev/flow/data/recommendation/eval/NeuroBenchmarkTest.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2025-2026 Flow | A-EDev
+ *
+ * This file is part of Flow (https://github.com/A-EDev/Flow).
+ */
+
+package io.github.aedev.flow.data.recommendation.eval
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import java.io.File
+
+/**
+ * Runs the offline pipeline benchmark and writes a metrics report to
+ * app/build/reports/neuro-benchmark/report.txt so engine changes can be
+ * compared number-to-number across commits, not argued on paper.
+ *
+ * Assertions here are FLOORS — loose enough to be stable, tight enough that a
+ * regression in repetition control or interest coverage fails the build.
+ * Tighten them as the roadmap lands improvements.
+ */
+class NeuroBenchmarkTest {
+    @Test
+    fun `pipeline benchmark - report and regression floors`() {
+        val serving = NeuroBenchmark.simulateServing()
+        val discovery = NeuroBenchmark.discoveryCoverage()
+        val report = NeuroBenchmark.renderReport("branch", serving, discovery)
+
+        println(report)
+        val out = File("build/reports/neuro-benchmark").apply { mkdirs() }
+        File(out, "report.txt").writeText(report)
+
+        val s = serving.summary
+        // Relevance and diversity must never collapse.
+        assertThat(s.meanNdcg).isAtLeast(0.55)
+        assertThat(s.meanIld).isAtLeast(0.20)
+        // The user's interests must not vanish from the feed entirely.
+        assertThat(s.meanGroupCoverage).isAtLeast(0.30)
+        assertThat(s.cumulativeGroupCoverage).isAtLeast(0.50)
+        // Repetition must stay below "mostly reruns".
+        assertThat(s.meanRepeatRate).isAtMost(0.85)
+        // Discovery has to keep producing queries.
+        assertThat(discovery.sessions).isNotEmpty()
+        assertThat(discovery.sessions.all { it.isNotEmpty() }).isTrue()
+    }
+
+    @Test
+    fun `serving benchmark is reproducible for a fixed seed`() {
+        val a = NeuroBenchmark.simulateServing(seed = 7L)
+        val b = NeuroBenchmark.simulateServing(seed = 7L)
+        // Discovery uses unseeded shuffles internally, so query ORDER can vary;
+        // the deterministic core must still hold: same relevance envelope.
+        assertThat(a.summary.meanNdcg).isWithin(0.15).of(b.summary.meanNdcg)
+        assertThat(a.summary.meanRepeatRate).isWithin(0.20).of(b.summary.meanRepeatRate)
+    }
+}

--- a/app/src/test/java/io/github/aedev/flow/data/recommendation/eval/NeuroBenchmarkTest.kt
+++ b/app/src/test/java/io/github/aedev/flow/data/recommendation/eval/NeuroBenchmarkTest.kt
@@ -24,7 +24,12 @@ class NeuroBenchmarkTest {
     fun `pipeline benchmark - report and regression floors`() {
         val serving = NeuroBenchmark.simulateServing()
         val discovery = NeuroBenchmark.discoveryCoverage()
-        val report = NeuroBenchmark.renderReport("branch", serving, discovery)
+        val ungated = NeuroBenchmark.simulateServing(seenGateEnabled = false)
+        val report =
+            NeuroBenchmark.renderReport("branch", serving, discovery) +
+                "\nCOUNTERFACTUAL (seen-gate OFF, same universe/seed)\n" +
+                "  meanSeenRepeatRate       = %.3f\n".format(ungated.summary.meanSeenRepeatRate) +
+                "  meanServedRepeatRate     = %.3f\n".format(ungated.summary.meanServedRepeatRate)
 
         println(report)
         val out = File("build/reports/neuro-benchmark").apply { mkdirs() }
@@ -37,8 +42,11 @@ class NeuroBenchmarkTest {
         // The user's interests must not vanish from the feed entirely.
         assertThat(s.meanGroupCoverage).isAtLeast(0.30)
         assertThat(s.cumulativeGroupCoverage).isAtLeast(0.50)
-        // Repetition must stay below "mostly reruns".
-        assertThat(s.meanRepeatRate).isAtMost(0.85)
+        // User-experienced repetition (already-impressed items reappearing) must
+        // stay low — the seen-gate's whole job. Served-repeat is looser: items the
+        // user never actually saw may legitimately return.
+        assertThat(s.meanSeenRepeatRate).isAtMost(0.15)
+        assertThat(s.meanServedRepeatRate).isAtMost(0.60)
         // Discovery has to keep producing queries.
         assertThat(discovery.sessions).isNotEmpty()
         assertThat(discovery.sessions.all { it.isNotEmpty() }).isTrue()
@@ -51,6 +59,6 @@ class NeuroBenchmarkTest {
         // Discovery uses unseeded shuffles internally, so query ORDER can vary;
         // the deterministic core must still hold: same relevance envelope.
         assertThat(a.summary.meanNdcg).isWithin(0.15).of(b.summary.meanNdcg)
-        assertThat(a.summary.meanRepeatRate).isWithin(0.20).of(b.summary.meanRepeatRate)
+        assertThat(a.summary.meanSeenRepeatRate).isWithin(0.20).of(b.summary.meanSeenRepeatRate)
     }
 }

--- a/app/src/test/java/io/github/aedev/flow/data/recommendation/eval/NeuroBenchmarkTest.kt
+++ b/app/src/test/java/io/github/aedev/flow/data/recommendation/eval/NeuroBenchmarkTest.kt
@@ -39,12 +39,14 @@ class NeuroBenchmarkTest {
         // Relevance and diversity must never collapse.
         assertThat(s.meanNdcg).isAtLeast(0.55)
         assertThat(s.meanIld).isAtLeast(0.20)
-        // Interest coverage: the cluster scheduler must keep cycling ALL saved
-        // interests into the feed (baseline before R3 was flat 0.50 / 0.50 with
-        // weak-tail groups never served at all).
-        assertThat(s.meanGroupCoverage).isAtLeast(0.55)
-        assertThat(s.cumulativeGroupCoverage).isAtLeast(0.65)
-        assertThat(s.weakGroupServiceRate).isAtLeast(0.30)
+        // Interest coverage: every saved interest belongs in EVERY feed (majors
+        // guaranteed, tail rotating). Baseline before the cluster work was a flat
+        // 0.50 / 0.50 with weak-tail groups never served at all; the multi-cluster
+        // feed model reached 1.0 across the board.
+        assertThat(s.meanGroupCoverage).isAtLeast(0.85)
+        assertThat(s.cumulativeGroupCoverage).isAtLeast(0.95)
+        assertThat(s.weakGroupServiceRate).isAtLeast(0.80)
+        assertThat(s.meanSeenRepeatRate).isAtMost(0.10)
         // User-experienced repetition (already-impressed items reappearing) must
         // stay low — the seen-gate's whole job. Served-repeat is looser: items the
         // user never actually saw may legitimately return.

--- a/app/src/test/java/io/github/aedev/flow/ui/screens/search/SearchViewModelTest.kt
+++ b/app/src/test/java/io/github/aedev/flow/ui/screens/search/SearchViewModelTest.kt
@@ -1,5 +1,6 @@
 package io.github.aedev.flow.ui.screens.search
 
+import android.content.Context
 import com.google.common.truth.Truth.assertThat
 import io.github.aedev.flow.data.local.ContentType
 import io.github.aedev.flow.data.local.SearchFilter
@@ -25,6 +26,9 @@ import org.junit.Test
 class SearchViewModelTest {
     private val testDispatcher = StandardTestDispatcher()
     private val repository: YouTubeRepository = mockk(relaxed = true)
+    private val context: Context = mockk(relaxed = true)
+
+    private fun viewModel() = SearchViewModel(context, repository, ShortsContentFilter(flowOf(true)), ShortsQueueHandoff())
 
     @Before
     fun setUp() {
@@ -39,14 +43,14 @@ class SearchViewModelTest {
 
     @Test
     fun `initial ui state has empty query and null filters`() {
-        val viewModel = SearchViewModel(repository, ShortsContentFilter(flowOf(true)), ShortsQueueHandoff())
+        val viewModel = viewModel()
         assertThat(viewModel.uiState.value.query).isEmpty()
         assertThat(viewModel.uiState.value.filters).isNull()
     }
 
     @Test
     fun `search with valid query updates uiState`() {
-        val viewModel = SearchViewModel(repository, ShortsContentFilter(flowOf(true)), ShortsQueueHandoff())
+        val viewModel = viewModel()
         viewModel.search("Kotlin Compose")
 
         val uiState = viewModel.uiState.value
@@ -55,7 +59,7 @@ class SearchViewModelTest {
 
     @Test
     fun `search with empty query resets uiState`() {
-        val viewModel = SearchViewModel(repository, ShortsContentFilter(flowOf(true)), ShortsQueueHandoff())
+        val viewModel = viewModel()
         viewModel.search("Kotlin")
         viewModel.search("")
 
@@ -66,7 +70,7 @@ class SearchViewModelTest {
 
     @Test
     fun `updateFilters updates filters in uiState when query is active`() {
-        val viewModel = SearchViewModel(repository, ShortsContentFilter(flowOf(true)), ShortsQueueHandoff())
+        val viewModel = viewModel()
         viewModel.search("Music")
 
         val filter = SearchFilter(contentType = ContentType.VIDEOS)
@@ -77,7 +81,7 @@ class SearchViewModelTest {
 
     @Test
     fun `clearSearch resets search query and filters`() {
-        val viewModel = SearchViewModel(repository, ShortsContentFilter(flowOf(true)), ShortsQueueHandoff())
+        val viewModel = viewModel()
         viewModel.search("Android", SearchFilter(contentType = ContentType.PLAYLISTS))
 
         viewModel.clearSearch()
@@ -92,7 +96,7 @@ class SearchViewModelTest {
             val suggestions = listOf("kotlin tutorial", "kotlin android")
             coEvery { repository.getSearchSuggestions("kotlin") } returns suggestions
 
-            val viewModel = SearchViewModel(repository, ShortsContentFilter(flowOf(true)), ShortsQueueHandoff())
+            val viewModel = viewModel()
             val result = viewModel.getSearchSuggestions("kotlin")
 
             assertThat(result).isEqualTo(suggestions)

--- a/app/src/test/java/io/github/aedev/flow/utils/RelativeUploadDateParserTest.kt
+++ b/app/src/test/java/io/github/aedev/flow/utils/RelativeUploadDateParserTest.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2025-2026 Flow | A-EDev
+ *
+ * This file is part of Flow (https://github.com/A-EDev/Flow).
+ */
+
+package io.github.aedev.flow.utils
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class RelativeUploadDateParserTest {
+    private val now = 1_700_000_000_000L
+    private val dayMs = 86_400_000L
+
+    @Test
+    fun `parses common relative dates`() {
+        assertThat(RelativeUploadDateParser.parse("3 days ago", now)).isEqualTo(now - 3 * dayMs)
+        assertThat(RelativeUploadDateParser.parse("2 weeks ago", now)).isEqualTo(now - 14 * dayMs)
+        assertThat(RelativeUploadDateParser.parse("1 month ago", now)).isEqualTo(now - 30 * dayMs)
+        assertThat(RelativeUploadDateParser.parse("4 years ago", now)).isEqualTo(now - 4 * 365 * dayMs)
+    }
+
+    @Test
+    fun `strips streamed and premiered prefixes`() {
+        assertThat(RelativeUploadDateParser.parse("Streamed 2 days ago", now)).isEqualTo(now - 2 * dayMs)
+        assertThat(RelativeUploadDateParser.parse("Premiered 5 hours ago", now)).isEqualTo(now - 5 * 3_600_000L)
+    }
+
+    @Test
+    fun `unknown text returns null - never now`() {
+        assertThat(RelativeUploadDateParser.parse(null, now)).isNull()
+        assertThat(RelativeUploadDateParser.parse("", now)).isNull()
+        assertThat(RelativeUploadDateParser.parse("some random text", now)).isNull()
+    }
+
+    @Test
+    fun `today and yesterday resolve`() {
+        assertThat(RelativeUploadDateParser.parse("today", now)).isEqualTo(now)
+        assertThat(RelativeUploadDateParser.parse("yesterday", now)).isEqualTo(now - dayMs)
+    }
+}


### PR DESCRIPTION
## Summary

Overhaul of FlowNeuroEngine (schema v15) and the home feed, audited against twitter/the-algorithm:

- **Every interest in every feed**: interests are clustered on-device (label propagation over user-grounded edges) and every refresh serves the top clusters together, with the tail rotating by staleness. Load-more digs into cluster branches tree-style for deeper variety per page.
- **Repetition is now a lifecycle, not a penalty**: hard seen-gate (1 impression hides 6h, repeats 60h), reserve-cache consumption, related-seed cooldowns, and stale-query rotation.
- **Learning repairs**: watch-progress signal was dead code, affinities were pruned the same update they were created, and new interests couldn't break through maturity damping — all fixed, plus a one-time V15 brain rehydration.
- **Feed lanes**: RSS-first fresh-subs lane covering all subscriptions (one slot per channel), fixed plural relative-date parsing that inverted subs recency ("3 days" parsed as seconds), first-page source mix, and a never-dry load-more seeded from feed/history related lanes.
- **Channel knowledge**: creator tags, passive upload-title profiling, and a persistent tag content index feeding cluster edges.
- Offline evaluation harness (`NeuroBenchmarkTest`) with regression floors, plus a real-brain diagnostic (`BrainDiagnosticTest`). Benchmark: interest coverage 0.50 → 1.00, weak-interest service 0.00 → 1.00, seen-repeat rate 0.043.

## Related issue

None.

## Change type

- [x] Bug fix
- [x] Feature
- [ ] Refactor or maintenance
- [ ] Build, packaging, or CI
- [ ] Documentation

## Validation

- [x] `./gradlew :app:assembleGithubDebug`
- [x] `./gradlew :app:testGithubDebugUnitTest` (includes the new benchmark floors and engine unit tests)
- [x] `./gradlew :app:compileFossDebugKotlin` and `ktlintCheck`
- [x] Manually tested on a physical device: feed mix, cluster variety across refreshes, load-more depth, fresh-subs recency, no repeat storms.

**Test device and Android version:** XIAOMI POCO X6 PRO, Android 16

## Risk and compatibility

- Brain schema bumped to v15 with a one-time in-place migration (`NeuroMaintenance`): junk scrub + vector/affinity rehydration. No Room schema change (`consumeReserve` is DAO queries only). Feeds visibly change after update — intended.
- New DataStore file `flow_neuro_content_v1.json` (tag content index, LRU-capped at 1500 entries).
- Home feed now reads the RSS subscription feed on refresh (existing repository, no new network surface).
- Music path untouched; player path untouched.

- [x] The change does not introduce secrets, private data, or unexpected telemetry.
- [x] New user-facing text uses Android string resources. (No new user-facing strings besides the changelog asset.)
- [x] Dependency and lockfile changes are intentional and limited to this PR. (No dependency changes.)
- [x] Room schema changes include the required version bump and migration, or this PR does not change the Room schema.
- [x] Breaking changes and upgrade steps are clearly documented. (V15 migration is automatic; changelog updated.)