### PR TITLE
fix(ci): limit concurrent Kotlin compilations

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Run unit tests
         run: >
           ./gradlew :app:testGithubDebugUnitTest :app:testFossDebugUnitTest
-          --build-cache --stacktrace
+          --max-workers=1 --build-cache --stacktrace
 
       # Instrumentation tests are not executed in CI, but they must still
       # compile: breakage here otherwise lands on main unnoticed.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Run unit tests
         run: >
           ./gradlew :app:testGithubDebugUnitTest :app:testFossDebugUnitTest
-          --parallel --build-cache --stacktrace
+          --build-cache --stacktrace
 
       # Instrumentation tests are not executed in CI, but they must still
       # compile: breakage here otherwise lands on main unnoticed.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,7 +103,7 @@ jobs:
         if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
         run: >
           ./gradlew :app:assembleGithubRelease :app:assembleGithubNightly :app:assembleFossRelease
-          --parallel --build-cache --stacktrace
+          --max-workers=1 --build-cache --stacktrace
         env:
           STORE_PASSWORD: ${{ secrets.STORE_PASSWORD }}
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
@@ -113,7 +113,7 @@ jobs:
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
         run: >
           ./gradlew :app:assembleGithubRelease :app:assembleFossRelease
-          --parallel --build-cache --stacktrace
+          --max-workers=1 --build-cache --stacktrace
         env:
           STORE_PASSWORD: ${{ secrets.STORE_PASSWORD }}
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}


### PR DESCRIPTION
The workflow launches multiple flavor compilations concurrently. Those Kotlin compiler tasks share constrained runner memory and OOM while transforming large Compose methods such as `TvMusicScreen`.

Limit each multi-flavor Gradle invocation to one worker so test and APK flavor compilations run sequentially. Test coverage and build outputs are unchanged.

Failing main run: https://github.com/A-EDev/Flow/actions/runs/33759758634
Failing PR test run: https://github.com/A-EDev/Flow/actions/runs/33766987360
Failing APK build run: https://github.com/mishalshanavas/Flow/actions/runs/33826218299/job/100879335160