### PR TITLE
feat(music): deeper MusicBrain integration - new shelves, mix pages, artist insights, widget, genre context

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -294,6 +294,17 @@
                 android:resource="@xml/widget_recently_played_info" />
         </receiver>
         <receiver
+            android:name=".widget.onrepeat.OnRepeatWidgetReceiver"
+            android:exported="true"
+            android:label="@string/widget_on_repeat_label">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+            </intent-filter>
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/widget_on_repeat_info" />
+        </receiver>
+        <receiver
             android:name=".widget.downloads.DownloadsWidgetReceiver"
             android:exported="true"
             android:label="@string/widget_downloads_label">

--- a/app/src/main/assets/changelog/v2.2.5.txt
+++ b/app/src/main/assets/changelog/v2.2.5.txt
@@ -12,6 +12,12 @@ NEW FEATURES
 - Tell the music engine what you don't want: "Not interested" softens an artist for two weeks and "Don't recommend" blocks them everywhere, both reversible
 - The Flow Control Center now shows your music taste: top artists, listening rhythm, discovery appetite and blocked-artist management
 - Your music taste profile now syncs between devices and can be exported and imported as a file
+- New Rediscover shelf brings back loved artists you haven't played in weeks, and a time-of-day rotation shelf surfaces what you actually play at this hour — both rendered without a single network call
+- New "From artists you love" shelf collects the latest albums and singles from your top artists
+- Daily Mixes now open as full playlist pages you can play, shuffle and save to your library
+- Artist pages now show your own history with that artist — play count, liked status and your most-played tracks — and mark which "fans also like" artists are already in your rotation
+- New On Repeat home-screen widget puts the songs you keep replaying one tap away
+- The engine now learns genres and moods from what you play on genre rows and mood chips: mood chips reorder to match your habits and a Genres card appears in the Control Center
 - Serve every one of your interests in every home feed: your biggest interests are always present and your smaller ones rotate through the remaining slots, instead of the feed looping your top topic
 - Dig deeper as you scroll: each load of more videos descends one level further into every interest's branches, like walking a tree, instead of repeating the surface
 - Keep the feed going forever: when the usual sources thin out, loading more now digs fresh related-video lanes seeded from the videos on screen, your history, likes and playlists
@@ -22,6 +28,8 @@ NEW FEATURES
 IMPROVEMENTS
 - Music content now follows your chosen region setting instead of the device's locale
 - Music home caches invalidate when the region changes, so shelves refresh with the right content immediately
+- The Speed dial, Listen again, Recommended, music videos and long listens shelves are now ranked by your taste instead of arriving in YouTube's order
+- The music page now leads with what fits your journey: charts and moods while the engine is new, your own taste once it has matured
 - Stop showing you the same videos over and over: something you actually saw is filtered out of the next refreshes, briefly after one appearance and for days after repeats, and gently returns later
 - Pull-to-refresh now builds a genuinely fresh page instead of reshuffling what is already on screen
 - Cached reserve videos are consumed once served instead of reappearing for hours after every refresh

--- a/app/src/main/assets/changelog/v2.2.5.txt
+++ b/app/src/main/assets/changelog/v2.2.5.txt
@@ -18,6 +18,7 @@ NEW FEATURES
 - Artist pages now show your own history with that artist — play count, liked status and your most-played tracks — and mark which "fans also like" artists are already in your rotation
 - New On Repeat home-screen widget puts the songs you keep replaying one tap away
 - The engine now learns genres and moods from what you play on genre rows and mood chips: mood chips reorder to match your habits and a Genres card appears in the Control Center
+- The engine now keeps a private monthly listening ledger on your device — minutes listened, plays, discoveries and your listening clock — the foundation for an upcoming recap screen; it never leaves your device
 - Serve every one of your interests in every home feed: your biggest interests are always present and your smaller ones rotate through the remaining slots, instead of the feed looping your top topic
 - Dig deeper as you scroll: each load of more videos descends one level further into every interest's branches, like walking a tree, instead of repeating the surface
 - Keep the feed going forever: when the usual sources thin out, loading more now digs fresh related-video lanes seeded from the videos on screen, your history, likes and playlists
@@ -43,6 +44,7 @@ IMPROVEMENTS
 PERFORMANCE
 - Feed ranking noise now scales with your actual scores instead of drowning them when the feed was stale
 - Music shelves only recompose while the Music screen is visible and similar-song lanes are cached, so background listening no longer burns network and battery
+- Opening an artist, album or Daily Mix page no longer silently reloads the entire music home feed behind the scenes — one shared engine now serves every music page, cutting Daily Mix opens from up to 30 seconds to about a second and ending a major source of battery drain and device heat
 
 FIXES AND STABILITY
 - Fix all related-music fetching silently broken by a YouTube layout change, which had starved similar-music sections and flooded Quick Picks with regional charts

--- a/app/src/main/java/io/github/aedev/flow/data/recommendation/music/MusicBrainEngine.kt
+++ b/app/src/main/java/io/github/aedev/flow/data/recommendation/music/MusicBrainEngine.kt
@@ -48,6 +48,7 @@ class MusicBrainEngine
         }
 
         private val storage = MusicBrainStorage(appContext)
+        private val statsStorage = MusicStatsStorage(appContext)
         private val playerPreferences by lazy { PlayerPreferences(appContext) }
 
         private val mutex = Mutex()
@@ -55,6 +56,9 @@ class MusicBrainEngine
         private var pendingSaveJob: Job? = null
 
         private var brain = MusicBrain()
+
+        /** Monthly listening aggregates for the recap surfaces — device-local, never synced. */
+        private var ledger = MusicStatsLedger()
         private var isInitialized = false
 
         private val _hiddenArtists = kotlinx.coroutines.flow.MutableStateFlow<Set<String>>(emptySet())
@@ -82,6 +86,7 @@ class MusicBrainEngine
                 mutex.withLock {
                     if (isInitialized) return@withLock
                     brain = storage.load() ?: MusicBrain()
+                    ledger = statsStorage.load() ?: MusicStatsLedger()
                     if (!brain.backfilled) {
                         backfill.run(brain, System.currentTimeMillis())
                         brain.backfilled = true
@@ -103,14 +108,10 @@ class MusicBrainEngine
             track: MusicTrack,
             playedFraction: Double,
             genre: String? = null,
+            playedMs: Long = 0L,
         ) {
             if (track.videoId.isBlank() || track.videoId.startsWith(LOCAL_MEDIA_PREFIX)) return
             val pct = playedFraction.coerceIn(0.0, 1.0)
-            val crossed = MusicBrainLearn.newlyCrossed(0.0, pct)
-            if (crossed.isEmpty()) {
-                Log.d(TAG, "listen ${track.videoId} pct=$pct below first milestone")
-                return
-            }
             if (playerPreferences.isDeepFlowCurrentlyActive()) return
             ensureInitialized()
 
@@ -122,15 +123,36 @@ class MusicBrainEngine
                 Log.w(TAG, "listen ${track.videoId} has no artist key")
                 return
             }
+            // Sub-milestone sessions teach the brain nothing, but their listening
+            // time still belongs in the recap ledger's minutes.
+            val crossed = MusicBrainLearn.newlyCrossed(0.0, pct)
             val now = System.currentTimeMillis()
             mutex.withLock {
-                val coArtist =
-                    lastCounted
-                        ?.takeIf { now - it.second < MusicBrainParams.SESSION_GAP_MS && it.first != signal.artistKey }
-                        ?.first
-                val counted = MusicBrainLearn.applyMusicSignal(brain, signal, crossed, now, coArtist)
-                if (counted) lastCounted = signal.artistKey to now
-                Log.i(TAG, "listen ${track.videoId} pct=${"%.2f".format(pct)} counted=$counted artist=${signal.artistKey}")
+                val wasNewArtist = signal.artistKey !in brain.seenArtists
+                var counted = false
+                if (crossed.isNotEmpty()) {
+                    val coArtist =
+                        lastCounted
+                            ?.takeIf { now - it.second < MusicBrainParams.SESSION_GAP_MS && it.first != signal.artistKey }
+                            ?.first
+                    counted = MusicBrainLearn.applyMusicSignal(brain, signal, crossed, now, coArtist)
+                    if (counted) lastCounted = signal.artistKey to now
+                    Log.i(TAG, "listen ${track.videoId} pct=${"%.2f".format(pct)} counted=$counted artist=${signal.artistKey}")
+                } else {
+                    Log.d(TAG, "listen ${track.videoId} pct=$pct below first milestone")
+                }
+                MusicStatsLedgerOps.record(
+                    ledger,
+                    now,
+                    artistKey = signal.artistKey,
+                    artistName = signal.artistDisplay,
+                    trackId = signal.trackId,
+                    trackTitle = signal.title,
+                    genre = signal.genre,
+                    listenedMs = playedMs,
+                    counted = counted,
+                    newArtist = counted && wasNewArtist,
+                )
             }
             scheduleDebouncedSave()
         }
@@ -144,10 +166,11 @@ class MusicBrainEngine
             track: MusicTrack,
             playedFraction: Double,
             genre: String? = null,
+            playedMs: Long = 0L,
         ) {
             saveScope.launch {
                 try {
-                    onListenSession(track, playedFraction, genre)
+                    onListenSession(track, playedFraction, genre, playedMs)
                 } catch (e: Exception) {
                     Log.w(TAG, "Listen session failed: ${e.message}")
                 }
@@ -164,8 +187,23 @@ class MusicBrainEngine
             if (signal.artistKey.isEmpty()) return
             val now = System.currentTimeMillis()
             mutex.withLock {
+                val wasNewArtist = signal.artistKey !in brain.seenArtists
                 val counted = MusicBrainLearn.applyMusicSignal(brain, signal, emptyList(), now, coArtist = null)
-                if (counted) lastCounted = signal.artistKey to now
+                if (counted) {
+                    lastCounted = signal.artistKey to now
+                    MusicStatsLedgerOps.record(
+                        ledger,
+                        now,
+                        artistKey = signal.artistKey,
+                        artistName = signal.artistDisplay,
+                        trackId = signal.trackId,
+                        trackTitle = signal.title,
+                        genre = null,
+                        listenedMs = 0L,
+                        counted = true,
+                        newArtist = wasNewArtist,
+                    )
+                }
             }
             scheduleDebouncedSave()
         }
@@ -426,12 +464,21 @@ class MusicBrainEngine
             }
         }
 
+        /** Immutable snapshot of the listening ledger for the stats/recap surfaces. */
+        internal suspend fun listeningStats(): MusicStatsStorage.SerializableStats {
+            ensureInitialized()
+            return mutex.withLock { ledger.toSerializable() }
+        }
+
         private fun scheduleDebouncedSave() {
             pendingSaveJob?.cancel()
             pendingSaveJob =
                 saveScope.launch {
                     delay(SAVE_DEBOUNCE_MS)
-                    mutex.withLock { storage.save(brain) }
+                    mutex.withLock {
+                        storage.save(brain)
+                        statsStorage.save(ledger)
+                    }
                 }
         }
     }

--- a/app/src/main/java/io/github/aedev/flow/data/recommendation/music/MusicBrainEngine.kt
+++ b/app/src/main/java/io/github/aedev/flow/data/recommendation/music/MusicBrainEngine.kt
@@ -227,30 +227,46 @@ class MusicBrainEngine
         }
 
         /** On Repeat, rendered entirely from local meta — zero network. */
-        suspend fun heavyRotationTracks(limit: Int): List<MusicTrack> {
+        suspend fun heavyRotationTracks(limit: Int): List<MusicTrack> =
+            localShelf(limit) { now, cap -> MusicBrainRanker.heavyRotation(brain, now, cap) }
+
+        /** Loved-but-quiet artists' best tracks — zero network. */
+        suspend fun rediscoverTracks(limit: Int): List<MusicTrack> =
+            localShelf(limit) { now, cap -> MusicBrainRanker.rediscover(brain, now, cap) }
+
+        /** Tracks the user actually plays at this time of day — zero network. */
+        suspend fun timeOfDayTracks(limit: Int): List<MusicTrack> =
+            localShelf(limit) { now, cap -> MusicBrainRanker.timeOfDayRotation(brain, now, cap) }
+
+        private suspend fun localShelf(
+            limit: Int,
+            pick: (nowMs: Long, cap: Int) -> List<String>,
+        ): List<MusicTrack> {
             ensureInitialized()
             return mutex.withLock {
-                MusicBrainRanker
-                    .heavyRotation(brain, System.currentTimeMillis(), limit.coerceIn(1, 100))
-                    .mapNotNull { trackId ->
-                        val meta = brain.trackMeta[trackId] ?: return@mapNotNull null
-                        MusicTrack(
-                            videoId = trackId,
-                            title = meta.title,
-                            artist = meta.artist,
-                            thumbnailUrl = meta.thumbnail,
-                            duration = 0,
-                            channelId = if (isIdKeyedArtist(meta.artistKey)) meta.artistKey else "",
-                            artists =
-                                listOf(
-                                    MusicArtist(
-                                        name = meta.artist,
-                                        id = meta.artistKey.takeIf { isIdKeyedArtist(it) },
-                                    ),
-                                ),
-                        )
-                    }
+                pick(System.currentTimeMillis(), limit.coerceIn(1, 100))
+                    .mapNotNull { trackId -> trackFromMeta(trackId) }
             }
+        }
+
+        /** Must run with the mutex held. */
+        private fun trackFromMeta(trackId: String): MusicTrack? {
+            val meta = brain.trackMeta[trackId] ?: return null
+            return MusicTrack(
+                videoId = trackId,
+                title = meta.title,
+                artist = meta.artist,
+                thumbnailUrl = meta.thumbnail,
+                duration = 0,
+                channelId = if (isIdKeyedArtist(meta.artistKey)) meta.artistKey else "",
+                artists =
+                    listOf(
+                        MusicArtist(
+                            name = meta.artist,
+                            id = meta.artistKey.takeIf { isIdKeyedArtist(it) },
+                        ),
+                    ),
+            )
         }
 
         suspend fun dislikeArtist(

--- a/app/src/main/java/io/github/aedev/flow/data/recommendation/music/MusicBrainEngine.kt
+++ b/app/src/main/java/io/github/aedev/flow/data/recommendation/music/MusicBrainEngine.kt
@@ -102,6 +102,7 @@ class MusicBrainEngine
         suspend fun onListenSession(
             track: MusicTrack,
             playedFraction: Double,
+            genre: String? = null,
         ) {
             if (track.videoId.isBlank() || track.videoId.startsWith(LOCAL_MEDIA_PREFIX)) return
             val pct = playedFraction.coerceIn(0.0, 1.0)
@@ -113,7 +114,10 @@ class MusicBrainEngine
             if (playerPreferences.isDeepFlowCurrentlyActive()) return
             ensureInitialized()
 
-            val signal = track.toMusicSignal(pct)
+            val signal =
+                track
+                    .toMusicSignal(pct)
+                    .copy(genre = genre?.trim()?.lowercase()?.takeIf { it.isNotEmpty() })
             if (signal.artistKey.isEmpty()) {
                 Log.w(TAG, "listen ${track.videoId} has no artist key")
                 return
@@ -139,10 +143,11 @@ class MusicBrainEngine
         fun onListenSessionAsync(
             track: MusicTrack,
             playedFraction: Double,
+            genre: String? = null,
         ) {
             saveScope.launch {
                 try {
-                    onListenSession(track, playedFraction)
+                    onListenSession(track, playedFraction, genre)
                 } catch (e: Exception) {
                     Log.w(TAG, "Listen session failed: ${e.message}")
                 }
@@ -266,6 +271,12 @@ class MusicBrainEngine
                         .mapNotNull { trackFromMeta(it.first) }
                 MusicArtistInsights(plays = affinity.plays, liked = affinity.liked, topTracks = topTracks)
             }
+        }
+
+        /** Read-only copy of the learned genre/mood affinities (lowercased keys). */
+        suspend fun genreAffinitySnapshot(): Map<String, Double> {
+            ensureInitialized()
+            return mutex.withLock { HashMap(brain.genreAffinity) }
         }
 
         /** Every key form of every artist with counted plays — badge lookups on artist pages. */

--- a/app/src/main/java/io/github/aedev/flow/data/recommendation/music/MusicBrainEngine.kt
+++ b/app/src/main/java/io/github/aedev/flow/data/recommendation/music/MusicBrainEngine.kt
@@ -238,6 +238,50 @@ class MusicBrainEngine
         suspend fun timeOfDayTracks(limit: Int): List<MusicTrack> =
             localShelf(limit) { now, cap -> MusicBrainRanker.timeOfDayRotation(brain, now, cap) }
 
+        /**
+         * The brain's history with one artist, matched across both key forms.
+         * Null when the brain has never counted a play for them.
+         */
+        suspend fun artistInsights(
+            artistId: String?,
+            artistName: String,
+        ): MusicArtistInsights? {
+            ensureInitialized()
+            return mutex.withLock {
+                val keys =
+                    buildSet {
+                        add(musicArtistKey(artistId, artistName))
+                        artistName.trim().lowercase().takeIf { it.isNotEmpty() }?.let { add(it) }
+                    }
+                val affinity = keys.mapNotNull { brain.artistAffinity[it] }.maxByOrNull { it.plays }
+                if (affinity == null || affinity.plays <= 0) return@withLock null
+                val topTracks =
+                    brain.trackMeta.entries
+                        .filter { it.value.artistKey in keys }
+                        .mapNotNull { (id, _) ->
+                            brain.trackPlays[id]?.takeIf { it.isNotEmpty() }?.let { Triple(id, it.size, it.max()) }
+                        }.sortedWith(
+                            compareByDescending<Triple<String, Int, Long>> { it.second }.thenByDescending { it.third },
+                        ).take(10)
+                        .mapNotNull { trackFromMeta(it.first) }
+                MusicArtistInsights(plays = affinity.plays, liked = affinity.liked, topTracks = topTracks)
+            }
+        }
+
+        /** Every key form of every artist with counted plays — badge lookups on artist pages. */
+        suspend fun listenedArtistKeys(): Set<String> {
+            ensureInitialized()
+            return mutex.withLock {
+                val out = HashSet<String>()
+                for ((key, affinity) in brain.artistAffinity) {
+                    if (affinity.plays <= 0 || brain.isArtistBlocked(key)) continue
+                    out.add(key)
+                    affinity.display.takeIf { it.isNotBlank() }?.let { out.add(it.trim().lowercase()) }
+                }
+                out
+            }
+        }
+
         private suspend fun localShelf(
             limit: Int,
             pick: (nowMs: Long, cap: Int) -> List<String>,

--- a/app/src/main/java/io/github/aedev/flow/data/recommendation/music/MusicBrainEngine.kt
+++ b/app/src/main/java/io/github/aedev/flow/data/recommendation/music/MusicBrainEngine.kt
@@ -256,7 +256,11 @@ class MusicBrainEngine
                 val keys =
                     buildSet {
                         add(musicArtistKey(artistId, artistName))
-                        artistName.trim().lowercase().takeIf { it.isNotEmpty() }?.let { add(it) }
+                        artistName
+                            .trim()
+                            .lowercase()
+                            .takeIf { it.isNotEmpty() }
+                            ?.let { add(it) }
                     }
                 val affinity = keys.mapNotNull { brain.artistAffinity[it] }.maxByOrNull { it.plays }
                 if (affinity == null || affinity.plays <= 0) return@withLock null

--- a/app/src/main/java/io/github/aedev/flow/data/recommendation/music/MusicBrainModels.kt
+++ b/app/src/main/java/io/github/aedev/flow/data/recommendation/music/MusicBrainModels.kt
@@ -209,6 +209,12 @@ object MusicBrainParams {
     // Ranking
     const val ACT_DECAY = 0.5
     const val ACT_DT_FLOOR_HOURS = 0.05
+
+    // Local shelves (Rediscover / time-of-day rotation)
+    const val REDISCOVER_MIN_PLAYS = 3
+    const val REDISCOVER_MIN_SCORE = 0.25
+    const val REDISCOVER_STALE_MS = 21L * 24 * 60 * 60 * 1000
+    const val TIME_BUCKET_MIN_PLAYS = 2
     const val DISLIKE_COOLDOWN_MS = 14L * 24 * 60 * 60 * 1000
     const val DISLIKE_COOLDOWN_MULTIPLIER = 0.1
     const val MAX_CONSECUTIVE_ARTIST = 2

--- a/app/src/main/java/io/github/aedev/flow/data/recommendation/music/MusicBrainProfile.kt
+++ b/app/src/main/java/io/github/aedev/flow/data/recommendation/music/MusicBrainProfile.kt
@@ -6,6 +6,15 @@
 
 package io.github.aedev.flow.data.recommendation.music
 
+import io.github.aedev.flow.ui.screens.music.MusicTrack
+
+/** The brain's view of one artist, rendered on that artist's page. */
+data class MusicArtistInsights(
+    val plays: Int,
+    val liked: Boolean,
+    val topTracks: List<MusicTrack>,
+)
+
 data class MusicTopArtist(
     val key: String,
     val name: String,

--- a/app/src/main/java/io/github/aedev/flow/data/recommendation/music/MusicBrainRanker.kt
+++ b/app/src/main/java/io/github/aedev/flow/data/recommendation/music/MusicBrainRanker.kt
@@ -288,4 +288,75 @@ internal object MusicBrainRanker {
             .take(limit)
             .map { it.first }
             .toList()
+
+    /**
+     * Rediscover: one best track per loved-but-quiet artist — strong affinity,
+     * enough counted plays, and nothing played for [MusicBrainParams.REDISCOVER_STALE_MS].
+     * Ordered by affinity so the most-missed artist leads. Zero network.
+     */
+    fun rediscover(
+        brain: MusicBrain,
+        nowMs: Long,
+        limit: Int,
+    ): List<String> {
+        val staleBefore = nowMs - MusicBrainParams.REDISCOVER_STALE_MS
+
+        // One pass over the track library: the best-remembered track per artist
+        // (most ring entries, newest play breaks ties).
+        data class Best(val trackId: String, val plays: Int, val newest: Long)
+        val bestByArtist = HashMap<String, Best>()
+        for ((trackId, meta) in brain.trackMeta) {
+            val stamps = brain.trackPlays[trackId] ?: continue
+            if (stamps.isEmpty()) continue
+            val candidate = Best(trackId, stamps.size, stamps.max())
+            val current = bestByArtist[meta.artistKey]
+            if (current == null ||
+                candidate.plays > current.plays ||
+                (candidate.plays == current.plays && candidate.newest > current.newest)
+            ) {
+                bestByArtist[meta.artistKey] = candidate
+            }
+        }
+
+        return brain.artistAffinity.entries
+            .asSequence()
+            .filter { (key, aff) ->
+                aff.plays >= MusicBrainParams.REDISCOVER_MIN_PLAYS &&
+                    aff.score >= MusicBrainParams.REDISCOVER_MIN_SCORE &&
+                    aff.lastPlayed in 1 until staleBefore &&
+                    !brain.isArtistBlocked(key) &&
+                    !isInDislikeCooldown(brain, key, nowMs)
+            }.sortedByDescending { it.value.score }
+            .mapNotNull { (key, _) -> bestByArtist[key]?.trackId }
+            .take(limit)
+            .toList()
+    }
+
+    /**
+     * Time-of-day rotation: tracks the user actually plays in the CURRENT time
+     * bucket, ranked by in-bucket play count with activation as the tie-break.
+     * Bucket-conditional, so it complements (not duplicates) On Repeat. Zero network.
+     */
+    fun timeOfDayRotation(
+        brain: MusicBrain,
+        nowMs: Long,
+        limit: Int,
+    ): List<String> {
+        val bucket = MusicTimeBucket.fromTimestamp(nowMs)
+        return brain.trackPlays.entries
+            .asSequence()
+            .filter { (trackId, _) ->
+                val meta = brain.trackMeta[trackId]
+                meta == null ||
+                    (!brain.isArtistBlocked(meta.artistKey) && !isInDislikeCooldown(brain, meta.artistKey, nowMs))
+            }.map { (trackId, stamps) ->
+                Triple(trackId, stamps.count { MusicTimeBucket.fromTimestamp(it) == bucket }, stamps)
+            }.filter { it.second >= MusicBrainParams.TIME_BUCKET_MIN_PLAYS }
+            .sortedWith(
+                compareByDescending<Triple<String, Int, List<Long>>> { it.second }
+                    .thenByDescending { baseLevelActivation(brain, it.first, nowMs) },
+            ).take(limit)
+            .map { it.first }
+            .toList()
+    }
 }

--- a/app/src/main/java/io/github/aedev/flow/data/recommendation/music/MusicBrainRanker.kt
+++ b/app/src/main/java/io/github/aedev/flow/data/recommendation/music/MusicBrainRanker.kt
@@ -303,7 +303,11 @@ internal object MusicBrainRanker {
 
         // One pass over the track library: the best-remembered track per artist
         // (most ring entries, newest play breaks ties).
-        data class Best(val trackId: String, val plays: Int, val newest: Long)
+        data class Best(
+            val trackId: String,
+            val plays: Int,
+            val newest: Long,
+        )
         val bestByArtist = HashMap<String, Best>()
         for ((trackId, meta) in brain.trackMeta) {
             val stamps = brain.trackPlays[trackId] ?: continue

--- a/app/src/main/java/io/github/aedev/flow/data/recommendation/music/MusicListeningStats.kt
+++ b/app/src/main/java/io/github/aedev/flow/data/recommendation/music/MusicListeningStats.kt
@@ -1,0 +1,127 @@
+/*
+ * Copyright (C) 2025-2026 Flow | A-EDev
+ *
+ * This file is part of Flow (https://github.com/A-EDev/Flow).
+ */
+
+package io.github.aedev.flow.data.recommendation.music
+
+import java.util.Calendar
+
+/**
+ * Per-month listening aggregates — the data a Wrapped-style recap needs but the
+ * brain deliberately does not keep (rings hold only the 8 newest plays, affinity
+ * is all-time). Device-local, never synced, never part of the brain wire format.
+ *
+ * Display names are stored in-ledger on purpose: the brain prunes weak
+ * affinities and old track meta, and a December recap must still render a
+ * March artist by name.
+ */
+class MonthListening(
+    /** Counted plays: the ≥50% milestone or an explicit like. */
+    var plays: Int = 0,
+    /** Every session that produced any listening time, partial ones included. */
+    var sessions: Int = 0,
+    var listenedMs: Long = 0L,
+    val artistPlays: MutableMap<String, Int> = HashMap(),
+    val artistNames: MutableMap<String, String> = HashMap(),
+    val trackPlays: MutableMap<String, Int> = HashMap(),
+    val trackTitles: MutableMap<String, String> = HashMap(),
+    val genrePlays: MutableMap<String, Int> = HashMap(),
+    /** Artists whose first counted play ever happened this month. */
+    val discoveredArtists: MutableSet<String> = HashSet(),
+    /** Day of month (1..31) -> counted plays; feeds streaks and the calendar. */
+    val dayPlays: MutableMap<Int, Int> = HashMap(),
+    /** Hour of day (0..23) -> counted plays; feeds the listening clock. */
+    val hourPlays: MutableMap<Int, Int> = HashMap(),
+)
+
+class MusicStatsLedger {
+    val months: MutableMap<String, MonthListening> = HashMap()
+    var schemaVersion: Int = MusicStatsParams.SCHEMA_VERSION
+}
+
+object MusicStatsParams {
+    const val SCHEMA_VERSION = 1
+    const val MONTHS_MAX = 36
+    const val ARTISTS_PER_MONTH = 250
+    const val TRACKS_PER_MONTH = 300
+    const val GENRES_PER_MONTH = 50
+}
+
+/** Pure mutation functions, called under the engine mutex — no I/O, no Android. */
+object MusicStatsLedgerOps {
+    /** Calendar month key, local time: "2026-08". Sortable lexicographically. */
+    fun monthKey(nowMs: Long): String {
+        val cal = Calendar.getInstance().apply { timeInMillis = nowMs }
+        return "%04d-%02d".format(cal.get(Calendar.YEAR), cal.get(Calendar.MONTH) + 1)
+    }
+
+    fun record(
+        ledger: MusicStatsLedger,
+        nowMs: Long,
+        artistKey: String,
+        artistName: String,
+        trackId: String,
+        trackTitle: String,
+        genre: String?,
+        listenedMs: Long,
+        counted: Boolean,
+        newArtist: Boolean,
+    ) {
+        if (artistKey.isEmpty() || (listenedMs <= 0L && !counted)) return
+        val month = ledger.months.getOrPut(monthKey(nowMs)) { MonthListening() }
+        month.sessions += 1
+        month.listenedMs += listenedMs.coerceAtLeast(0L)
+        if (!counted) {
+            prune(ledger)
+            return
+        }
+
+        month.plays += 1
+        month.artistPlays[artistKey] = (month.artistPlays[artistKey] ?: 0) + 1
+        if (artistName.isNotBlank()) month.artistNames[artistKey] = artistName
+        month.trackPlays[trackId] = (month.trackPlays[trackId] ?: 0) + 1
+        if (trackTitle.isNotBlank()) month.trackTitles[trackId] = trackTitle
+        genre?.takeIf { it.isNotBlank() }?.let { month.genrePlays[it] = (month.genrePlays[it] ?: 0) + 1 }
+        if (newArtist) month.discoveredArtists.add(artistKey)
+
+        val cal = Calendar.getInstance().apply { timeInMillis = nowMs }
+        val day = cal.get(Calendar.DAY_OF_MONTH)
+        val hour = cal.get(Calendar.HOUR_OF_DAY)
+        month.dayPlays[day] = (month.dayPlays[day] ?: 0) + 1
+        month.hourPlays[hour] = (month.hourPlays[hour] ?: 0) + 1
+
+        prune(ledger)
+    }
+
+    fun prune(ledger: MusicStatsLedger) {
+        if (ledger.months.size > MusicStatsParams.MONTHS_MAX) {
+            ledger.months.keys
+                .sorted()
+                .take(ledger.months.size - MusicStatsParams.MONTHS_MAX)
+                .forEach { ledger.months.remove(it) }
+        }
+        for (month in ledger.months.values) {
+            capCounts(month.artistPlays, MusicStatsParams.ARTISTS_PER_MONTH, month.artistNames)
+            capCounts(month.trackPlays, MusicStatsParams.TRACKS_PER_MONTH, month.trackTitles)
+            capCounts(month.genrePlays, MusicStatsParams.GENRES_PER_MONTH, names = null)
+        }
+    }
+
+    private fun capCounts(
+        counts: MutableMap<String, Int>,
+        cap: Int,
+        names: MutableMap<String, String>?,
+    ) {
+        if (counts.size <= cap) return
+        counts.entries
+            .sortedBy { it.value }
+            .take(counts.size - cap)
+            .map { it.key }
+            .forEach { key ->
+                counts.remove(key)
+                names?.remove(key)
+            }
+    }
+}

--- a/app/src/main/java/io/github/aedev/flow/data/recommendation/music/MusicStatsStorage.kt
+++ b/app/src/main/java/io/github/aedev/flow/data/recommendation/music/MusicStatsStorage.kt
@@ -1,0 +1,152 @@
+/*
+ * Copyright (C) 2025-2026 Flow | A-EDev
+ *
+ * This file is part of Flow (https://github.com/A-EDev/Flow).
+ */
+
+package io.github.aedev.flow.data.recommendation.music
+
+import android.content.Context
+import android.util.Log
+import androidx.datastore.core.CorruptionException
+import androidx.datastore.core.DataStore
+import androidx.datastore.core.Serializer
+import androidx.datastore.dataStore
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.Json
+import java.io.InputStream
+import java.io.OutputStream
+
+/**
+ * Persistence for the listening ledger — same typed-DataStore JSON pattern as
+ * [MusicBrainStorage], its own file so brain saves and stats saves stay cheap
+ * and the brain's sync wire format is untouched.
+ */
+internal class MusicStatsStorage(
+    private val appContext: Context,
+) {
+    companion object {
+        private const val TAG = "MusicStatsStorage"
+        private const val FILE_NAME = "flow_music_stats_v1.json"
+
+        private val json = Json { ignoreUnknownKeys = true }
+    }
+
+    @Serializable
+    data class SerializableMonth(
+        val plays: Int = 0,
+        val sessions: Int = 0,
+        val listenedMs: Long = 0L,
+        val artistPlays: Map<String, Int> = emptyMap(),
+        val artistNames: Map<String, String> = emptyMap(),
+        val trackPlays: Map<String, Int> = emptyMap(),
+        val trackTitles: Map<String, String> = emptyMap(),
+        val genrePlays: Map<String, Int> = emptyMap(),
+        val discoveredArtists: List<String> = emptyList(),
+        val dayPlays: Map<Int, Int> = emptyMap(),
+        val hourPlays: Map<Int, Int> = emptyMap(),
+    )
+
+    @Serializable
+    data class SerializableStats(
+        val schemaVersion: Int = MusicStatsParams.SCHEMA_VERSION,
+        val months: Map<String, SerializableMonth> = emptyMap(),
+    )
+
+    private object StatsSerializer : Serializer<SerializableStats> {
+        override val defaultValue: SerializableStats = SerializableStats()
+
+        override suspend fun readFrom(input: InputStream): SerializableStats =
+            try {
+                val text = input.readBytes().decodeToString()
+                if (text.isBlank()) defaultValue else json.decodeFromString(text)
+            } catch (e: SerializationException) {
+                throw CorruptionException("Corrupted music stats", e)
+            } catch (e: Exception) {
+                Log.w(TAG, "Failed to read music stats, starting empty: ${e.message}")
+                defaultValue
+            }
+
+        override suspend fun writeTo(
+            t: SerializableStats,
+            output: OutputStream,
+        ) {
+            output.write(json.encodeToString(SerializableStats.serializer(), t).encodeToByteArray())
+        }
+    }
+
+    private val Context.musicStatsDataStore: DataStore<SerializableStats> by dataStore(
+        fileName = FILE_NAME,
+        serializer = StatsSerializer,
+        corruptionHandler =
+            androidx.datastore.core.handlers
+                .ReplaceFileCorruptionHandler { SerializableStats() },
+    )
+
+    suspend fun save(ledger: MusicStatsLedger) =
+        withContext(Dispatchers.IO) {
+            try {
+                appContext.musicStatsDataStore.updateData { ledger.toSerializable() }
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to persist music stats", e)
+            }
+        }
+
+    suspend fun load(): MusicStatsLedger? =
+        withContext(Dispatchers.IO) {
+            try {
+                val stored = appContext.musicStatsDataStore.data.first()
+                if (stored.months.isEmpty()) null else stored.toLedger()
+            } catch (e: Exception) {
+                Log.e(TAG, "Failed to load music stats", e)
+                null
+            }
+        }
+}
+
+internal fun MusicStatsLedger.toSerializable(): MusicStatsStorage.SerializableStats =
+    MusicStatsStorage.SerializableStats(
+        schemaVersion = schemaVersion,
+        months =
+            months.mapValues { (_, m) ->
+                MusicStatsStorage.SerializableMonth(
+                    plays = m.plays,
+                    sessions = m.sessions,
+                    listenedMs = m.listenedMs,
+                    artistPlays = m.artistPlays.toMap(),
+                    artistNames = m.artistNames.toMap(),
+                    trackPlays = m.trackPlays.toMap(),
+                    trackTitles = m.trackTitles.toMap(),
+                    genrePlays = m.genrePlays.toMap(),
+                    discoveredArtists = m.discoveredArtists.toList(),
+                    dayPlays = m.dayPlays.toMap(),
+                    hourPlays = m.hourPlays.toMap(),
+                )
+            },
+    )
+
+internal fun MusicStatsStorage.SerializableStats.toLedger(): MusicStatsLedger {
+    val ledger = MusicStatsLedger()
+    ledger.schemaVersion = schemaVersion
+    for ((key, m) in months) {
+        ledger.months[key] =
+            MonthListening(
+                plays = m.plays,
+                sessions = m.sessions,
+                listenedMs = m.listenedMs,
+                artistPlays = HashMap(m.artistPlays),
+                artistNames = HashMap(m.artistNames),
+                trackPlays = HashMap(m.trackPlays),
+                trackTitles = HashMap(m.trackTitles),
+                genrePlays = HashMap(m.genrePlays),
+                discoveredArtists = HashSet(m.discoveredArtists),
+                dayPlays = HashMap(m.dayPlays),
+                hourPlays = HashMap(m.hourPlays),
+            )
+    }
+    return ledger
+}

--- a/app/src/main/java/io/github/aedev/flow/player/EnhancedMusicPlayerManager.kt
+++ b/app/src/main/java/io/github/aedev/flow/player/EnhancedMusicPlayerManager.kt
@@ -44,6 +44,15 @@ import kotlin.math.pow
 object EnhancedMusicPlayerManager {
     var player: Player? = null
         private set
+
+    /**
+     * Genre/mood of the surface the current queue was started from, or null for
+     * unscoped queues. Stamped into listen signals by the music service so the
+     * brain learns time-of-day × genre context.
+     */
+    @Volatile
+    var playContextGenre: String? = null
+
     private var appContext: Context? = null
 
     private val _playerInstance = MutableStateFlow<Player?>(null)
@@ -1017,6 +1026,7 @@ object EnhancedMusicPlayerManager {
             _currentTrack.value = null
             _queue.value = emptyList()
             _automixItems.value = emptyList()
+            playContextGenre = null
             _currentQueueIndex.value = 0
             clearPendingPlayNext()
             _currentPosition.value = 0L

--- a/app/src/main/java/io/github/aedev/flow/service/Media3MusicService.kt
+++ b/app/src/main/java/io/github/aedev/flow/service/Media3MusicService.kt
@@ -455,6 +455,7 @@ class Media3MusicService : MediaLibraryService() {
 
     private var learnMediaId: String? = null
     private var learnTrack: io.github.aedev.flow.ui.screens.music.MusicTrack? = null
+    private var learnGenre: String? = null
     private var learnDurationMs = 0L
     private var learnPlayedMs = 0L
     private var learnPlayingSinceMs = -1L
@@ -488,6 +489,10 @@ class Media3MusicService : MediaLibraryService() {
         // Pin the track now: by finalize time a new playlist may have replaced the
         // queue and the outgoing track would no longer resolve.
         learnTrack = resolveLearnTrack(mediaId)
+        // Pin the genre context too — it belongs to the queue this track started in.
+        learnGenre =
+            io.github.aedev.flow.player.EnhancedMusicPlayerManager
+                .playContextGenre
         learnDurationMs = 0L
         learnPlayedMs = 0L
         learnPlayingSinceMs =
@@ -501,8 +506,10 @@ class Media3MusicService : MediaLibraryService() {
         val pinnedTrack = learnTrack
         val pinnedDurationMs = learnDurationMs
         val playedMs = learnPlayedMs
+        val pinnedGenre = learnGenre
         learnMediaId = null
         learnTrack = null
+        learnGenre = null
         learnDurationMs = 0L
         learnPlayedMs = 0L
         if (mediaId.isNullOrBlank() || playedMs <= 0) {
@@ -524,7 +531,7 @@ class Media3MusicService : MediaLibraryService() {
         Log.d(TAG, "listen finalize: $mediaId playedMs=$playedMs pct=${playedMs.toDouble() / durationMs}")
         // Engine-scoped, NOT lifecycleScope: the finalize from onDestroy runs after
         // this service's scope is already cancelled, and the session must still land.
-        musicBrain.onListenSessionAsync(track, playedMs.toDouble() / durationMs)
+        musicBrain.onListenSessionAsync(track, playedMs.toDouble() / durationMs, pinnedGenre)
     }
 
     /**

--- a/app/src/main/java/io/github/aedev/flow/service/Media3MusicService.kt
+++ b/app/src/main/java/io/github/aedev/flow/service/Media3MusicService.kt
@@ -531,7 +531,7 @@ class Media3MusicService : MediaLibraryService() {
         Log.d(TAG, "listen finalize: $mediaId playedMs=$playedMs pct=${playedMs.toDouble() / durationMs}")
         // Engine-scoped, NOT lifecycleScope: the finalize from onDestroy runs after
         // this service's scope is already cancelled, and the session must still land.
-        musicBrain.onListenSessionAsync(track, playedMs.toDouble() / durationMs, pinnedGenre)
+        musicBrain.onListenSessionAsync(track, playedMs.toDouble() / durationMs, pinnedGenre, playedMs)
     }
 
     /**

--- a/app/src/main/java/io/github/aedev/flow/ui/FlowNavigation.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/FlowNavigation.kt
@@ -1229,6 +1229,8 @@ fun NavGraphBuilder.flowAppGraph(
             if (playlistId.startsWith("community_")) {
                 val genre = playlistId.substringAfter("community_")
                 musicViewModel.loadCommunityPlaylist(genre)
+            } else if (playlistId.startsWith(MusicViewModel.DAILY_MIX_ID_PREFIX)) {
+                musicViewModel.loadDailyMixPage(playlistId)
             } else {
                 musicViewModel.fetchPlaylistDetails(playlistId)
             }

--- a/app/src/main/java/io/github/aedev/flow/ui/FlowNavigation.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/FlowNavigation.kt
@@ -1133,6 +1133,8 @@ fun NavGraphBuilder.flowAppGraph(
                 ArtistPage(
                     artistDetails = details,
                     downloadedTrackIds = uiState.downloadedTrackIds,
+                    insights = uiState.artistInsights,
+                    knownRelatedArtistIds = uiState.knownRelatedArtistIds,
                     onBackClick = { navController.popBackStack() },
                     onTrackClick = { track, queue ->
                         musicPlayerViewModel.loadAndPlayTrack(track, queue)

--- a/app/src/main/java/io/github/aedev/flow/ui/FlowNavigation.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/FlowNavigation.kt
@@ -1116,7 +1116,9 @@ fun NavGraphBuilder.flowAppGraph(
     // Artist Page
     composable("artist/{channelId}") { backStackEntry ->
         val channelId = backStackEntry.arguments?.getString("channelId") ?: return@composable
-        val musicViewModel: MusicViewModel = hiltViewModel()
+        val musicViewModel: MusicViewModel =
+            io.github.aedev.flow.ui.screens.music
+                .sharedMusicViewModel()
         val musicPlayerViewModel: MusicPlayerViewModel = hiltViewModel()
         val uiState by musicViewModel.uiState.collectAsState()
 
@@ -1181,7 +1183,9 @@ fun NavGraphBuilder.flowAppGraph(
         val params = backStackEntry.arguments?.getString("params")
         // channelId is available if needed contextually
 
-        val musicViewModel: MusicViewModel = hiltViewModel()
+        val musicViewModel: MusicViewModel =
+            io.github.aedev.flow.ui.screens.music
+                .sharedMusicViewModel()
         val musicPlayerViewModel: MusicPlayerViewModel = hiltViewModel()
 
         io.github.aedev.flow.ui.screens.music.ArtistItemsScreen(
@@ -1219,7 +1223,9 @@ fun NavGraphBuilder.flowAppGraph(
     // Music Playlist Page
     composable("musicPlaylist/{playlistId}") { backStackEntry ->
         val playlistId = backStackEntry.arguments?.getString("playlistId") ?: return@composable
-        val musicViewModel: MusicViewModel = hiltViewModel()
+        val musicViewModel: MusicViewModel =
+            io.github.aedev.flow.ui.screens.music
+                .sharedMusicViewModel()
         val musicPlayerViewModel: MusicPlayerViewModel = hiltViewModel()
         val musicPlaylistsViewModel: io.github.aedev.flow.ui.screens.music.MusicPlaylistsViewModel = hiltViewModel()
         val uiState by musicViewModel.uiState.collectAsState()

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/music/ArtistItemsScreen.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/music/ArtistItemsScreen.kt
@@ -50,7 +50,7 @@ fun ArtistItemsScreen(
     onAlbumClick: (String) -> Unit,
     onArtistClick: (String) -> Unit,
     onPlaylistClick: (String) -> Unit,
-    viewModel: MusicViewModel = hiltViewModel(),
+    viewModel: MusicViewModel = sharedMusicViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsState()
     val artistItemsPage = uiState.artistItemsPage

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/music/ArtistPage.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/music/ArtistPage.kt
@@ -59,6 +59,8 @@ import io.github.aedev.flow.ui.screens.music.components.TrackListItem
 fun ArtistPage(
     artistDetails: ArtistDetails,
     downloadedTrackIds: Set<String> = emptySet(),
+    insights: io.github.aedev.flow.data.recommendation.music.MusicArtistInsights? = null,
+    knownRelatedArtistIds: Set<String> = emptySet(),
     onBackClick: () -> Unit,
     onTrackClick: (MusicTrack, List<MusicTrack>) -> Unit,
     onAlbumClick: (MusicPlaylist) -> Unit,
@@ -444,6 +446,50 @@ fun ArtistPage(
                     }
                 }
 
+                // Your history — the local brain's record of this artist, zero network
+                if (insights != null && insights.topTracks.isNotEmpty()) {
+                    item {
+                        SectionHeader(title = stringResource(R.string.section_your_history))
+                        Text(
+                            text =
+                                buildString {
+                                    append(stringResource(R.string.artist_insights_played_times, insights.plays))
+                                    if (insights.liked) {
+                                        append(" · ")
+                                        append(stringResource(R.string.artist_insights_liked))
+                                    }
+                                },
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            modifier = Modifier.padding(horizontal = 24.dp),
+                        )
+                    }
+                    itemsIndexed(insights.topTracks.take(5)) { index, track ->
+                        TrackListItem(
+                            track = track,
+                            isDownloaded = downloadedTrackIds.contains(track.videoId),
+                            leadingContent = {
+                                Text(
+                                    text = (index + 1).toString(),
+                                    style = MaterialTheme.typography.bodyMedium,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    modifier = Modifier.width(32.dp),
+                                    textAlign = androidx.compose.ui.text.style.TextAlign.Center,
+                                )
+                            },
+                            onClick = { onTrackClick(track, insights.topTracks) },
+                            onLongClick = {
+                                selectedTrack = track
+                                showBottomSheet = true
+                            },
+                            onMenuClick = {
+                                selectedTrack = track
+                                showBottomSheet = true
+                            },
+                        )
+                    }
+                }
+
                 // Singles & EPs
                 if (artistDetails.singles.isNotEmpty()) {
                     item {
@@ -538,6 +584,9 @@ fun ArtistPage(
                             items(artistDetails.relatedArtists) { artist ->
                                 RelatedArtistCard(
                                     artist = artist,
+                                    badge =
+                                        stringResource(R.string.artist_known_related_badge)
+                                            .takeIf { artist.channelId in knownRelatedArtistIds },
                                     onClick = { onArtistClick(artist.channelId) },
                                 )
                             }
@@ -708,6 +757,7 @@ fun VideoCard(
 fun RelatedArtistCard(
     artist: ArtistDetails,
     onClick: () -> Unit,
+    badge: String? = null,
 ) {
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
@@ -733,5 +783,15 @@ fun RelatedArtistCard(
             overflow = TextOverflow.Ellipsis,
             textAlign = androidx.compose.ui.text.style.TextAlign.Center,
         )
+        if (badge != null) {
+            Text(
+                text = badge,
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.primary,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                textAlign = androidx.compose.ui.text.style.TextAlign.Center,
+            )
+        }
     }
 }

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/music/EnhancedMusicScreen.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/music/EnhancedMusicScreen.kt
@@ -65,15 +65,34 @@ fun EnhancedMusicScreen(
     val musicListState = rememberLazyListState()
     val quickPicksGridState = rememberLazyGridState()
 
+    // Planner-lite: the brain's maturity decides which sections lead the page —
+    // a cold brain has nothing personal to say, a mature one leads with taste.
     val sectionOrder =
-        remember(uiState.sessionSeed) {
+        remember(uiState.sessionSeed, uiState.brainMaturity) {
             val defaultOrder = HomeSectionType.values().toList()
             val anchored =
-                listOf(
-                    HomeSectionType.QUICK_PICKS,
-                    HomeSectionType.FROM_COMMUNITY,
-                    HomeSectionType.DAILY_DISCOVER,
-                )
+                when (uiState.brainMaturity) {
+                    "cold_start" ->
+                        listOf(
+                            HomeSectionType.CHARTS,
+                            HomeSectionType.MOODS_AND_GENRES,
+                            HomeSectionType.NEW_RELEASES,
+                        )
+
+                    "mature" ->
+                        listOf(
+                            HomeSectionType.QUICK_PICKS,
+                            HomeSectionType.SIMILAR_TO,
+                            HomeSectionType.FROM_COMMUNITY,
+                        )
+
+                    else ->
+                        listOf(
+                            HomeSectionType.QUICK_PICKS,
+                            HomeSectionType.FROM_COMMUNITY,
+                            HomeSectionType.DAILY_DISCOVER,
+                        )
+                }
             val dynamicPool = defaultOrder - anchored
             anchored + dynamicPool.shuffled(java.util.Random(uiState.sessionSeed))
         }

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/music/EnhancedMusicScreen.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/music/EnhancedMusicScreen.kt
@@ -57,7 +57,7 @@ fun EnhancedMusicScreen(
     onRecognizeClick: () -> Unit = {},
     onAlbumClick: (String) -> Unit = {},
     onMoodsClick: (io.github.aedev.flow.innertube.pages.MoodAndGenres.Item?) -> Unit = {},
-    viewModel: MusicViewModel = hiltViewModel(),
+    viewModel: MusicViewModel = sharedMusicViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsState()
     val context = LocalContext.current

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/music/EnhancedMusicScreen.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/music/EnhancedMusicScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import io.github.aedev.flow.R
+import io.github.aedev.flow.data.recommendation.music.MusicTimeBucket
 import io.github.aedev.flow.player.EnhancedMusicPlayerManager
 import io.github.aedev.flow.ui.TabScrollEventBus
 import io.github.aedev.flow.ui.components.*
@@ -283,25 +284,28 @@ fun EnhancedMusicScreen(
                                     }
                                 }
                             } else {
-                                // On Repeat — the local music brain's relistening shelf, zero network
+                                // The local-brain cluster: On Repeat, the time-of-day
+                                // rotation and Rediscover render from stored meta only.
                                 if (uiState.onRepeatTracks.isNotEmpty()) {
                                     item {
-                                        NavigationTitle(title = stringResource(R.string.section_on_repeat))
-                                        val onRepeatThumbnailHeight = currentGridThumbnailHeight()
-                                        LazyRow(
-                                            contentPadding = PaddingValues(horizontal = 12.dp),
-                                            horizontalArrangement = Arrangement.spacedBy(12.dp),
-                                        ) {
-                                            items(uiState.onRepeatTracks, key = { it.videoId }) { track ->
-                                                GridItem(
-                                                    title = track.title,
-                                                    subtitle = track.artist,
-                                                    thumbnailUrl = track.thumbnailUrl,
-                                                    thumbnailHeight = onRepeatThumbnailHeight,
-                                                    onClick = { onSongClick(track, uiState.onRepeatTracks, "on_repeat") },
-                                                )
-                                            }
-                                        }
+                                        LocalBrainShelf(
+                                            title = stringResource(R.string.section_on_repeat),
+                                            tracks = uiState.onRepeatTracks,
+                                            playFrom = "on_repeat",
+                                            onSongClick = onSongClick,
+                                        )
+                                    }
+                                }
+
+                                val rotationBucket = uiState.rotationBucket
+                                if (uiState.rotationTracks.isNotEmpty() && rotationBucket != null) {
+                                    item {
+                                        LocalBrainShelf(
+                                            title = stringResource(rotationTitleRes(rotationBucket)),
+                                            tracks = uiState.rotationTracks,
+                                            playFrom = "rotation",
+                                            onSongClick = onSongClick,
+                                        )
                                     }
                                 }
 
@@ -315,6 +319,17 @@ fun EnhancedMusicScreen(
                                                 selectedTrack = track
                                                 showBottomSheet = true
                                             },
+                                        )
+                                    }
+                                }
+
+                                if (uiState.rediscoverTracks.isNotEmpty()) {
+                                    item {
+                                        LocalBrainShelf(
+                                            title = stringResource(R.string.section_rediscover),
+                                            tracks = uiState.rediscoverTracks,
+                                            playFrom = "rediscover",
+                                            onSongClick = onSongClick,
                                         )
                                     }
                                 }
@@ -957,3 +972,37 @@ private fun quickPicksPlayAllAction(
     val first = tracks.firstOrNull() ?: return null
     return { onSongClick(first, tracks, "quick_picks") }
 }
+
+/** Shared renderer for the zero-network brain shelves (On Repeat, rotation, Rediscover). */
+@Composable
+private fun LocalBrainShelf(
+    title: String,
+    tracks: List<MusicTrack>,
+    playFrom: String,
+    onSongClick: (MusicTrack, List<MusicTrack>, String?) -> Unit,
+) {
+    NavigationTitle(title = title)
+    val thumbnailHeight = currentGridThumbnailHeight()
+    LazyRow(
+        contentPadding = PaddingValues(horizontal = 12.dp),
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        items(tracks, key = { it.videoId }) { track ->
+            GridItem(
+                title = track.title,
+                subtitle = track.artist,
+                thumbnailUrl = track.thumbnailUrl,
+                thumbnailHeight = thumbnailHeight,
+                onClick = { onSongClick(track, tracks, playFrom) },
+            )
+        }
+    }
+}
+
+private fun rotationTitleRes(bucket: MusicTimeBucket): Int =
+    when (bucket) {
+        MusicTimeBucket.WEEKDAY_MORNING, MusicTimeBucket.WEEKEND_MORNING -> R.string.section_rotation_morning
+        MusicTimeBucket.WEEKDAY_AFTERNOON, MusicTimeBucket.WEEKEND_AFTERNOON -> R.string.section_rotation_afternoon
+        MusicTimeBucket.WEEKDAY_EVENING, MusicTimeBucket.WEEKEND_EVENING -> R.string.section_rotation_evening
+        MusicTimeBucket.WEEKDAY_NIGHT, MusicTimeBucket.WEEKEND_NIGHT -> R.string.section_rotation_night
+    }

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/music/EnhancedMusicScreen.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/music/EnhancedMusicScreen.kt
@@ -730,6 +730,32 @@ fun EnhancedMusicScreen(
                                             }
                                         }
 
+                                        HomeSectionType.FAVORITE_ARTIST_ALBUMS -> {
+                                            if (uiState.favoriteArtistAlbums.isNotEmpty()) {
+                                                item {
+                                                    SectionTitle(title = stringResource(R.string.section_from_artists_you_love))
+                                                    val favoriteAlbumThumbnailHeight = currentGridThumbnailHeight()
+                                                    LazyRow(
+                                                        contentPadding = PaddingValues(horizontal = 12.dp),
+                                                        horizontalArrangement = Arrangement.spacedBy(12.dp),
+                                                    ) {
+                                                        items(uiState.favoriteArtistAlbums, key = { it.id }) { album ->
+                                                            GridItem(
+                                                                title = album.title,
+                                                                subtitle = album.author,
+                                                                thumbnailUrl = album.thumbnailUrl,
+                                                                thumbnailHeight = favoriteAlbumThumbnailHeight,
+                                                                onClick = { onAlbumClick(album.id) },
+                                                                onLongClick = {
+                                                                    selectedCollection = album.toCollectionActionItem(isAlbum = true)
+                                                                },
+                                                            )
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+
                                         HomeSectionType.NEW_RELEASES -> {
                                             if (uiState.newReleases.isNotEmpty()) {
                                                 item {

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/music/EnhancedMusicScreen.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/music/EnhancedMusicScreen.kt
@@ -498,7 +498,8 @@ fun EnhancedMusicScreen(
                                                                     {
                                                                         if (section.isArtistSeed) {
                                                                             onArtistClick(section.seedId)
-                                                                        } else {
+                                                                        } else if (section.seedId.startsWith(MusicViewModel.DAILY_MIX_ID_PREFIX)) {
+                                                                            onAlbumClick(section.seedId)
                                                                         }
                                                                     }
                                                                 } else {

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/music/EnhancedMusicScreen.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/music/EnhancedMusicScreen.kt
@@ -72,26 +72,29 @@ fun EnhancedMusicScreen(
             val defaultOrder = HomeSectionType.values().toList()
             val anchored =
                 when (uiState.brainMaturity) {
-                    "cold_start" ->
+                    "cold_start" -> {
                         listOf(
                             HomeSectionType.CHARTS,
                             HomeSectionType.MOODS_AND_GENRES,
                             HomeSectionType.NEW_RELEASES,
                         )
+                    }
 
-                    "mature" ->
+                    "mature" -> {
                         listOf(
                             HomeSectionType.QUICK_PICKS,
                             HomeSectionType.SIMILAR_TO,
                             HomeSectionType.FROM_COMMUNITY,
                         )
+                    }
 
-                    else ->
+                    else -> {
                         listOf(
                             HomeSectionType.QUICK_PICKS,
                             HomeSectionType.FROM_COMMUNITY,
                             HomeSectionType.DAILY_DISCOVER,
                         )
+                    }
                 }
             val dynamicPool = defaultOrder - anchored
             anchored + dynamicPool.shuffled(java.util.Random(uiState.sessionSeed))
@@ -517,7 +520,10 @@ fun EnhancedMusicScreen(
                                                                     {
                                                                         if (section.isArtistSeed) {
                                                                             onArtistClick(section.seedId)
-                                                                        } else if (section.seedId.startsWith(MusicViewModel.DAILY_MIX_ID_PREFIX)) {
+                                                                        } else if (section.seedId.startsWith(
+                                                                                MusicViewModel.DAILY_MIX_ID_PREFIX,
+                                                                            )
+                                                                        ) {
                                                                             onAlbumClick(section.seedId)
                                                                         }
                                                                     }
@@ -693,18 +699,22 @@ fun EnhancedMusicScreen(
                                                                         when (track.itemType) {
                                                                             MusicItemType.ALBUM,
                                                                             MusicItemType.PLAYLIST,
-                                                                            -> onAlbumClick(track.videoId)
+                                                                            -> {
+                                                                                onAlbumClick(track.videoId)
+                                                                            }
 
                                                                             // Under a mood chip every section is that
                                                                             // mood's content — tag plays with it.
-                                                                            else ->
+                                                                            else -> {
                                                                                 onSongClick(
                                                                                     track,
                                                                                     section.tracks,
-                                                                                    uiState.selectedHomeChip?.title
+                                                                                    uiState.selectedHomeChip
+                                                                                        ?.title
                                                                                         ?.let { MUSIC_GENRE_SOURCE_PREFIX + it }
                                                                                         ?: section.title,
                                                                                 )
+                                                                            }
                                                                         }
                                                                     },
                                                                     onLongClick = {

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/music/EnhancedMusicScreen.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/music/EnhancedMusicScreen.kt
@@ -633,7 +633,7 @@ fun EnhancedMusicScreen(
                                                                 thumbnailUrl = track.thumbnailUrl,
                                                                 thumbnailHeight = genreThumbnailHeight,
                                                                 isDownloaded = uiState.downloadedTrackIds.contains(track.videoId),
-                                                                onClick = { onSongClick(track, tracks, genre) },
+                                                                onClick = { onSongClick(track, tracks, MUSIC_GENRE_SOURCE_PREFIX + genre) },
                                                                 onLongClick = {
                                                                     selectedTrack = track
                                                                     showBottomSheet = true
@@ -676,7 +676,16 @@ fun EnhancedMusicScreen(
                                                                             MusicItemType.PLAYLIST,
                                                                             -> onAlbumClick(track.videoId)
 
-                                                                            else -> onSongClick(track, section.tracks, section.title)
+                                                                            // Under a mood chip every section is that
+                                                                            // mood's content — tag plays with it.
+                                                                            else ->
+                                                                                onSongClick(
+                                                                                    track,
+                                                                                    section.tracks,
+                                                                                    uiState.selectedHomeChip?.title
+                                                                                        ?.let { MUSIC_GENRE_SOURCE_PREFIX + it }
+                                                                                        ?: section.title,
+                                                                                )
                                                                         }
                                                                     },
                                                                     onLongClick = {

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/music/EnhancedMusicScreen.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/music/EnhancedMusicScreen.kt
@@ -177,12 +177,15 @@ fun EnhancedMusicScreen(
                                 .take(10)
                         }
 
-                    val speedDialTracks =
+                    // Raw concatenation is only the placeholder until the VM's
+                    // brain-ranked speed dial lands.
+                    val fallbackSpeedDial =
                         remember(uiState.history, uiState.forYouTracks, uiState.listenAgain) {
                             (uiState.history + uiState.forYouTracks + uiState.listenAgain)
                                 .audioMusicOnly()
                                 .take(26)
                         }
+                    val speedDialTracks = uiState.speedDialTracks.ifEmpty { fallbackSpeedDial }
                     val quickPickTracks =
                         remember(uiState.forYouTracks) {
                             uiState.forYouTracks.audioMusicOnly().take(20)

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/music/MusicModels.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/music/MusicModels.kt
@@ -5,6 +5,13 @@ import kotlinx.serialization.Serializable
 
 enum class MusicItemType { SONG, ALBUM, PLAYLIST, ARTIST }
 
+/**
+ * Play-source prefix marking a genre/mood-scoped surface (genre rows, mood
+ * chips). The player strips it for the "Playing from" label and hands the genre
+ * to the music brain as listen-context provenance.
+ */
+const val MUSIC_GENRE_SOURCE_PREFIX = "genre:"
+
 @Serializable
 data class MusicTrack(
     val videoId: String,

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/music/MusicPlayerViewModel.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/music/MusicPlayerViewModel.kt
@@ -263,9 +263,21 @@ class MusicPlayerViewModel
             sourceName: String? = null,
         ) {
             loadTrackJob?.cancel()
+            // Genre-scoped surfaces tag their source; the genre becomes listen
+            // context for this queue and is stripped from the display label.
+            // Any non-tagged queue start clears the previous context.
+            val contextGenre =
+                sourceName
+                    ?.trim()
+                    ?.takeIf { it.startsWith(MUSIC_GENRE_SOURCE_PREFIX) }
+                    ?.removePrefix(MUSIC_GENRE_SOURCE_PREFIX)
+                    ?.trim()
+                    ?.takeIf { it.isNotEmpty() }
+            EnhancedMusicPlayerManager.playContextGenre = contextGenre
+            val displaySourceName = contextGenre ?: sourceName
             loadTrackJob =
                 viewModelScope.launch {
-                    val finalSourceName = resolveSourceName(sourceName, track)
+                    val finalSourceName = resolveSourceName(displaySourceName, track)
                     val activeQueue = if (queue.isNotEmpty()) queue else listOf(track)
                     val localUriOverrides =
                         withContext(PerformanceDispatcher.diskIO) {
@@ -351,6 +363,8 @@ class MusicPlayerViewModel
                 when (key) {
                     "listen_again" -> context.getString(R.string.section_listen_again)
                     "on_repeat" -> context.getString(R.string.section_on_repeat)
+                    "rotation" -> context.getString(R.string.source_your_rotation)
+                    "rediscover" -> context.getString(R.string.section_rediscover)
                     "daily_discover" -> context.getString(R.string.section_daily_discover)
                     "quick_picks" -> context.getString(R.string.section_quick_picks)
                     "speed_dial", "speed_dial_shuffle" -> context.getString(R.string.section_speed_dial)

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/music/MusicUiStateNormalization.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/music/MusicUiStateNormalization.kt
@@ -51,6 +51,10 @@ internal fun MusicUiState.withHiddenArtists(hidden: Set<String>): MusicUiState {
         topAlbums
             .filterNot { it.author.trim().lowercase() in hidden }
             .let { if (it.size == topAlbums.size) topAlbums else it }
+    val filteredFavoriteAlbums =
+        favoriteArtistAlbums
+            .filterNot { it.author.trim().lowercase() in hidden }
+            .let { if (it.size == favoriteArtistAlbums.size) favoriteArtistAlbums else it }
     val filteredCommunity =
         communityPlaylists
             .mapNotNull { item ->
@@ -98,6 +102,7 @@ internal fun MusicUiState.withHiddenArtists(hidden: Set<String>): MusicUiState {
         filteredLongListens === longListens &&
         filteredAllSongs === allSongs &&
         filteredTopAlbums === topAlbums &&
+        filteredFavoriteAlbums === favoriteArtistAlbums &&
         filteredCommunity === communityPlaylists &&
         filteredGenreTracks === genreTracks &&
         filteredDynamicSections === dynamicSections &&
@@ -124,6 +129,7 @@ internal fun MusicUiState.withHiddenArtists(hidden: Set<String>): MusicUiState {
         longListens = filteredLongListens,
         allSongs = filteredAllSongs,
         topAlbums = filteredTopAlbums,
+        favoriteArtistAlbums = filteredFavoriteAlbums,
         communityPlaylists = filteredCommunity,
         genreTracks = filteredGenreTracks,
         dynamicSections = filteredDynamicSections,
@@ -154,6 +160,7 @@ internal fun MusicUiState.withUniqueLazyContent(): MusicUiState {
         }
     val uniqueFeaturedPlaylists = featuredPlaylists.uniqueMusicPlaylists()
     val uniqueTopAlbums = topAlbums.uniqueMusicPlaylists()
+    val uniqueFavoriteArtistAlbums = favoriteArtistAlbums.uniqueMusicPlaylists()
     val uniqueDynamicSections = dynamicSections.uniqueSectionTracks()
     val uniqueDailyMixSections = dailyMixSections.uniqueSectionTracks()
     val uniqueSimilarSections = similarToSections.uniqueSectionTracks()
@@ -184,6 +191,7 @@ internal fun MusicUiState.withUniqueLazyContent(): MusicUiState {
         uniqueCommunityPlaylists === communityPlaylists &&
         uniqueFeaturedPlaylists === featuredPlaylists &&
         uniqueTopAlbums === topAlbums &&
+        uniqueFavoriteArtistAlbums === favoriteArtistAlbums &&
         uniqueDynamicSections === dynamicSections &&
         uniqueDailyMixSections === dailyMixSections &&
         uniqueSimilarSections === similarToSections &&
@@ -212,6 +220,7 @@ internal fun MusicUiState.withUniqueLazyContent(): MusicUiState {
         genreTracks = uniqueGenreTracks,
         featuredPlaylists = uniqueFeaturedPlaylists,
         topAlbums = uniqueTopAlbums,
+        favoriteArtistAlbums = uniqueFavoriteArtistAlbums,
         dynamicSections = uniqueDynamicSections,
         dailyMixSections = uniqueDailyMixSections,
         homeChips = uniqueHomeChips,

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/music/MusicUiStateNormalization.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/music/MusicUiStateNormalization.kt
@@ -64,6 +64,8 @@ internal fun MusicUiState.withHiddenArtists(hidden: Set<String>): MusicUiState {
     val filteredGenreTracks = genreTracks.mapValuesIfChanged { it.dropHidden() }
 
     val filteredOnRepeat = onRepeatTracks.dropHidden()
+    val filteredRediscover = rediscoverTracks.dropHidden()
+    val filteredRotation = rotationTracks.dropHidden()
     val filteredForYou = forYouTracks.dropHidden()
     val filteredRecommended = recommendedTracks.dropHidden()
     val filteredListenAgain = listenAgain.dropHidden()
@@ -81,6 +83,8 @@ internal fun MusicUiState.withHiddenArtists(hidden: Set<String>): MusicUiState {
     if (
         filteredDailyDiscover === dailyDiscover &&
         filteredOnRepeat === onRepeatTracks &&
+        filteredRediscover === rediscoverTracks &&
+        filteredRotation === rotationTracks &&
         filteredForYou === forYouTracks &&
         filteredRecommended === recommendedTracks &&
         filteredListenAgain === listenAgain &&
@@ -104,6 +108,8 @@ internal fun MusicUiState.withHiddenArtists(hidden: Set<String>): MusicUiState {
     return copy(
         dailyDiscover = filteredDailyDiscover,
         onRepeatTracks = filteredOnRepeat,
+        rediscoverTracks = filteredRediscover,
+        rotationTracks = filteredRotation,
         forYouTracks = filteredForYou,
         recommendedTracks = filteredRecommended,
         listenAgain = filteredListenAgain,

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/music/MusicUiStateNormalization.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/music/MusicUiStateNormalization.kt
@@ -66,6 +66,7 @@ internal fun MusicUiState.withHiddenArtists(hidden: Set<String>): MusicUiState {
     val filteredOnRepeat = onRepeatTracks.dropHidden()
     val filteredRediscover = rediscoverTracks.dropHidden()
     val filteredRotation = rotationTracks.dropHidden()
+    val filteredSpeedDial = speedDialTracks.dropHidden()
     val filteredForYou = forYouTracks.dropHidden()
     val filteredRecommended = recommendedTracks.dropHidden()
     val filteredListenAgain = listenAgain.dropHidden()
@@ -85,6 +86,7 @@ internal fun MusicUiState.withHiddenArtists(hidden: Set<String>): MusicUiState {
         filteredOnRepeat === onRepeatTracks &&
         filteredRediscover === rediscoverTracks &&
         filteredRotation === rotationTracks &&
+        filteredSpeedDial === speedDialTracks &&
         filteredForYou === forYouTracks &&
         filteredRecommended === recommendedTracks &&
         filteredListenAgain === listenAgain &&
@@ -110,6 +112,7 @@ internal fun MusicUiState.withHiddenArtists(hidden: Set<String>): MusicUiState {
         onRepeatTracks = filteredOnRepeat,
         rediscoverTracks = filteredRediscover,
         rotationTracks = filteredRotation,
+        speedDialTracks = filteredSpeedDial,
         forYouTracks = filteredForYou,
         recommendedTracks = filteredRecommended,
         listenAgain = filteredListenAgain,

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/music/MusicViewModel.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/music/MusicViewModel.kt
@@ -373,18 +373,23 @@ class MusicViewModel
         private suspend fun buildDailyMixSections(): List<MusicSection> {
             val mixes = musicBrain.dailyMixes(3)
             if (mixes.isEmpty()) return emptyList()
+            // One parallel round for every mix's lanes — sequential rounds tripled
+            // the wall-clock cost on a cold related-lane cache.
+            val lanesByMix =
+                kotlinx.coroutines.coroutineScope {
+                    mixes
+                        .map { mix ->
+                            mix.seedTrackIds
+                                .take(3)
+                                .map { seedId ->
+                                    async(PerformanceDispatcher.networkIO) { cachedRelatedLane(seedId) }
+                                }
+                        }.map { jobs -> jobs.awaitAll().flatten() }
+                }
             val used = HashSet<String>()
             val sections = ArrayList<MusicSection>()
-            for (mix in mixes) {
-                val related =
-                    kotlinx.coroutines.coroutineScope {
-                        mix.seedTrackIds
-                            .take(3)
-                            .map { seedId ->
-                                async(PerformanceDispatcher.networkIO) { cachedRelatedLane(seedId) }
-                            }.awaitAll()
-                            .flatten()
-                    }
+            for ((index, mix) in mixes.withIndex()) {
+                val related = lanesByMix[index]
                 val pool = musicBrain.rankTracks(related.distinctBy { it.videoId }, "discover")
                 val items = pool.filterNot { it.videoId in used }.take(14)
                 if (items.size < 4) continue

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/music/MusicViewModel.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/music/MusicViewModel.kt
@@ -167,7 +167,7 @@ class MusicViewModel
                 // saved taste keeps seeding even when recent history is noisy.
                 val seeds = MusicQuickPicks.selectSeeds(current, history + favorites)
 
-                val (relatedLanes, artistLanesRaw) =
+                val (relatedLanes, artistResult) =
                     kotlinx.coroutines.coroutineScope {
                         val relatedJobs =
                             seeds.map { seed ->
@@ -177,10 +177,18 @@ class MusicViewModel
                             async(PerformanceDispatcher.networkIO) {
                                 runCatching { buildArtistLanes() }
                                     .onFailure { Log.w("MusicViewModel", "Artist lanes failed: $it") }
-                                    .getOrDefault(emptyList())
+                                    .getOrDefault(ArtistLanes(emptyList(), emptyList()))
                             }
                         relatedJobs.awaitAll() to artistJob.await()
                     }
+                val artistLanesRaw = artistResult.lanes
+
+                if (artistResult.albums.size >= 4) {
+                    _uiState.update { state ->
+                        val topAlbumIds = state.topAlbums.mapTo(HashSet()) { it.id }
+                        state.copy(favoriteArtistAlbums = artistResult.albums.filterNot { it.id in topAlbumIds })
+                    }
+                }
 
                 val personalizedLanes =
                     relatedLanes
@@ -254,17 +262,24 @@ class MusicViewModel
                     .getOrNull()
                     ?.also { artistDetailsCache[channelId] = it }
 
+        /** Lanes for the Quick Picks composer plus the artists' own releases for the albums shelf. */
+        private data class ArtistLanes(
+            val lanes: List<List<MusicTrack>>,
+            val albums: List<MusicPlaylist>,
+        )
+
         /**
          * The artist-graph lanes: top tracks of the brain's strongest artists, plus
          * one lane drawn from their "fans also like" artists — recall the user's
          * taste has earned, independent of what happens to be in recent history.
          */
-        private suspend fun buildArtistLanes(): List<List<MusicTrack>> {
+        private suspend fun buildArtistLanes(): ArtistLanes {
             val topArtists = musicBrain.topArtistKeys(MusicQuickPicks.ARTIST_LANE_COUNT)
-            if (topArtists.isEmpty()) return emptyList()
+            if (topArtists.isEmpty()) return ArtistLanes(emptyList(), emptyList())
 
             val lanes = ArrayList<List<MusicTrack>>()
             val relatedPerArtist = ArrayList<List<String>>()
+            val releasesPerArtist = ArrayList<List<MusicPlaylist>>()
             kotlinx.coroutines.coroutineScope {
                 topArtists
                     .map { key -> async(PerformanceDispatcher.networkIO) { key to cachedArtistDetails(key) } }
@@ -276,6 +291,12 @@ class MusicViewModel
                             .take(MusicQuickPicks.LANE_SIZE)
                             .takeIf { it.isNotEmpty() }
                             ?.let { lanes.add(it) }
+                        // Artist pages list releases newest-first, so the head of
+                        // each list is that artist's latest work.
+                        (details.albums.take(2) + details.singles.take(2))
+                            .filter { it.id.isNotBlank() }
+                            .takeIf { it.isNotEmpty() }
+                            ?.let { releasesPerArtist.add(it) }
                         val related = details.relatedArtists.mapNotNull { r -> r.channelId.takeIf { it.isNotBlank() } }
                         if (related.isNotEmpty()) {
                             musicBrain.recordArtistRelated(key, related)
@@ -308,7 +329,22 @@ class MusicViewModel
                         .distinctBy { it.videoId }
                 if (similarPool.isNotEmpty()) lanes.add(similarPool)
             }
-            return lanes
+
+            // Round-robin one release per artist per pass, so no artist owns the shelf.
+            val albums = ArrayList<MusicPlaylist>()
+            var depth = 0
+            while (albums.size < 12) {
+                var any = false
+                for (releases in releasesPerArtist) {
+                    releases.getOrNull(depth)?.let {
+                        albums.add(it)
+                        any = true
+                    }
+                }
+                if (!any) break
+                depth++
+            }
+            return ArtistLanes(lanes, albums.distinctBy { it.id })
         }
 
         /**
@@ -1409,6 +1445,7 @@ data class MusicUiState(
     val genres: List<String> = emptyList(),
     val featuredPlaylists: List<MusicPlaylist> = emptyList(),
     val topAlbums: List<MusicPlaylist> = emptyList(),
+    val favoriteArtistAlbums: List<MusicPlaylist> = emptyList(), // Releases from the brain's top artists
     val dynamicSections: List<MusicSection> = emptyList(),
     val dailyMixSections: List<MusicSection> = emptyList(),
     val homeChips: List<HomePage.Chip> = emptyList(),

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/music/MusicViewModel.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/music/MusicViewModel.kt
@@ -32,7 +32,9 @@ import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -117,6 +119,24 @@ class MusicViewModel
                         refreshLocalShelves()
                     }
                 }
+            }
+
+            // Speed dial ranked by the comfort surface, so the tiles are the
+            // truest "most yours" rather than raw shelf concatenation order.
+            // Writing speedDialTracks re-emits _uiState, but the source triple is
+            // unchanged then, so distinctUntilChanged breaks the loop.
+            viewModelScope.launch {
+                _uiState
+                    .map { Triple(it.history, it.forYouTracks, it.listenAgain) }
+                    .distinctUntilChanged()
+                    .collectLatest { (history, forYou, listenAgain) ->
+                        val pool = (history + forYou + listenAgain).audioMusicOnly().take(40)
+                        if (pool.isEmpty()) return@collectLatest
+                        val ranked = musicBrain.rankTracks(pool, "heavy_rotation").take(26)
+                        if (ranked.isNotEmpty()) {
+                            _uiState.update { it.copy(speedDialTracks = ranked) }
+                        }
+                    }
             }
         }
 
@@ -1049,6 +1069,13 @@ class MusicViewModel
                     }?.tracks
                     ?.audioMusicOnly() ?: emptyList()
 
+            // YT hands these shelves back unranked; a brain pass puts the user's
+            // taste first and drops blocked artists at the source.
+            val rankedListenAgain = musicBrain.rankTracks(listenAgain, "heavy_rotation")
+            val rankedRecommended = musicBrain.rankTracks(recommended, "quick_picks")
+            val rankedVideosForYou = musicBrain.rankTracks(musicVideosForYou, "quick_picks")
+            val rankedLongListens = musicBrain.rankTracks(longListens, "quick_picks")
+
             _uiState.update { currentState ->
                 currentState.copy(
                     forYouTracks =
@@ -1057,12 +1084,12 @@ class MusicViewModel
                         } else {
                             quickPicks.ifEmpty { currentState.forYouTracks }
                         },
-                    recommendedTracks = recommended.ifEmpty { currentState.recommendedTracks },
-                    listenAgain = listenAgain,
+                    recommendedTracks = rankedRecommended.ifEmpty { currentState.recommendedTracks },
+                    listenAgain = rankedListenAgain,
                     musicVideos = musicVideos,
-                    musicVideosForYou = musicVideosForYou,
+                    musicVideosForYou = rankedVideosForYou,
                     livePerformances = livePerformances,
-                    longListens = longListens,
+                    longListens = rankedLongListens,
                     dynamicSections = sections,
                 )
             }
@@ -1365,6 +1392,7 @@ data class MusicUiState(
     val rediscoverTracks: List<MusicTrack> = emptyList(), // Loved-but-quiet artists (local music brain)
     val rotationTracks: List<MusicTrack> = emptyList(), // Time-of-day rotation (local music brain)
     val rotationBucket: MusicTimeBucket? = null,
+    val speedDialTracks: List<MusicTrack> = emptyList(), // Brain-ranked speed dial pool
     val forYouTracks: List<MusicTrack> = emptyList(), // Quick Picks
     val recommendedTracks: List<MusicTrack> = emptyList(), // Recommended for you
     val listenAgain: List<MusicTrack> = emptyList(), // Listen Again

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/music/MusicViewModel.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/music/MusicViewModel.kt
@@ -15,6 +15,7 @@ import io.github.aedev.flow.data.newmusic.InnertubeMusicService
 import io.github.aedev.flow.data.recommendation.MusicRecommendationAlgorithm
 import io.github.aedev.flow.data.recommendation.MusicSection
 import io.github.aedev.flow.data.recommendation.music.MusicQuickPicks
+import io.github.aedev.flow.data.recommendation.music.MusicTimeBucket
 import io.github.aedev.flow.innertube.YouTube
 import io.github.aedev.flow.innertube.models.BrowseEndpoint
 import io.github.aedev.flow.innertube.models.SongItem
@@ -99,7 +100,7 @@ class MusicViewModel
                             lastTrackId = activeTrack.videoId
                             if (isUiVisible()) {
                                 rebuildQuickPicks(activeTrack)
-                                refreshOnRepeat()
+                                refreshLocalShelves()
                             } else {
                                 shelvesStale = true
                             }
@@ -113,7 +114,7 @@ class MusicViewModel
                     if (count > 0 && shelvesStale) {
                         shelvesStale = false
                         rebuildQuickPicks(EnhancedMusicPlayerManager.currentTrack.value)
-                        refreshOnRepeat()
+                        refreshLocalShelves()
                     }
                 }
             }
@@ -334,14 +335,36 @@ class MusicViewModel
             }
         }
 
-        private suspend fun refreshOnRepeat() {
+        /**
+         * The three brain-native shelves rendered purely from local meta:
+         * On Repeat, the time-of-day rotation and Rediscover. Zero network,
+         * refreshed together per track change (visibility-gated by the callers).
+         */
+        private suspend fun refreshLocalShelves() {
             try {
                 val onRepeat = musicBrain.heavyRotationTracks(16).audioMusicOnly()
-                if (onRepeat.size >= 2) {
-                    _uiState.update { it.copy(onRepeatTracks = onRepeat) }
+                val onRepeatIds = onRepeat.mapTo(HashSet()) { it.videoId }
+                val rotation =
+                    musicBrain
+                        .timeOfDayTracks(20)
+                        .audioMusicOnly()
+                        .filterNot { it.videoId in onRepeatIds }
+                val rediscover =
+                    musicBrain
+                        .rediscoverTracks(12)
+                        .audioMusicOnly()
+                        .filterNot { it.videoId in onRepeatIds }
+                _uiState.update {
+                    it.copy(
+                        onRepeatTracks = if (onRepeat.size >= 2) onRepeat else it.onRepeatTracks,
+                        // Time-sensitive shelves hide rather than linger when thin.
+                        rotationTracks = if (rotation.size >= 3) rotation else emptyList(),
+                        rotationBucket = MusicTimeBucket.fromTimestamp(System.currentTimeMillis()),
+                        rediscoverTracks = if (rediscover.size >= 3) rediscover else emptyList(),
+                    )
                 }
             } catch (e: Exception) {
-                Log.e("MusicViewModel", "Error loading On Repeat", e)
+                Log.e("MusicViewModel", "Error loading local shelves", e)
             }
         }
 
@@ -391,7 +414,7 @@ class MusicViewModel
             // Watch history holds one row per track, so backfill cannot seed relistens;
             // the shelf earns items only from live sessions and refreshes per track change.
             viewModelScope.launch(PerformanceDispatcher.diskIO) {
-                refreshOnRepeat()
+                refreshLocalShelves()
             }
 
             // Daily Mixes — co-occurrence clusters expanded through related recall.
@@ -1339,6 +1362,9 @@ data class MusicUiState(
     val sessionSeed: Long = System.currentTimeMillis(),
     val dailyDiscover: List<DailyDiscoverItem> = emptyList(),
     val onRepeatTracks: List<MusicTrack> = emptyList(), // On Repeat (local music brain)
+    val rediscoverTracks: List<MusicTrack> = emptyList(), // Loved-but-quiet artists (local music brain)
+    val rotationTracks: List<MusicTrack> = emptyList(), // Time-of-day rotation (local music brain)
+    val rotationBucket: MusicTimeBucket? = null,
     val forYouTracks: List<MusicTrack> = emptyList(), // Quick Picks
     val recommendedTracks: List<MusicTrack> = emptyList(), // Recommended for you
     val listenAgain: List<MusicTrack> = emptyList(), // Listen Again

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/music/MusicViewModel.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/music/MusicViewModel.kt
@@ -57,6 +57,11 @@ class MusicViewModel
         private val downloadManager: DownloadManager,
         private val musicBrain: io.github.aedev.flow.data.recommendation.music.MusicBrainEngine,
     ) : ViewModel() {
+        companion object {
+            /** Route prefix for synthesized Daily Mix playlist pages. */
+            const val DAILY_MIX_ID_PREFIX = "daily_mix_"
+        }
+
         private val _uiState = MutableStateFlow(MusicUiState())
 
         // WhileSubscribed (not Eagerly) is load-bearing for battery: it makes
@@ -356,40 +361,85 @@ class MusicViewModel
          */
         private suspend fun refreshDailyMixes() {
             try {
-                val mixes = musicBrain.dailyMixes(3)
-                if (mixes.isEmpty()) return
-                val used = HashSet<String>()
-                val sections = ArrayList<MusicSection>()
-                for (mix in mixes) {
-                    val related =
-                        kotlinx.coroutines.coroutineScope {
-                            mix.seedTrackIds
-                                .take(3)
-                                .map { seedId ->
-                                    async(PerformanceDispatcher.networkIO) { cachedRelatedLane(seedId) }
-                                }.awaitAll()
-                                .flatten()
-                        }
-                    val pool = musicBrain.rankTracks(related.distinctBy { it.videoId }, "discover")
-                    val items = pool.filterNot { it.videoId in used }.take(14)
-                    if (items.size < 4) continue
-                    used.addAll(items.map { it.videoId })
-                    sections.add(
-                        MusicSection(
-                            title = context.getString(R.string.section_daily_mix_title, mix.label),
-                            label = context.getString(R.string.section_daily_mix_label),
-                            thumbnailUrl = items.first().thumbnailUrl,
-                            seedId = null,
-                            isArtistSeed = false,
-                            tracks = items,
-                        ),
-                    )
-                }
+                val sections = buildDailyMixSections()
                 if (sections.isNotEmpty()) {
                     _uiState.update { it.copy(dailyMixSections = sections) }
                 }
             } catch (e: Exception) {
                 Log.e("MusicViewModel", "Error building daily mixes", e)
+            }
+        }
+
+        private suspend fun buildDailyMixSections(): List<MusicSection> {
+            val mixes = musicBrain.dailyMixes(3)
+            if (mixes.isEmpty()) return emptyList()
+            val used = HashSet<String>()
+            val sections = ArrayList<MusicSection>()
+            for (mix in mixes) {
+                val related =
+                    kotlinx.coroutines.coroutineScope {
+                        mix.seedTrackIds
+                            .take(3)
+                            .map { seedId ->
+                                async(PerformanceDispatcher.networkIO) { cachedRelatedLane(seedId) }
+                            }.awaitAll()
+                            .flatten()
+                    }
+                val pool = musicBrain.rankTracks(related.distinctBy { it.videoId }, "discover")
+                val items = pool.filterNot { it.videoId in used }.take(14)
+                if (items.size < 4) continue
+                used.addAll(items.map { it.videoId })
+                sections.add(
+                    MusicSection(
+                        title = context.getString(R.string.section_daily_mix_title, mix.label),
+                        label = context.getString(R.string.section_daily_mix_label),
+                        thumbnailUrl = items.first().thumbnailUrl,
+                        // The synthetic id routes the header tap to a playlist page.
+                        seedId = "$DAILY_MIX_ID_PREFIX${sections.size}",
+                        isArtistSeed = false,
+                        tracks = items,
+                    ),
+                )
+            }
+            return sections
+        }
+
+        /**
+         * A Daily Mix as a full playlist page (play all, shuffle, save to library).
+         * Mixes are deterministic per brain state, so a fresh ViewModel (own nav
+         * destination) rebuilds the same mix when the section isn't in memory.
+         */
+        fun loadDailyMixPage(mixId: String) {
+            val index = mixId.removePrefix(DAILY_MIX_ID_PREFIX).toIntOrNull() ?: return
+            viewModelScope.launch(PerformanceDispatcher.networkIO) {
+                _uiState.update { it.copy(isPlaylistLoading = true, playlistDetails = null) }
+                val section =
+                    _uiState.value.dailyMixSections.getOrNull(index)
+                        ?: runCatching { buildDailyMixSections() }
+                            .onFailure { Log.e("MusicViewModel", "Error rebuilding daily mix", it) }
+                            .getOrDefault(emptyList())
+                            .getOrNull(index)
+                if (section == null) {
+                    _uiState.update { it.copy(isPlaylistLoading = false) }
+                    return@launch
+                }
+                val details =
+                    PlaylistDetails(
+                        id = mixId,
+                        title = section.title,
+                        thumbnailUrl = section.thumbnailUrl ?: section.tracks.first().thumbnailUrl,
+                        author = context.getString(R.string.section_daily_mix_label),
+                        trackCount = section.tracks.size,
+                        description = context.getString(R.string.daily_mix_page_description),
+                        tracks = section.tracks,
+                    )
+                _uiState.update {
+                    it.copy(
+                        isPlaylistLoading = false,
+                        playlistDetails = details,
+                        selectedPlaylist = details,
+                    )
+                }
             }
         }
 

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/music/MusicViewModel.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/music/MusicViewModel.kt
@@ -14,8 +14,10 @@ import io.github.aedev.flow.data.music.YouTubeMusicService
 import io.github.aedev.flow.data.newmusic.InnertubeMusicService
 import io.github.aedev.flow.data.recommendation.MusicRecommendationAlgorithm
 import io.github.aedev.flow.data.recommendation.MusicSection
+import io.github.aedev.flow.data.recommendation.music.MusicArtistInsights
 import io.github.aedev.flow.data.recommendation.music.MusicQuickPicks
 import io.github.aedev.flow.data.recommendation.music.MusicTimeBucket
+import io.github.aedev.flow.data.recommendation.music.musicArtistKey
 import io.github.aedev.flow.innertube.YouTube
 import io.github.aedev.flow.innertube.models.BrowseEndpoint
 import io.github.aedev.flow.innertube.models.SongItem
@@ -1168,7 +1170,13 @@ class MusicViewModel
          */
         fun fetchArtistDetails(channelId: String) {
             viewModelScope.launch(PerformanceDispatcher.networkIO) {
-                _uiState.value = _uiState.value.copy(isArtistLoading = true, artistDetails = null)
+                _uiState.value =
+                    _uiState.value.copy(
+                        isArtistLoading = true,
+                        artistDetails = null,
+                        artistInsights = null,
+                        knownRelatedArtistIds = emptySet(),
+                    )
 
                 supervisorScope {
                     val detailsDeferred =
@@ -1186,10 +1194,28 @@ class MusicViewModel
                     val details = detailsDeferred.await()
                     val isSubscribed = subscriptionDeferred.await()
 
+                    // The brain's history with this artist plus which of the
+                    // "fans also like" row the user already listens to — local reads.
+                    val insights = details?.let { musicBrain.artistInsights(channelId, it.name) }
+                    val knownRelated =
+                        details
+                            ?.relatedArtists
+                            ?.takeIf { it.isNotEmpty() }
+                            ?.let { related ->
+                                val known = musicBrain.listenedArtistKeys()
+                                related
+                                    .filter { artist ->
+                                        val key = musicArtistKey(artist.channelId.takeIf { it.isNotBlank() }, artist.name)
+                                        key in known || artist.name.trim().lowercase() in known
+                                    }.mapTo(HashSet()) { it.channelId }
+                            }.orEmpty()
+
                     _uiState.value =
                         _uiState.value.copy(
                             isArtistLoading = false,
                             artistDetails = details?.copy(isSubscribed = isSubscribed),
+                            artistInsights = insights,
+                            knownRelatedArtistIds = knownRelated,
                         )
                 }
             }
@@ -1222,7 +1248,12 @@ class MusicViewModel
         }
 
         fun clearArtistDetails() {
-            _uiState.value = _uiState.value.copy(artistDetails = null)
+            _uiState.value =
+                _uiState.value.copy(
+                    artistDetails = null,
+                    artistInsights = null,
+                    knownRelatedArtistIds = emptySet(),
+                )
         }
 
         /**
@@ -1459,6 +1490,8 @@ data class MusicUiState(
     val error: String? = null,
     val downloadedTrackIds: Set<String> = emptySet(),
     val artistDetails: ArtistDetails? = null,
+    val artistInsights: MusicArtistInsights? = null,
+    val knownRelatedArtistIds: Set<String> = emptySet(),
     val isArtistLoading: Boolean = false,
     val playlistDetails: PlaylistDetails? = null,
     val selectedPlaylist: PlaylistDetails? = null,

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/music/MusicViewModel.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/music/MusicViewModel.kt
@@ -589,9 +589,17 @@ class MusicViewModel
                 val homeSections = homeResult.first
                 val homeContinuation = homeResult.second
 
-                // Fetch Chips
+                // Fetch Chips — ordered by learned genre/mood affinity so the
+                // moods the user actually plays lead the row (stable otherwise).
                 val homeChips = musicRecommendationAlgorithm.getHomeChips()
-                _uiState.update { it.copy(homeChips = homeChips) }
+                val genreAffinity = musicBrain.genreAffinitySnapshot()
+                val orderedChips =
+                    if (genreAffinity.isEmpty()) {
+                        homeChips
+                    } else {
+                        homeChips.sortedByDescending { genreAffinity[it.title.trim().lowercase()] ?: 0.0 }
+                    }
+                _uiState.update { it.copy(homeChips = orderedChips) }
 
                 if (homeSections.isNotEmpty()) {
                     processHomeSections(homeSections)

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/music/MusicViewModel.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/music/MusicViewModel.kt
@@ -523,6 +523,10 @@ class MusicViewModel
             // the shelf earns items only from live sessions and refreshes per track change.
             viewModelScope.launch(PerformanceDispatcher.diskIO) {
                 refreshLocalShelves()
+                // Maturity steers which sections lead the page (planner-lite).
+                runCatching { musicBrain.tasteProfile().maturity }
+                    .getOrNull()
+                    ?.let { maturity -> _uiState.update { it.copy(brainMaturity = maturity) } }
             }
 
             // Daily Mixes — co-occurrence clusters expanded through related recall.
@@ -1539,6 +1543,7 @@ data class MusicUiState(
     val dailyMixSections: List<MusicSection> = emptyList(),
     val homeChips: List<HomePage.Chip> = emptyList(),
     val selectedHomeChip: HomePage.Chip? = null,
+    val brainMaturity: String? = null, // "cold_start" / "warming" / "mature" — steers section order
     val explorePage: io.github.aedev.flow.innertube.pages.ExplorePage? = null,
     val moodsAndGenres: List<MoodAndGenres> = emptyList(),
     val selectedGenre: String? = null,

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/music/SharedMusicViewModel.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/music/SharedMusicViewModel.kt
@@ -1,0 +1,23 @@
+package io.github.aedev.flow.ui.screens.music
+
+import androidx.activity.ComponentActivity
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalContext
+import androidx.hilt.navigation.compose.hiltViewModel
+
+/**
+ * One [MusicViewModel] per activity, shared by the Music tab and every music
+ * route (artist, playlist, mix, view-all) — the same scoping the TV shell uses.
+ *
+ * This is load-bearing for battery and latency: the ViewModel's init kicks off
+ * the entire home-feed load (dozens of network calls), so a per-route instance
+ * used to re-run that flood on every artist/album/mix open, starving the fixed
+ * network pool (30 s Daily Mix pages) and heating the device. One shared
+ * instance loads home once and lets every route reuse its section state and
+ * related-lane/artist caches.
+ */
+@Composable
+fun sharedMusicViewModel(): MusicViewModel {
+    val activity = LocalContext.current as? ComponentActivity
+    return if (activity != null) hiltViewModel(activity) else hiltViewModel()
+}

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/music/components/HomeSectionType.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/music/components/HomeSectionType.kt
@@ -17,5 +17,5 @@ enum class HomeSectionType {
     CHARTS,
     POPULAR_ARTISTS,
     MIXED_FOR_YOU,
-    MOODS_AND_GENRES
+    MOODS_AND_GENRES,
 }

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/music/components/HomeSectionType.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/music/components/HomeSectionType.kt
@@ -12,6 +12,7 @@ enum class HomeSectionType {
     GENRES,
     DYNAMIC_HOME,
     TOP_ALBUMS,
+    FAVORITE_ARTIST_ALBUMS,
     NEW_RELEASES,
     CHARTS,
     POPULAR_ARTISTS,

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/personality/FlowPersonalityScreen.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/personality/FlowPersonalityScreen.kt
@@ -255,6 +255,11 @@ fun FlowPersonalityScreen(
                         MusicListeningPatternsSection(profile = profile)
                     }
                 }
+                if (profile.topGenres.isNotEmpty()) {
+                    item(key = "music_genres") {
+                        MusicGenreAffinitySection(profile = profile)
+                    }
+                }
                 if (musicBlockedArtists.isNotEmpty()) {
                     item(key = "music_blocked") {
                         MusicBlockedArtistsSection(

--- a/app/src/main/java/io/github/aedev/flow/ui/screens/personality/MusicPersonaSections.kt
+++ b/app/src/main/java/io/github/aedev/flow/ui/screens/personality/MusicPersonaSections.kt
@@ -204,6 +204,25 @@ internal fun MusicListeningPatternsSection(profile: MusicTasteProfile) {
 }
 
 @Composable
+internal fun MusicGenreAffinitySection(profile: MusicTasteProfile) {
+    val maxAffinity = profile.topGenres.maxOfOrNull { it.second } ?: 0.0
+    if (maxAffinity <= 0.0) return
+    DashboardSection(
+        title = stringResource(R.string.music_genre_affinity_title),
+        subtitle = stringResource(R.string.music_genre_affinity_subtitle),
+        icon = Icons.Outlined.LibraryMusic,
+    ) {
+        profile.topGenres.take(8).forEach { (genre, affinity) ->
+            CompactProgressRow(
+                title = genre.replaceFirstChar { it.titlecase() },
+                subtitle = affinity.percentLabel(),
+                value = affinity / maxAffinity,
+            )
+        }
+    }
+}
+
+@Composable
 internal fun MusicBlockedArtistsSection(
     blockedArtists: List<Pair<String, String>>,
     onUnblock: (String) -> Unit,

--- a/app/src/main/java/io/github/aedev/flow/widget/core/FlowWidgets.kt
+++ b/app/src/main/java/io/github/aedev/flow/widget/core/FlowWidgets.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.glance.appwidget.updateAll
 import io.github.aedev.flow.widget.downloads.DownloadsWidget
 import io.github.aedev.flow.widget.nowplaying.NowPlayingWidget
+import io.github.aedev.flow.widget.onrepeat.OnRepeatWidget
 import io.github.aedev.flow.widget.quickactions.QuickActionsWidget
 import io.github.aedev.flow.widget.recent.RecentlyPlayedWidget
 import io.github.aedev.flow.widget.recognize.RecognizeWidget
@@ -18,5 +19,6 @@ object FlowWidgets {
         RecognizeWidget().updateAll(context)
         RecentlyPlayedWidget().updateAll(context)
         DownloadsWidget().updateAll(context)
+        OnRepeatWidget().updateAll(context)
     }
 }

--- a/app/src/main/java/io/github/aedev/flow/widget/core/WidgetDeepLink.kt
+++ b/app/src/main/java/io/github/aedev/flow/widget/core/WidgetDeepLink.kt
@@ -20,6 +20,7 @@ object WidgetDeepLink {
     const val ROUTE_DOWNLOADS = "downloads"
     const val ROUTE_HISTORY = "history"
     const val ROUTE_RECOGNIZE = "musicRecognize"
+    const val ROUTE_MUSIC = "music"
 
     fun openApp(context: Context): Intent = base(context, "open")
 

--- a/app/src/main/java/io/github/aedev/flow/widget/core/WidgetDeepLink.kt
+++ b/app/src/main/java/io/github/aedev/flow/widget/core/WidgetDeepLink.kt
@@ -12,7 +12,6 @@ import io.github.aedev.flow.MainActivity
  * targets never collapse into one another.
  */
 object WidgetDeepLink {
-
     const val EXTRA_WIDGET_ROUTE = "widget_route"
 
     // Navigation routes that already exist in FlowNavigation.
@@ -25,18 +24,24 @@ object WidgetDeepLink {
     fun openApp(context: Context): Intent = base(context, "open")
 
     /** Expands the full music player over whatever screen the app opens on. */
-    fun openMusicPlayer(context: Context): Intent =
-        base(context, "music_player").putExtra("open_music_player", true)
+    fun openMusicPlayer(context: Context): Intent = base(context, "music_player").putExtra("open_music_player", true)
 
     /** Navigates to an existing FlowNavigation route (search, downloads, history, …). */
-    fun openRoute(context: Context, route: String): Intent =
-        base(context, "route/$route").putExtra(EXTRA_WIDGET_ROUTE, route)
+    fun openRoute(
+        context: Context,
+        route: String,
+    ): Intent = base(context, "route/$route").putExtra(EXTRA_WIDGET_ROUTE, route)
 
     /** Opens the video player on [videoId] via the existing deeplink playback path. */
-    fun playVideo(context: Context, videoId: String): Intent =
-        base(context, "video/$videoId").putExtra("video_id", videoId)
+    fun playVideo(
+        context: Context,
+        videoId: String,
+    ): Intent = base(context, "video/$videoId").putExtra("video_id", videoId)
 
-    private fun base(context: Context, path: String): Intent =
+    private fun base(
+        context: Context,
+        path: String,
+    ): Intent =
         Intent(context, MainActivity::class.java).apply {
             // Custom action (not ACTION_VIEW): MainActivity.handleIntent must read our
             // extras, not try to parse the uniqueness-only data Uri as a YouTube URL.

--- a/app/src/main/java/io/github/aedev/flow/widget/core/WidgetEntryPoint.kt
+++ b/app/src/main/java/io/github/aedev/flow/widget/core/WidgetEntryPoint.kt
@@ -5,6 +5,7 @@ import dagger.hilt.EntryPoint
 import dagger.hilt.InstallIn
 import dagger.hilt.android.EntryPointAccessors
 import dagger.hilt.components.SingletonComponent
+import io.github.aedev.flow.data.recommendation.music.MusicBrainEngine
 import io.github.aedev.flow.data.video.VideoDownloadManager
 
 /**
@@ -15,6 +16,8 @@ import io.github.aedev.flow.data.video.VideoDownloadManager
 @InstallIn(SingletonComponent::class)
 interface WidgetEntryPoint {
     fun videoDownloadManager(): VideoDownloadManager
+
+    fun musicBrainEngine(): MusicBrainEngine
 }
 
 fun widgetEntryPoint(context: Context): WidgetEntryPoint =

--- a/app/src/main/java/io/github/aedev/flow/widget/core/WidgetVideoList.kt
+++ b/app/src/main/java/io/github/aedev/flow/widget/core/WidgetVideoList.kt
@@ -110,17 +110,19 @@ private fun PanelHeader(
     onClick: Action,
 ) {
     Row(
-        modifier = GlanceModifier
-            .fillMaxWidth()
-            .padding(horizontal = 12.dp, vertical = 10.dp)
-            .clickable(onClick),
+        modifier =
+            GlanceModifier
+                .fillMaxWidth()
+                .padding(horizontal = 12.dp, vertical = 10.dp)
+                .clickable(onClick),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         Box(
-            modifier = GlanceModifier
-                .size(28.dp)
-                .background(chipBackground)
-                .cornerRadius(14.dp),
+            modifier =
+                GlanceModifier
+                    .size(28.dp)
+                    .background(chipBackground)
+                    .cornerRadius(14.dp),
             contentAlignment = Alignment.Center,
         ) {
             Image(
@@ -133,11 +135,12 @@ private fun PanelHeader(
         Spacer(modifier = GlanceModifier.width(10.dp))
         Text(
             text = title,
-            style = TextStyle(
-                color = GlanceTheme.colors.onSurface,
-                fontSize = 15.sp,
-                fontWeight = FontWeight.Bold,
-            ),
+            style =
+                TextStyle(
+                    color = GlanceTheme.colors.onSurface,
+                    fontSize = 15.sp,
+                    fontWeight = FontWeight.Bold,
+                ),
             maxLines = 1,
         )
     }
@@ -147,28 +150,31 @@ private fun PanelHeader(
 private fun HeroCard(item: WidgetVideoItem) {
     val context = LocalContext.current
     Column(
-        modifier = GlanceModifier
-            .fillMaxWidth()
-            .padding(horizontal = 12.dp)
-            .clickable(actionStartActivity(item.openIntent ?: WidgetDeepLink.playVideo(context, item.videoId))),
+        modifier =
+            GlanceModifier
+                .fillMaxWidth()
+                .padding(horizontal = 12.dp)
+                .clickable(actionStartActivity(item.openIntent ?: WidgetDeepLink.playVideo(context, item.videoId))),
     ) {
         Image(
             provider = ImageProvider(item.hero!!),
             contentDescription = null,
-            modifier = GlanceModifier
-                .fillMaxWidth()
-                .height(104.dp)
-                .cornerRadius(WIDGET_HERO_CORNER_DP.dp),
+            modifier =
+                GlanceModifier
+                    .fillMaxWidth()
+                    .height(104.dp)
+                    .cornerRadius(WIDGET_HERO_CORNER_DP.dp),
             contentScale = ContentScale.Crop,
         )
         Spacer(modifier = GlanceModifier.height(6.dp))
         Text(
             text = item.title,
-            style = TextStyle(
-                color = GlanceTheme.colors.onSurface,
-                fontSize = 14.sp,
-                fontWeight = FontWeight.Medium,
-            ),
+            style =
+                TextStyle(
+                    color = GlanceTheme.colors.onSurface,
+                    fontSize = 14.sp,
+                    fontWeight = FontWeight.Medium,
+                ),
             maxLines = 2,
         )
         if (item.subtitle.isNotBlank()) {
@@ -186,10 +192,11 @@ private fun HeroCard(item: WidgetVideoItem) {
 private fun VideoRow(item: WidgetVideoItem) {
     val context = LocalContext.current
     Row(
-        modifier = GlanceModifier
-            .fillMaxWidth()
-            .padding(horizontal = 12.dp, vertical = 5.dp)
-            .clickable(actionStartActivity(item.openIntent ?: WidgetDeepLink.playVideo(context, item.videoId))),
+        modifier =
+            GlanceModifier
+                .fillMaxWidth()
+                .padding(horizontal = 12.dp, vertical = 5.dp)
+                .clickable(actionStartActivity(item.openIntent ?: WidgetDeepLink.playVideo(context, item.videoId))),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         if (item.thumbnail != null) {
@@ -201,10 +208,11 @@ private fun VideoRow(item: WidgetVideoItem) {
             )
         } else {
             Box(
-                modifier = GlanceModifier
-                    .size(WIDGET_THUMB_WIDTH, WIDGET_THUMB_HEIGHT)
-                    .background(GlanceTheme.colors.surfaceVariant)
-                    .cornerRadius(WIDGET_THUMB_CORNER_DP.dp),
+                modifier =
+                    GlanceModifier
+                        .size(WIDGET_THUMB_WIDTH, WIDGET_THUMB_HEIGHT)
+                        .background(GlanceTheme.colors.surfaceVariant)
+                        .cornerRadius(WIDGET_THUMB_CORNER_DP.dp),
                 contentAlignment = Alignment.Center,
             ) {
                 Image(

--- a/app/src/main/java/io/github/aedev/flow/widget/core/WidgetVideoList.kt
+++ b/app/src/main/java/io/github/aedev/flow/widget/core/WidgetVideoList.kt
@@ -35,13 +35,18 @@ import androidx.glance.text.TextStyle
 import androidx.glance.unit.ColorProvider
 import io.github.aedev.flow.R
 
-/** Display model for the video content widgets. The first item may carry a hero image. */
+/**
+ * Display model for the content widgets. The first item may carry a hero image.
+ * [openIntent] overrides the default tap target (the video player) — music
+ * widgets point their rows at the Music surfaces instead.
+ */
 data class WidgetVideoItem(
     val videoId: String,
     val title: String,
     val subtitle: String,
     val thumbnail: Bitmap? = null,
     val hero: Bitmap? = null,
+    val openIntent: android.content.Intent? = null,
 )
 
 // Row thumbnail (16:9) — shared so every list widget loads/caches at the same size.
@@ -145,7 +150,7 @@ private fun HeroCard(item: WidgetVideoItem) {
         modifier = GlanceModifier
             .fillMaxWidth()
             .padding(horizontal = 12.dp)
-            .clickable(actionStartActivity(WidgetDeepLink.playVideo(context, item.videoId))),
+            .clickable(actionStartActivity(item.openIntent ?: WidgetDeepLink.playVideo(context, item.videoId))),
     ) {
         Image(
             provider = ImageProvider(item.hero!!),
@@ -184,7 +189,7 @@ private fun VideoRow(item: WidgetVideoItem) {
         modifier = GlanceModifier
             .fillMaxWidth()
             .padding(horizontal = 12.dp, vertical = 5.dp)
-            .clickable(actionStartActivity(WidgetDeepLink.playVideo(context, item.videoId))),
+            .clickable(actionStartActivity(item.openIntent ?: WidgetDeepLink.playVideo(context, item.videoId))),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         if (item.thumbnail != null) {

--- a/app/src/main/java/io/github/aedev/flow/widget/onrepeat/OnRepeatWidget.kt
+++ b/app/src/main/java/io/github/aedev/flow/widget/onrepeat/OnRepeatWidget.kt
@@ -1,0 +1,103 @@
+package io.github.aedev.flow.widget.onrepeat
+
+import android.content.Context
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.glance.GlanceId
+import androidx.glance.GlanceTheme
+import androidx.glance.appwidget.GlanceAppWidget
+import androidx.glance.appwidget.GlanceAppWidgetReceiver
+import androidx.glance.appwidget.action.actionStartActivity
+import androidx.glance.appwidget.provideContent
+import io.github.aedev.flow.R
+import io.github.aedev.flow.widget.core.FlowGlanceTheme
+import io.github.aedev.flow.widget.core.WIDGET_HERO_CORNER_DP
+import io.github.aedev.flow.widget.core.WIDGET_HERO_HEIGHT_PX
+import io.github.aedev.flow.widget.core.WIDGET_HERO_WIDTH_PX
+import io.github.aedev.flow.widget.core.WIDGET_THUMB_CORNER_DP
+import io.github.aedev.flow.widget.core.WIDGET_THUMB_HEIGHT
+import io.github.aedev.flow.widget.core.WIDGET_THUMB_WIDTH
+import io.github.aedev.flow.widget.core.WidgetDeepLink
+import io.github.aedev.flow.widget.core.WidgetImageLoader
+import io.github.aedev.flow.widget.core.WidgetVideoItem
+import io.github.aedev.flow.widget.core.WidgetVideoPanel
+import io.github.aedev.flow.widget.core.widgetColorsFlow
+import io.github.aedev.flow.widget.core.widgetEntryPoint
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withContext
+
+/** The music brain's On Repeat shelf on the home screen — zero network to render. */
+class OnRepeatWidget : GlanceAppWidget() {
+    companion object {
+        private const val MAX_ITEMS = 8
+    }
+
+    override suspend fun provideGlance(
+        context: Context,
+        id: GlanceId,
+    ) {
+        val density = context.resources.displayMetrics.density
+        val thumbWidthPx = (WIDGET_THUMB_WIDTH.value * density).toInt()
+        val thumbHeightPx = (WIDGET_THUMB_HEIGHT.value * density).toInt()
+
+        // Rows open the Music tab, where the shelf leads the page.
+        val openMusic = WidgetDeepLink.openRoute(context, WidgetDeepLink.ROUTE_MUSIC)
+
+        val items =
+            withContext(Dispatchers.IO) {
+                widgetEntryPoint(context)
+                    .musicBrainEngine()
+                    .heavyRotationTracks(MAX_ITEMS)
+                    .mapIndexed { index, track ->
+                        WidgetVideoItem(
+                            videoId = track.videoId,
+                            title = track.title,
+                            subtitle = track.artist,
+                            thumbnail =
+                                if (index == 0) {
+                                    null
+                                } else {
+                                    WidgetImageLoader.load(
+                                        context, track.thumbnailUrl,
+                                        thumbWidthPx, thumbHeightPx, WIDGET_THUMB_CORNER_DP * density,
+                                    )
+                                },
+                            hero =
+                                if (index == 0) {
+                                    WidgetImageLoader.load(
+                                        context, track.thumbnailUrl,
+                                        WIDGET_HERO_WIDTH_PX, WIDGET_HERO_HEIGHT_PX, WIDGET_HERO_CORNER_DP * density,
+                                    )
+                                } else {
+                                    null
+                                },
+                            openIntent = openMusic,
+                        )
+                    }
+            }
+
+        val colorsFlow = widgetColorsFlow(context)
+        val initialColors = colorsFlow.first()
+
+        provideContent {
+            val colors by colorsFlow.collectAsState(initialColors)
+            FlowGlanceTheme(colors) {
+                WidgetVideoPanel(
+                    title = context.getString(R.string.widget_on_repeat),
+                    headerIconRes = R.drawable.ic_widget_music,
+                    chipBackground = GlanceTheme.colors.secondaryContainer,
+                    chipContent = GlanceTheme.colors.onSecondaryContainer,
+                    headerAction = actionStartActivity(openMusic),
+                    emptyMessage = context.getString(R.string.widget_no_on_repeat),
+                    emptyAction = actionStartActivity(openMusic),
+                    items = items,
+                )
+            }
+        }
+    }
+}
+
+class OnRepeatWidgetReceiver : GlanceAppWidgetReceiver() {
+    override val glanceAppWidget: GlanceAppWidget = OnRepeatWidget()
+}

--- a/app/src/main/java/io/github/aedev/flow/widget/onrepeat/OnRepeatWidget.kt
+++ b/app/src/main/java/io/github/aedev/flow/widget/onrepeat/OnRepeatWidget.kt
@@ -59,15 +59,21 @@ class OnRepeatWidget : GlanceAppWidget() {
                                     null
                                 } else {
                                     WidgetImageLoader.load(
-                                        context, track.thumbnailUrl,
-                                        thumbWidthPx, thumbHeightPx, WIDGET_THUMB_CORNER_DP * density,
+                                        context,
+                                        track.thumbnailUrl,
+                                        thumbWidthPx,
+                                        thumbHeightPx,
+                                        WIDGET_THUMB_CORNER_DP * density,
                                     )
                                 },
                             hero =
                                 if (index == 0) {
                                     WidgetImageLoader.load(
-                                        context, track.thumbnailUrl,
-                                        WIDGET_HERO_WIDTH_PX, WIDGET_HERO_HEIGHT_PX, WIDGET_HERO_CORNER_DP * density,
+                                        context,
+                                        track.thumbnailUrl,
+                                        WIDGET_HERO_WIDTH_PX,
+                                        WIDGET_HERO_HEIGHT_PX,
+                                        WIDGET_HERO_CORNER_DP * density,
                                     )
                                 } else {
                                     null

--- a/app/src/main/res/drawable/ic_widget_music.xml
+++ b/app/src/main/res/drawable/ic_widget_music.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M12,3v10.55c-0.59,-0.34 -1.27,-0.55 -2,-0.55 -2.21,0 -4,1.79 -4,4s1.79,4 4,4 4,-1.79 4,-4V7h4V3h-6z"/>
+</vector>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1659,6 +1659,9 @@
     <string name="section_rotation_afternoon">Your afternoon rotation</string>
     <string name="section_rotation_evening">Your evening rotation</string>
     <string name="section_rotation_night">Your late-night rotation</string>
+    <string name="source_your_rotation">Your rotation</string>
+    <string name="music_genre_affinity_title">Genres and moods</string>
+    <string name="music_genre_affinity_subtitle">Learned from the genre and mood surfaces you actually play</string>
     <string name="recommendations_header">Recommendations</string>
     <string name="not_interested_desc">Show less from this artist for a while</string>
     <string name="dont_recommend_artist">Don\'t recommend %1$s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1648,6 +1648,11 @@
     <string name="section_on_repeat">On Repeat</string>
     <string name="section_daily_mix_title">%1$s Mix</string>
     <string name="section_daily_mix_label">Daily Mix</string>
+    <string name="section_rediscover">Rediscover</string>
+    <string name="section_rotation_morning">Your morning rotation</string>
+    <string name="section_rotation_afternoon">Your afternoon rotation</string>
+    <string name="section_rotation_evening">Your evening rotation</string>
+    <string name="section_rotation_night">Your late-night rotation</string>
     <string name="recommendations_header">Recommendations</string>
     <string name="not_interested_desc">Show less from this artist for a while</string>
     <string name="dont_recommend_artist">Don\'t recommend %1$s</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1650,6 +1650,10 @@
     <string name="section_daily_mix_label">Daily Mix</string>
     <string name="section_rediscover">Rediscover</string>
     <string name="section_from_artists_you_love">From artists you love</string>
+    <string name="section_your_history">Your history</string>
+    <string name="artist_insights_played_times">Played %1$d times</string>
+    <string name="artist_insights_liked">Liked</string>
+    <string name="artist_known_related_badge">In your rotation</string>
     <string name="section_rotation_morning">Your morning rotation</string>
     <string name="section_rotation_afternoon">Your afternoon rotation</string>
     <string name="section_rotation_evening">Your evening rotation</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1648,6 +1648,7 @@
     <string name="section_on_repeat">On Repeat</string>
     <string name="section_daily_mix_title">%1$s Mix</string>
     <string name="section_daily_mix_label">Daily Mix</string>
+    <string name="daily_mix_page_description">Built from artists you listen to together. Save it to keep today\'s mix.</string>
     <string name="section_rediscover">Rediscover</string>
     <string name="section_from_artists_you_love">From artists you love</string>
     <string name="section_your_history">Your history</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1649,6 +1649,7 @@
     <string name="section_daily_mix_title">%1$s Mix</string>
     <string name="section_daily_mix_label">Daily Mix</string>
     <string name="section_rediscover">Rediscover</string>
+    <string name="section_from_artists_you_love">From artists you love</string>
     <string name="section_rotation_morning">Your morning rotation</string>
     <string name="section_rotation_afternoon">Your afternoon rotation</string>
     <string name="section_rotation_evening">Your evening rotation</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2487,6 +2487,10 @@
     <string name="widget_turntable_label">Turntable</string>
     <string name="widget_turntable_description">Your music as a spinning record</string>
     <string name="widget_recently_played_label">Recently played</string>
+    <string name="widget_on_repeat_label">On Repeat</string>
+    <string name="widget_on_repeat">On Repeat</string>
+    <string name="widget_on_repeat_description">The songs you keep coming back to</string>
+    <string name="widget_no_on_repeat">Songs you keep replaying will appear here</string>
     <string name="widget_recently_played_description">Pick up where you left off</string>
     <string name="widget_downloads_label">Downloads</string>
     <string name="widget_downloads_description">Play your offline downloads</string>

--- a/app/src/main/res/xml/widget_on_repeat_info.xml
+++ b/app/src/main/res/xml/widget_on_repeat_info.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Hourly system refresh; content is re-read from the local music brain on each update. -->
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:minWidth="250dp"
+    android:minHeight="180dp"
+    android:minResizeWidth="180dp"
+    android:minResizeHeight="110dp"
+    android:targetCellWidth="4"
+    android:targetCellHeight="3"
+    android:updatePeriodMillis="3600000"
+    android:initialLayout="@layout/glance_default_loading_layout"
+    android:description="@string/widget_on_repeat_description"
+    android:resizeMode="horizontal|vertical"
+    android:widgetCategory="home_screen" />

--- a/app/src/test/java/io/github/aedev/flow/data/recommendation/music/MusicBrainLearnTest.kt
+++ b/app/src/test/java/io/github/aedev/flow/data/recommendation/music/MusicBrainLearnTest.kt
@@ -231,6 +231,15 @@ class MusicBrainLearnTest {
     }
 
     @Test
+    fun `a counted listen with genre context feeds genre affinity and the time bucket`() {
+        val brain = MusicBrain()
+        listen(brain, signal().copy(genre = "pop"))
+        assertThat(brain.genreAffinity["pop"] ?: 0.0).isGreaterThan(0.0)
+        val bucket = MusicTimeBucket.fromTimestamp(now)
+        assertThat(brain.timeBuckets[bucket]!!["pop"]).isEqualTo(1.0)
+    }
+
+    @Test
     fun `a dislike hides only while its cooldown is active`() {
         val brain = MusicBrain()
         MusicBrainLearn.applyDislike(brain, "UCartist1", now)

--- a/app/src/test/java/io/github/aedev/flow/data/recommendation/music/MusicBrainRankerTest.kt
+++ b/app/src/test/java/io/github/aedev/flow/data/recommendation/music/MusicBrainRankerTest.kt
@@ -177,4 +177,60 @@ class MusicBrainRankerTest {
         assertThat(discoverHigh).isAtMost(MusicBrainParams.NOVELTY_MAX)
         assertThat(lowQp).isLessThan(discoverLow)
     }
+
+    private fun MusicBrain.addTrack(
+        trackId: String,
+        artistKey: String,
+        stamps: List<Long>,
+    ) {
+        trackMeta[trackId] = MusicTrackMeta(title = trackId, artist = artistKey, artistKey = artistKey, thumbnail = "")
+        trackPlays[trackId] = stamps.toMutableList()
+    }
+
+    @Test
+    fun `rediscover surfaces the strong stale artist and skips fresh, weak and blocked ones`() {
+        val brain = MusicBrain()
+        val staleAt = now - MusicBrainParams.REDISCOVER_STALE_MS - 86_400_000L
+        brain.artistAffinity["UCstale"] = MusicAffinity(plays = 8, score = 0.7, lastPlayed = staleAt)
+        brain.artistAffinity["UCfresh"] = MusicAffinity(plays = 8, score = 0.7, lastPlayed = now)
+        brain.artistAffinity["UCweak"] = MusicAffinity(plays = 1, score = 0.05, lastPlayed = staleAt)
+        brain.artistAffinity["UCblockedStale"] = MusicAffinity(plays = 8, score = 0.7, lastPlayed = staleAt)
+        brain.blockedArtists.add("UCblockedStale")
+        brain.addTrack("s1", "UCstale", listOf(staleAt - 1000, staleAt))
+        brain.addTrack("s2", "UCstale", listOf(staleAt))
+        brain.addTrack("f1", "UCfresh", listOf(now))
+        brain.addTrack("w1", "UCweak", listOf(staleAt))
+        brain.addTrack("b1", "UCblockedStale", listOf(staleAt))
+
+        // One track per artist, and the most-played track wins the slot.
+        assertThat(MusicBrainRanker.rediscover(brain, now, 10)).containsExactly("s1")
+    }
+
+    @Test
+    fun `time of day rotation picks tracks played in the current bucket`() {
+        val brain = MusicBrain()
+        val bucket = MusicTimeBucket.fromTimestamp(now)
+        // Same clock time on earlier days stays in the same bucket.
+        val sameBucket = listOf(now - 7L * 86_400_000, now - 14L * 86_400_000, now - 21L * 86_400_000)
+        val otherBucket = sameBucket.map { it + 12 * 3_600_000L }.filter { MusicTimeBucket.fromTimestamp(it) != bucket }
+        brain.addTrack("inBucket", "UCa", sameBucket)
+        brain.addTrack("elsewhere", "UCb", otherBucket)
+        brain.addTrack("once", "UCc", sameBucket.take(1))
+
+        assertThat(MusicBrainRanker.timeOfDayRotation(brain, now, 10)).containsExactly("inBucket")
+    }
+
+    @Test
+    fun `rotation ranks by in-bucket count and drops disliked artists in cooldown`() {
+        val brain = MusicBrain()
+        val weekAgo = { n: Int -> now - n * 7L * 86_400_000 }
+        brain.addTrack("twice", "UCa", listOf(weekAgo(1), weekAgo(2)))
+        brain.addTrack("thrice", "UCb", listOf(weekAgo(1), weekAgo(2), weekAgo(3)))
+        brain.addTrack("cooled", "UCc", listOf(weekAgo(1), weekAgo(2)))
+        brain.dislikedArtists["UCc"] = now - 1000
+
+        assertThat(MusicBrainRanker.timeOfDayRotation(brain, now, 10))
+            .containsExactly("thrice", "twice")
+            .inOrder()
+    }
 }

--- a/app/src/test/java/io/github/aedev/flow/data/recommendation/music/MusicStatsLedgerTest.kt
+++ b/app/src/test/java/io/github/aedev/flow/data/recommendation/music/MusicStatsLedgerTest.kt
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 2025-2026 Flow | A-EDev
+ *
+ * This file is part of Flow (https://github.com/A-EDev/Flow).
+ */
+
+package io.github.aedev.flow.data.recommendation.music
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class MusicStatsLedgerTest {
+    private val now = 1_700_000_000_000L
+
+    private fun record(
+        ledger: MusicStatsLedger,
+        at: Long = now,
+        artistKey: String = "UCa",
+        artistName: String = "Artist A",
+        trackId: String = "t1",
+        trackTitle: String = "Song One",
+        genre: String? = null,
+        listenedMs: Long = 60_000L,
+        counted: Boolean = true,
+        newArtist: Boolean = false,
+    ) = MusicStatsLedgerOps.record(
+        ledger,
+        at,
+        artistKey,
+        artistName,
+        trackId,
+        trackTitle,
+        genre,
+        listenedMs,
+        counted,
+        newArtist,
+    )
+
+    @Test
+    fun `counted play lands in every aggregate of its month`() {
+        val ledger = MusicStatsLedger()
+        record(ledger, genre = "pop", newArtist = true)
+
+        val month = ledger.months.getValue(MusicStatsLedgerOps.monthKey(now))
+        assertThat(month.plays).isEqualTo(1)
+        assertThat(month.sessions).isEqualTo(1)
+        assertThat(month.listenedMs).isEqualTo(60_000L)
+        assertThat(month.artistPlays["UCa"]).isEqualTo(1)
+        assertThat(month.artistNames["UCa"]).isEqualTo("Artist A")
+        assertThat(month.trackPlays["t1"]).isEqualTo(1)
+        assertThat(month.trackTitles["t1"]).isEqualTo("Song One")
+        assertThat(month.genrePlays["pop"]).isEqualTo(1)
+        assertThat(month.discoveredArtists).containsExactly("UCa")
+        assertThat(month.dayPlays.values.sum()).isEqualTo(1)
+        assertThat(month.hourPlays.values.sum()).isEqualTo(1)
+    }
+
+    @Test
+    fun `partial session adds minutes and a session but no play`() {
+        val ledger = MusicStatsLedger()
+        record(ledger, listenedMs = 30_000L, counted = false)
+
+        val month = ledger.months.getValue(MusicStatsLedgerOps.monthKey(now))
+        assertThat(month.plays).isEqualTo(0)
+        assertThat(month.sessions).isEqualTo(1)
+        assertThat(month.listenedMs).isEqualTo(30_000L)
+        assertThat(month.artistPlays).isEmpty()
+        assertThat(month.discoveredArtists).isEmpty()
+    }
+
+    @Test
+    fun `plays split across calendar months`() {
+        val ledger = MusicStatsLedger()
+        val sixtyDays = 60L * 24 * 60 * 60 * 1000
+        record(ledger, at = now)
+        record(ledger, at = now - sixtyDays, trackId = "t2", trackTitle = "Song Two")
+
+        assertThat(ledger.months).hasSize(2)
+        assertThat(MusicStatsLedgerOps.monthKey(now)).isNotEqualTo(MusicStatsLedgerOps.monthKey(now - sixtyDays))
+    }
+
+    @Test
+    fun `per-month artist cap drops the weakest and their names`() {
+        val ledger = MusicStatsLedger()
+        record(ledger, artistKey = "UCstrong", artistName = "Strong", trackId = "s")
+        record(ledger, artistKey = "UCstrong", artistName = "Strong", trackId = "s")
+        (0 until MusicStatsParams.ARTISTS_PER_MONTH).forEach { i ->
+            record(ledger, artistKey = "UCa$i", artistName = "A$i", trackId = "t$i")
+        }
+
+        val month = ledger.months.getValue(MusicStatsLedgerOps.monthKey(now))
+        assertThat(month.artistPlays.size).isAtMost(MusicStatsParams.ARTISTS_PER_MONTH)
+        assertThat(month.artistPlays).containsKey("UCstrong")
+        assertThat(month.artistNames.keys).isEqualTo(month.artistPlays.keys)
+    }
+
+    @Test
+    fun `ledger serialization round-trips`() {
+        val ledger = MusicStatsLedger()
+        record(ledger, genre = "pop", newArtist = true)
+        record(ledger, listenedMs = 10_000L, counted = false)
+
+        val restored = ledger.toSerializable().toLedger()
+        val key = MusicStatsLedgerOps.monthKey(now)
+        assertThat(restored.months.getValue(key).plays).isEqualTo(1)
+        assertThat(restored.months.getValue(key).sessions).isEqualTo(2)
+        assertThat(restored.months.getValue(key).listenedMs).isEqualTo(70_000L)
+        assertThat(restored.months.getValue(key).discoveredArtists).containsExactly("UCa")
+        assertThat(restored.schemaVersion).isEqualTo(MusicStatsParams.SCHEMA_VERSION)
+    }
+}

--- a/fastlane/metadata/android/en-US/changelogs/19.txt
+++ b/fastlane/metadata/android/en-US/changelogs/19.txt
@@ -3,5 +3,7 @@
 - Added artist feedback (not interested / don't recommend) with blocked-artist management
 - Added music taste cards to the Flow Control Center and a music engine backup
 - Added the music taste profile to device sync
+- Added Rediscover, time-of-day rotation and top-artist album shelves
+- Added Daily Mix playlist pages, artist-page history and an On Repeat widget
 - Fixed music region settings, related music fetching and stale recommendations
 - Lower battery use during background music playback

--- a/fastlane/metadata/android/en-US/changelogs/19.txt
+++ b/fastlane/metadata/android/en-US/changelogs/19.txt
@@ -1,9 +1,0 @@
-- Added a local music taste engine with ranked shelves, smarter Quick Picks and On Repeat
-- Added Daily Mixes built from your own listening and endless music radio with a stable queue
-- Added artist feedback (not interested / don't recommend) with blocked-artist management
-- Added music taste cards to the Flow Control Center and a music engine backup
-- Added the music taste profile to device sync
-- Added Rediscover, time-of-day rotation and top-artist album shelves
-- Added Daily Mix playlist pages, artist-page history and an On Repeat widget
-- Fixed music region settings, related music fetching and stale recommendations
-- Lower battery use during background music playback


### PR DESCRIPTION
## Summary

Deepens the MusicBrain integration shipped in #985: the engine now feeds more surfaces and learns from more of them.

**New shelves (zero network)** — *Rediscover* (loved artists gone quiet for 3+ weeks, best track each) and a *time-of-day rotation* (tracks you actually play in the current time bucket), both rendered purely from stored meta and gated so they hide rather than pad when thin. **From artists you love** collects your top artists' latest albums/singles from the already-cached artist pages. **Daily Mixes open as playlist pages** (play all / shuffle / save to library) via the same synthesized-details route community playlists use — a fresh ViewModel deterministically rebuilds the mix. **Artist pages** gain a "Your history" strip (plays, liked, your most-played tracks of that artist) and "In your rotation" badges on fans-also-like artists the brain already knows. **On Repeat home-screen widget** joins the Glance family (rows open the Music tab). **Genre provenance**: plays started from genre rows and mood chips stamp that context into listen signals, which activates the ranker's context terms, reorders the mood chips by habit, and adds a Genres card to the Control Center. **Ranking**: Speed dial, Listen again, Recommended, music videos and long listens now pass through the brain; section order is anchored by brain maturity (charts-led when cold, taste-led when mature).

All artist matching reuses the dual key forms from #985; every new shelf participates in the reactive hidden-artists filter.

## Related issue

—

## Change type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor or maintenance
- [ ] Build, packaging, or CI
- [ ] Documentation

## Validation

- [x] `./gradlew :app:assembleGithubDebug`
- [x] `./gradlew :app:testGithubDebugUnitTest` (music engine suites incl. `MusicBenchmarkTest` regression floors, run before and after; 6 new tests for rediscover/rotation/genre learning)
- [x] `./gradlew :app:compileFossDebugKotlin`, `ktlintCheck`
- [x] I manually tested the affected behavior on an Android device or emulator.

**Test device and Android version:** POCO, Android 16 (HyperOS)

Device pass: brain-ranked Speed dial visibly reordered to top artists; rotation shelf renders in its bucket and hides outside it; Rediscover correctly gated (no 3-week-stale artists yet on this brain); "From artists you love" renders; Daily Mix header opens a 14-song playlist page and plays as a queue; artist page shows "Your history — Played 4 times" with the most-played track; no crashes in logcat across the pass. Widget added to the registry and manifest (compile-verified; add-to-home-screen is a manual step).

## Risk and compatibility

- New preferences/data: none — everything reads existing brain state; genre context adds an optional field to listen signals (wire-compatible, brain schema unchanged).
- Widget: new receiver + provider XML; existing widgets untouched apart from an optional per-item intent override on the shared panel.
- Player path: untouched except a `@Volatile` context-genre tag on the queue manager, cleared on every unscoped queue start.
- Known nit (pre-existing): one stored track title carries URL-encoded plus signs ("Devil+in+Disguise") from an old write path; surfaced by the new history strip, not caused by it.
- [x] The change does not introduce secrets, private data, or unexpected telemetry.
- [x] New user-facing text uses Android string resources.
- [x] Dependency and lockfile changes are intentional and limited to this PR. (none)
- [x] Room schema changes include the required version bump and migration, or this PR does not change the Room schema.
- [x] Breaking changes and upgrade steps are clearly documented. (none)
